### PR TITLE
[codex] Fix first-thread startup flicker

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -7380,7 +7380,9 @@ describe("ChatView transcript geometry (full app)", () => {
       const transcriptPane = document.querySelector('[data-chat-transcript-pane="true"]');
       expect(transcriptPane).not.toBeNull();
       expect(transcriptPane?.textContent).not.toContain("What should");
-      expect(transcriptPane?.textContent).not.toContain("Send a message to start the conversation.");
+      expect(transcriptPane?.textContent).not.toContain(
+        "Send a message to start the conversation.",
+      );
 
       for (const status of ["starting", "running"] as const) {
         const thread = {
@@ -7415,6 +7417,36 @@ describe("ChatView transcript geometry (full app)", () => {
       await mounted.cleanup();
     }
   });
+
+  it.each(["completed", "interrupted", "error"] as const)(
+    "shows the empty landing for terminal state %s without a start timestamp",
+    async (state) => {
+      const snapshot = addThreadToSnapshot(createDraftOnlySnapshot(), THREAD_ID);
+      const emptyThread = {
+        ...snapshot.threads[0]!,
+        session: null,
+        latestTurn: {
+          turnId: TurnId.makeUnsafe("restored-terminal-turn"),
+          state,
+          requestedAt: isoAt(0),
+          startedAt: null,
+          completedAt: isoAt(1),
+          assistantMessageId: null,
+        },
+      };
+      const mounted = await mountChatView({
+        viewport: DEFAULT_VIEWPORT,
+        snapshot: { ...snapshot, threads: [emptyThread] },
+      });
+
+      try {
+        expect(document.querySelector('[data-testid="empty-landing-heading"]')).not.toBeNull();
+        expect(document.querySelector('[data-empty-landing-composer-block="true"]')).not.toBeNull();
+      } finally {
+        await mounted.cleanup();
+      }
+    },
+  );
 
   it("creates a detached worktree on first send in New worktree mode", async () => {
     const restoreNativeApi = installDeterministicSendNativeApi();

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -7284,6 +7284,138 @@ describe("ChatView transcript geometry (full app)", () => {
     }
   });
 
+  it("keeps the first sent message visible throughout draft promotion", async () => {
+    const restoreNativeApi = installDeterministicSendNativeApi();
+    useComposerDraftStore.getState().setProjectDraftThreadId(PROJECT_ID, THREAD_ID);
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createDraftOnlySnapshot(),
+    });
+
+    try {
+      const prompt = "Keep the first message on screen";
+      useComposerDraftStore.getState().setPrompt(THREAD_ID, prompt);
+      const sendButton = await waitForSendButton();
+      expect(sendButton.disabled).toBe(false);
+      sendButton.click();
+      const startCommand = await vi.waitFor(() => {
+        const command = wsRequests
+          .map(readDispatchedCommand)
+          .find((candidate) => candidate?.type === "thread.turn.start");
+        expect(command).toBeDefined();
+        return command!;
+      });
+      const message = startCommand.message as { messageId: MessageId; text: string };
+      const messageSelector = `[data-message-id="${message.messageId}"][data-message-role="user"]`;
+      const expectTranscript = async () => {
+        await waitForLayout();
+        expect(document.querySelectorAll(messageSelector)).toHaveLength(1);
+        expect(document.querySelector(messageSelector)?.textContent).toContain(prompt);
+        expect(document.querySelector('[data-empty-landing-composer-block="true"]')).toBeNull();
+        expect(mounted.router.state.location.pathname).toBe(`/${THREAD_ID}`);
+      };
+      await expectTranscript();
+
+      const createdSnapshot = addThreadToSnapshot(fixture.snapshot, THREAD_ID);
+      const createdThread = { ...createdSnapshot.threads[0]!, session: null };
+      fixture.snapshot = { ...createdSnapshot, threads: [createdThread] };
+      useStore
+        .getState()
+        .syncServerShellSnapshot(createShellSnapshotFromReadModel(fixture.snapshot));
+      await expectTranscript();
+      useStore.getState().syncServerThreadDetailHotPath(createdThread);
+      await expectTranscript();
+
+      const startedThread = {
+        ...createdThread,
+        messages: [
+          {
+            ...createUserMessage({ id: message.messageId, text: message.text, offsetSeconds: 1 }),
+            createdAt: startCommand.createdAt as string,
+            updatedAt: startCommand.createdAt as string,
+          },
+        ],
+      };
+      fixture.snapshot = {
+        ...fixture.snapshot,
+        snapshotSequence: fixture.snapshot.snapshotSequence + 1,
+        threads: [startedThread],
+      };
+      useStore.getState().syncServerThreadDetailHotPath(startedThread);
+      useComposerDraftStore.getState().finalizePromotedDraftThread(THREAD_ID);
+      await expectTranscript();
+
+      // A creation snapshot can finish after the first message echo.
+      useStore.getState().syncServerThreadDetailHotPath(createdThread);
+      await expectTranscript();
+    } finally {
+      await mounted.cleanup();
+      restoreNativeApi();
+    }
+  });
+
+  it("keeps the transcript open while the first turn starts before its message arrives", async () => {
+    const snapshot = addThreadToSnapshot(createDraftOnlySnapshot(), THREAD_ID);
+    const emptyThread = { ...snapshot.threads[0]!, session: null };
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: { ...snapshot, threads: [emptyThread] },
+    });
+
+    try {
+      await expect.element(page.getByTestId("empty-landing-heading")).toBeInTheDocument();
+      const pendingTurn = {
+        turnId: TurnId.makeUnsafe("first-turn-starting"),
+        state: "running" as const,
+        requestedAt: new Date().toISOString(),
+        startedAt: null,
+        completedAt: null,
+        assistantMessageId: null,
+      };
+      const pendingThread = { ...emptyThread, latestTurn: pendingTurn };
+      fixture.snapshot = { ...fixture.snapshot, threads: [pendingThread] };
+      useStore.getState().syncServerThreadDetailHotPath(pendingThread);
+      await waitForLayout();
+      expect(document.querySelector('[data-testid="empty-landing-heading"]')).toBeNull();
+      const transcriptPane = document.querySelector('[data-chat-transcript-pane="true"]');
+      expect(transcriptPane).not.toBeNull();
+      expect(transcriptPane?.textContent).not.toContain("What should");
+      expect(transcriptPane?.textContent).not.toContain("Send a message to start the conversation.");
+
+      for (const status of ["starting", "running"] as const) {
+        const thread = {
+          ...pendingThread,
+          session: { ...snapshot.threads[0]!.session!, status },
+        };
+        fixture.snapshot = { ...fixture.snapshot, threads: [thread] };
+        useStore.getState().syncServerThreadDetailHotPath(thread);
+        await waitForLayout();
+        expect(document.querySelector('[data-testid="empty-landing-heading"]')).toBeNull();
+        expect(document.querySelector('[data-chat-transcript-pane="true"]')).toBe(transcriptPane);
+      }
+
+      const startedThread = {
+        ...pendingThread,
+        messages: [
+          createUserMessage({
+            id: MessageId.makeUnsafe("first-turn-message"),
+            text: "Start the first turn",
+            offsetSeconds: 1,
+          }),
+        ],
+      };
+      fixture.snapshot = { ...fixture.snapshot, threads: [startedThread] };
+      useStore.getState().syncServerThreadDetailHotPath(startedThread);
+      await expect
+        .element(page.getByText("Start the first turn", { exact: true }))
+        .toBeInTheDocument();
+      expect(document.querySelector('[data-testid="empty-landing-heading"]')).toBeNull();
+      expect(document.querySelector('[data-chat-transcript-pane="true"]')).toBe(transcriptPane);
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("creates a detached worktree on first send in New worktree mode", async () => {
     const restoreNativeApi = installDeterministicSendNativeApi();
     const mounted = await mountChatView({

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3652,6 +3652,9 @@ export default function ChatView({
     hasTimelineEntries: timelineEntries.length > 0,
     detailSyncState: threadDetailSyncState,
   });
+  // Turn/session updates can arrive before the first transcript row. An empty
+  // synced snapshot during startup must not restore the unstarted landing.
+  const hasPendingThreadWork = isWorking || (activeLatestTurn !== null && !latestTurnSettled);
   const handleRetryThreadDetailSync = useCallback(() => {
     useStore.getState().clearThreadDetailSyncFailure(threadId);
     const api = readNativeApi();
@@ -3673,13 +3676,14 @@ export default function ChatView({
         />
       );
     }
-    return undefined;
-  }, [handleRetryThreadDetailSync, isEditorRail, threadDetailHydration]);
+    return hasPendingThreadWork ? <span aria-hidden="true" /> : undefined;
+  }, [handleRetryThreadDetailSync, hasPendingThreadWork, isEditorRail, threadDetailHydration]);
   // Empty top-level threads render the centered landing composer instead of the transcript pane.
   // Home-scoped chats get the global "What should we work on?" copy plus the project picker,
   // while project-scoped drafts reuse the same centered layout with folder-specific copy.
   const isCenteredEmptyLanding =
     timelineEntries.length === 0 &&
+    !hasPendingThreadWork &&
     !activeThread?.parentThreadId &&
     !isEditorRail &&
     threadDetailHydration === "ready";

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3654,7 +3654,9 @@ export default function ChatView({
   });
   // Turn/session updates can arrive before the first transcript row. An empty
   // synced snapshot during startup must not restore the unstarted landing.
-  const hasPendingThreadWork = isWorking || (activeLatestTurn !== null && !latestTurnSettled);
+  // Terminal turns can lack start timestamps after restore/import; their state wins.
+  const hasPendingThreadWork =
+    isWorking || (activeLatestTurnState === "running" && !latestTurnSettled);
   const handleRetryThreadDetailSync = useCallback(() => {
     useStore.getState().clearThreadDetailSyncFailure(threadId);
     const api = readNativeApi();


### PR DESCRIPTION
## What Changed

Keep the transcript view open while a first turn is pending or its provider session is starting, even when the first message has not reached the client yet. Use explicit empty content during that gap so the transcript cannot fall back to its own “Send a message to start the conversation” prompt.

## Why

The landing screen previously depended on an empty transcript and a synced snapshot. Thread/turn metadata can arrive before the first message, so a thread that is already starting could briefly look unstarted. The shared UI now considers pending work before showing either welcome state; this applies across providers.

## UI Changes

Before: startup could restore the welcome screen or display the transcript’s unstarted prompt before the first message appeared.

After: the transcript view stays mounted through pending-turn, session-starting, and session-running updates, then displays the arriving message. Untouched empty threads retain their landing screen. Empty restored/imported threads with completed, interrupted, or failed turns also retain their landing screen when a start timestamp is missing; only a running turn contributes to the pending-turn guard.

Browser regression coverage checks these transitions, draft promotion, delayed snapshots, and absence of duplicate user rows. Screenshots and video are not attached.

## Verification

- Seven focused Chromium checks passed: first-message visibility throughout draft promotion; first-turn startup before message arrival; failed-send branch restoration; first-send worktree creation; and empty restored threads with completed, interrupted, or failed turns lacking a start timestamp.
- React Compiler coverage for `ChatView.tsx` passed.
- `git diff --check` passed.
- [Full CI passed](https://github.com/Emanuele-web04/synara/actions/runs/34333569943) on `5296d79afe535b6ac56e561cda8b8f79affca009`: formatting, lint, typecheck, all unit-test lanes, all three stable browser shards, desktop build, Windows regressions, migration lineage, release smoke, and the aggregate gate.

Commands:

```sh
bun run --cwd apps/web test:browser src/components/ChatView.browser.tsx -t 'keeps the first sent message visible|keeps the transcript open while the first turn|shows the empty landing for terminal state|restores a settled thread branch when turn start fails|creates a detached worktree on first send'
bun run --cwd apps/web test src/components/chatHotPath.compiler.test.ts -t ChatView.tsx
```

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path empty-state gating in `ChatView` that affects first-send and draft promotion UX; scope is narrow and covered by new browser regressions.
> 
> **Overview**
> **ChatView** no longer treats an empty synced timeline as an unstarted thread when work is already in flight. A new `hasPendingThreadWork` flag (active work or an unsettled latest turn) keeps the transcript pane mounted with a minimal empty placeholder instead of the centered landing or the transcript’s “start a conversation” empty state until the first message or settled state arrives.
> 
> Two **browser tests** lock this in: the first user message stays visible through draft promotion and out-of-order shell/thread snapshots, and the transcript stays open while a turn is pending before the first message syncs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0acd4584d3130723e970699a679beef8d80c9f63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
