### PR TITLE
fix(web): show configured project name in sidebar

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -39,6 +39,7 @@ import {
   resolveSettingsBackTarget,
   resolveProjectStatusIndicator,
   resolveSidebarNewThreadEnvMode,
+  resolveSidebarProjectRowLabel,
   resolveThreadHoverCardMetadata,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
@@ -433,6 +434,35 @@ describe("debug feature flags menu visibility", () => {
         storageValue: null,
       }),
     ).toBe(false);
+  });
+});
+
+describe("resolveSidebarProjectRowLabel", () => {
+  it("prefers the configured display name over the folder name", () => {
+    expect(
+      resolveSidebarProjectRowLabel({
+        name: "Hubspot extension",
+        folderName: "hubspot-support-send-email-extension",
+      }),
+    ).toBe("Hubspot extension");
+  });
+
+  it("falls back to the folder name when the display name is empty", () => {
+    expect(
+      resolveSidebarProjectRowLabel({
+        name: "   ",
+        folderName: "hubspot-support-send-email-extension",
+      }),
+    ).toBe("hubspot-support-send-email-extension");
+  });
+
+  it("trims whitespace from the configured display name", () => {
+    expect(
+      resolveSidebarProjectRowLabel({
+        name: "  Hubspot extension  ",
+        folderName: "hubspot-support-send-email-extension",
+      }),
+    ).toBe("Hubspot extension");
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -219,6 +219,22 @@ export function resolveThreadProjectLabel(
   return nonEmptyDisplayValue(project.name) ?? project.folderName;
 }
 
+/**
+ * Primary label for a project row in the Threads sidebar.
+ *
+ * Always prefer the configured display name (`project.name`, which already
+ * reflects `localName` when set). Do not render the underlying folder name as a
+ * competing sibling: a previous shrink-0 muted suffix could crowd the display
+ * name out of a narrow row and leave only a greyed-out folder label visible,
+ * while the hover card correctly showed the configured name (#1000). Folder
+ * identity stays in the project hover card path row.
+ */
+export function resolveSidebarProjectRowLabel(
+  project: Pick<Project, "name" | "folderName">,
+): string {
+  return nonEmptyDisplayValue(project.name) ?? project.folderName;
+}
+
 export type SidebarThreadHoverMetadata = {
   projectName: string;
   projectCwd: string | null;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -328,6 +328,7 @@ import {
   resolveSettingsBackTarget,
   type SettingsBackTarget,
   resolveSidebarNewThreadEnvMode,
+  resolveSidebarProjectRowLabel,
   resolveThreadHoverCardMetadata,
   resolveThreadProjectLabel,
   resolveThreadRowClassName,
@@ -4899,6 +4900,8 @@ export default function Sidebar() {
     // name container itself is not focusable — the row's button is.
     const projectToolbarReserveClassName =
       "group-hover/project-header:pr-[4.75rem] group-has-[:focus-visible]/project-header:pr-[4.75rem]";
+    // Configured display name only — folder identity lives in the hover card (#1000).
+    const projectRowLabel = resolveSidebarProjectRowLabel(project);
 
     return (
       <div className="group/collapsible">
@@ -4963,17 +4966,12 @@ export default function Sidebar() {
               >
                 <span
                   className={cn(
-                    "truncate font-system-ui text-[length:var(--app-font-size-ui,12px)] font-normal",
+                    "min-w-0 flex-1 truncate font-system-ui text-[length:var(--app-font-size-ui,12px)] font-normal",
                     SIDEBAR_ROW_LABEL_TEXT_CLASS_NAME,
                   )}
                 >
-                  {project.name}
+                  {projectRowLabel}
                 </span>
-                {project.localName ? (
-                  <span className="shrink-0 truncate text-[length:var(--app-font-size-ui,12px)] text-muted-foreground/40">
-                    {project.folderName}
-                  </span>
-                ) : null}
               </div>
               {/* Closed folders surface child-chat status on the project row; open
                   folders leave that signal to their visible child thread rows. */}


### PR DESCRIPTION
## Summary
- Sidebar project rows now show only the configured display name (`project.name`, which already reflects `localName`), matching the project details popover.
- Removes the muted `folderName` sibling that used `shrink-0` and could crowd the display name out of a narrow row, leaving only a greyed-out folder label visible (#1000).
- Adds `resolveSidebarProjectRowLabel` plus regression tests for display-name preference, empty-name fallback, and trimming.

Fixes #1000

## Test plan
- [x] `bunx vitest run src/components/Sidebar.logic.test.ts -t resolveSidebarProjectRowLabel` (from `apps/web`)
- [x] `bun fmt && bun lint && bun typecheck`
- [ ] Manually rename a project so `localName` differs from `folderName`, confirm the sidebar row shows the configured name in normal (non-muted) text, and confirm the hover card still shows the folder path.