### PR TITLE
fix(web): open absolute and ~/ paths from Cmd+P palette

### DIFF
--- a/apps/web/src/components/WorkspaceSearchPalette.browser.tsx
+++ b/apps/web/src/components/WorkspaceSearchPalette.browser.tsx
@@ -251,3 +251,55 @@ it("renders snippet rows and gates short queries behind the prompt", async () =>
     restoreNativeApi();
   }
 });
+
+it("offers an Open path row for in-workspace absolute paths without fuzzy search", async () => {
+  const searchEntries = vi.fn().mockResolvedValue({ entries: [], truncated: false });
+  const restoreNativeApi = installNativeApi({
+    projects: {
+      prewarmSearchIndex: vi.fn().mockResolvedValue({ started: true }),
+      searchEntries,
+    },
+  } as unknown as NativeApi);
+
+  try {
+    const handlers = await renderPalette("files");
+    await page.getByPlaceholder("Search files").fill(`${WORKSPACE_ROOT}/src/notes/todo.md`);
+
+    await expect.element(page.getByText("Open path")).toBeVisible();
+    await expect.element(page.getByText("todo.md")).toBeVisible();
+    expect(searchEntries).not.toHaveBeenCalled();
+
+    await page.getByText("todo.md").click();
+    expect(handlers.onOpenFile).toHaveBeenCalledWith("src/notes/todo.md");
+    expect(handlers.onOpenChange).toHaveBeenCalledWith(false);
+  } finally {
+    restoreNativeApi();
+  }
+});
+
+it("expands ~/ paths and opens them via Enter", async () => {
+  const searchEntries = vi.fn().mockResolvedValue({ entries: [], truncated: false });
+  const restoreNativeApi = installNativeApi({
+    projects: {
+      prewarmSearchIndex: vi.fn().mockResolvedValue({ started: true }),
+      searchEntries,
+    },
+  } as unknown as NativeApi);
+
+  try {
+    const handlers = await renderPalette("files");
+    await page.getByPlaceholder("Search files").fill("~/notes/todo.md");
+
+    await expect.element(page.getByText("Open path")).toBeVisible();
+    await expect.element(page.getByText("todo.md")).toBeVisible();
+    expect(searchEntries).not.toHaveBeenCalled();
+
+    await userEvent.keyboard("{Enter}");
+    await vi.waitFor(() =>
+      expect(handlers.onOpenFile).toHaveBeenCalledWith("/Users/tester/notes/todo.md"),
+    );
+    expect(handlers.onOpenChange).toHaveBeenCalledWith(false);
+  } finally {
+    restoreNativeApi();
+  }
+});

--- a/apps/web/src/components/WorkspaceSearchPalette.logic.test.ts
+++ b/apps/web/src/components/WorkspaceSearchPalette.logic.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isWorkspaceSearchFilesystemPathQuery,
+  resolveWorkspaceSearchFilesystemPath,
+} from "./WorkspaceSearchPalette.logic";
+
+describe("isWorkspaceSearchFilesystemPathQuery", () => {
+  it("detects absolute and home-relative paths", () => {
+    expect(isWorkspaceSearchFilesystemPathQuery("/Users/dev/notes/todo.md")).toBe(true);
+    expect(isWorkspaceSearchFilesystemPathQuery("~/notes/todo.md")).toBe(true);
+    expect(isWorkspaceSearchFilesystemPathQuery("~\\notes\\todo.md")).toBe(true);
+    expect(isWorkspaceSearchFilesystemPathQuery("C:\\Users\\dev\\notes\\todo.md")).toBe(true);
+    expect(isWorkspaceSearchFilesystemPathQuery("/Users/dev/notes/todo.md:12:3")).toBe(true);
+  });
+
+  it("rejects fuzzy search queries and bare home", () => {
+    expect(isWorkspaceSearchFilesystemPathQuery("Composer")).toBe(false);
+    expect(isWorkspaceSearchFilesystemPathQuery("src/app.ts")).toBe(false);
+    expect(isWorkspaceSearchFilesystemPathQuery("~")).toBe(false);
+    expect(isWorkspaceSearchFilesystemPathQuery("")).toBe(false);
+    expect(isWorkspaceSearchFilesystemPathQuery("   ")).toBe(false);
+  });
+});
+
+describe("resolveWorkspaceSearchFilesystemPath", () => {
+  const cwd = "/Users/tester/project";
+
+  it("maps in-workspace absolute paths to workspace-relative form", () => {
+    expect(resolveWorkspaceSearchFilesystemPath(`${cwd}/src/app.ts`, cwd)).toBe("src/app.ts");
+    expect(resolveWorkspaceSearchFilesystemPath(`${cwd}/src/app.ts:42`, cwd)).toBe("src/app.ts");
+  });
+
+  it("keeps out-of-workspace absolute paths absolute", () => {
+    expect(resolveWorkspaceSearchFilesystemPath("/Users/tester/notes/todo.md", cwd)).toBe(
+      "/Users/tester/notes/todo.md",
+    );
+  });
+
+  it("expands ~/ against the home inferred from cwd", () => {
+    expect(resolveWorkspaceSearchFilesystemPath("~/notes/todo.md", cwd)).toBe(
+      "/Users/tester/notes/todo.md",
+    );
+    expect(resolveWorkspaceSearchFilesystemPath("~/project/src/app.ts", cwd)).toBe("src/app.ts");
+  });
+
+  it("returns null when ~/ cannot be expanded", () => {
+    expect(resolveWorkspaceSearchFilesystemPath("~/notes/todo.md", null)).toBeNull();
+    expect(resolveWorkspaceSearchFilesystemPath("~/notes/todo.md", "/tmp/scratch")).toBeNull();
+  });
+
+  it("returns null for non-path queries", () => {
+    expect(resolveWorkspaceSearchFilesystemPath("Composer", cwd)).toBeNull();
+  });
+
+  it("expands Windows home-relative paths from a Windows cwd", () => {
+    expect(
+      resolveWorkspaceSearchFilesystemPath("~\\notes\\todo.md", "C:\\Users\\tester\\project"),
+    ).toBe("C:\\Users\\tester\\notes\\todo.md");
+  });
+});

--- a/apps/web/src/components/WorkspaceSearchPalette.logic.ts
+++ b/apps/web/src/components/WorkspaceSearchPalette.logic.ts
@@ -1,0 +1,73 @@
+// Purpose: Detects absolute / ~/ filesystem-path queries in the Cmd+P palette
+//          and resolves them to an openable dock file path.
+// Layer: Web UI logic (pure helpers; no React)
+
+import {
+  inferHomeFromCwd,
+  isLocalAbsolutePath,
+  joinWorkspaceRelativePath,
+  workspaceRelativePathOf,
+} from "@synara/shared/path";
+
+// Trailing `:line` / `:line:col` from pasted editor references; the dock viewer
+// opens whole files, so the position is dropped before opening.
+const FILE_POSITION_SUFFIX_PATTERN = /:\d+(?::\d+)?$/;
+
+function stripFilePositionSuffix(path: string): string {
+  return path.replace(FILE_POSITION_SUFFIX_PATTERN, "");
+}
+
+/** True when the query is an absolute path or a `~/` / `~\` home-relative path. */
+export function isWorkspaceSearchFilesystemPathQuery(query: string): boolean {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) {
+    return false;
+  }
+  if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) {
+    return true;
+  }
+  return isLocalAbsolutePath(stripFilePositionSuffix(trimmed));
+}
+
+/**
+ * Resolves a filesystem-path palette query to a dock-openable path.
+ * Prefers a workspace-relative form when the target sits inside `cwd`; otherwise
+ * returns the absolute path (preview grants handle out-of-workspace locals).
+ * Returns null when the query is not path-like, or when `~/…` cannot be expanded.
+ */
+export function resolveWorkspaceSearchFilesystemPath(
+  query: string,
+  cwd: string | null,
+): string | null {
+  const trimmed = query.trim();
+  if (!isWorkspaceSearchFilesystemPathQuery(trimmed)) {
+    return null;
+  }
+
+  const withoutPosition = stripFilePositionSuffix(trimmed);
+  let absolutePath: string;
+
+  if (withoutPosition.startsWith("~/") || withoutPosition.startsWith("~\\")) {
+    if (!cwd) {
+      return null;
+    }
+    const home = inferHomeFromCwd(cwd);
+    if (!home) {
+      return null;
+    }
+    absolutePath = joinWorkspaceRelativePath(home, withoutPosition.slice(2).replace(/\\/g, "/"));
+  } else if (isLocalAbsolutePath(withoutPosition)) {
+    absolutePath = withoutPosition;
+  } else {
+    return null;
+  }
+
+  if (cwd) {
+    const relativePath = workspaceRelativePathOf(absolutePath, cwd);
+    if (relativePath) {
+      return relativePath;
+    }
+  }
+
+  return absolutePath;
+}

--- a/apps/web/src/components/WorkspaceSearchPalette.tsx
+++ b/apps/web/src/components/WorkspaceSearchPalette.tsx
@@ -38,6 +38,10 @@ import {
   CommandStatus,
 } from "./ui/command";
 import { FileEntryIcon } from "./chat/FileEntryIcon";
+import {
+  isWorkspaceSearchFilesystemPathQuery,
+  resolveWorkspaceSearchFilesystemPath,
+} from "./WorkspaceSearchPalette.logic";
 
 export type WorkspaceSearchPaletteMode = "files" | "snippets";
 
@@ -83,6 +87,7 @@ const MODE_COPY: Record<
   WorkspaceSearchPaletteMode,
   {
     groupLabel: string;
+    openPathGroupLabel?: string;
     placeholder: string;
     prompt: string;
     noResults: string;
@@ -91,6 +96,7 @@ const MODE_COPY: Record<
 > = {
   files: {
     groupLabel: "Files",
+    openPathGroupLabel: "Open path",
     placeholder: "Search files",
     prompt: "Type to search for files",
     noResults: "No matching files",
@@ -259,6 +265,36 @@ const SnippetResultRow = memo(function SnippetResultRow(props: {
   );
 });
 
+// Exact absolute / ~/ open intent: same row chrome as file hits, but the path is
+// already resolved (workspace-relative when inside cwd, otherwise absolute).
+const OpenPathResultRow = memo(function OpenPathResultRow(props: {
+  path: string;
+  index: number;
+  onOpenFile: (relativePath: string) => void;
+}) {
+  const displayPath = props.path.replace(/\\/g, "/");
+  const { base, dir } = splitPath(displayPath);
+  return (
+    <CommandItem
+      index={props.index}
+      value={`open-path:${props.path}`}
+      className={`items-center ${ITEM_CLASS}`}
+      onClick={() => props.onOpenFile(props.path)}
+    >
+      <FileEntryIcon
+        pathValue={props.path}
+        kind="file"
+        colorMode="inherit"
+        className={ICON_CLASS}
+      />
+      <span className="min-w-0 flex-1 truncate text-[13px] text-zinc-700 dark:text-zinc-300">
+        {base || displayPath}
+      </span>
+      {dir ? <DirectoryText className="max-w-[55%] shrink-0" dir={dir} /> : null}
+    </CommandItem>
+  );
+});
+
 // Thin shell: dialog + popup only. All state lives in the content component
 // below, which Base UI keeps mounted through the exit transition and then
 // unmounts — resetting the palette without ever blanking it mid-animation.
@@ -292,6 +328,18 @@ function WorkspaceSearchPaletteContent(props: WorkspaceSearchPaletteProps) {
     prewarmProjectSearchIndex(props.cwd);
   }, [props.cwd]);
 
+  // Absolute / ~/ queries are an exact-open intent, not fuzzy index search.
+  const openPathTarget = useMemo(() => {
+    if (props.mode !== "files" || trimmedQuery.length === 0) {
+      return null;
+    }
+    return resolveWorkspaceSearchFilesystemPath(trimmedQuery, props.cwd);
+  }, [props.mode, trimmedQuery, props.cwd]);
+  const isFilesystemPathQuery =
+    props.mode === "files" && isWorkspaceSearchFilesystemPathQuery(trimmedQuery);
+  const isDebouncedFilesystemPathQuery =
+    props.mode === "files" && isWorkspaceSearchFilesystemPathQuery(debouncedQuery);
+
   const hasUsableQuery =
     props.mode === "files"
       ? trimmedQuery.length > 0
@@ -302,7 +350,11 @@ function WorkspaceSearchPaletteContent(props: WorkspaceSearchPaletteProps) {
       cwd: props.cwd,
       query: debouncedQuery,
       limit: SEARCH_LIMIT,
-      enabled: props.open && props.mode === "files" && debouncedQuery.length > 0,
+      enabled:
+        props.open &&
+        props.mode === "files" &&
+        debouncedQuery.length > 0 &&
+        !isDebouncedFilesystemPathQuery,
       staleTime: SEARCH_STALE_TIME_MS,
     }),
   );
@@ -321,13 +373,14 @@ function WorkspaceSearchPaletteContent(props: WorkspaceSearchPaletteProps) {
   );
 
   const fileEntries =
-    props.mode === "files" && hasUsableQuery
+    props.mode === "files" && hasUsableQuery && !isFilesystemPathQuery
       ? (fileSearchQuery.data?.entries ?? EMPTY_FILE_ENTRIES)
       : EMPTY_FILE_ENTRIES;
   const snippetMatches =
     props.mode === "snippets" && hasUsableQuery
       ? (snippetSearchQuery.data?.matches ?? EMPTY_SNIPPET_MATCHES)
       : EMPTY_SNIPPET_MATCHES;
+  const openPathIndexOffset = openPathTarget ? 1 : 0;
 
   // Exact item registry for Base UI, mirroring the rendered CommandItem
   // values in content and order. With it, the composite list clamps its
@@ -336,9 +389,12 @@ function WorkspaceSearchPaletteContent(props: WorkspaceSearchPaletteProps) {
   const itemValues = useMemo(
     () =>
       props.mode === "files"
-        ? fileEntries.map((entry) => `${entry.kind}:${entry.path}`)
+        ? [
+            ...(openPathTarget ? [`open-path:${openPathTarget}`] : []),
+            ...fileEntries.map((entry) => `${entry.kind}:${entry.path}`),
+          ]
         : snippetMatches.map((match) => `snippet:${match.path}:${match.lineNumber}`),
-    [props.mode, fileEntries, snippetMatches],
+    [props.mode, openPathTarget, fileEntries, snippetMatches],
   );
 
   const activeQuery = props.mode === "files" ? fileSearchQuery : snippetSearchQuery;
@@ -347,7 +403,7 @@ function WorkspaceSearchPaletteContent(props: WorkspaceSearchPaletteProps) {
   // changes). Only a settled response may claim "no results" — otherwise every
   // keystroke would flash the no-results state before data lands.
   const isSettled = trimmedQuery === debouncedQuery && !activeQuery.isFetching;
-  const hasRows = fileEntries.length > 0 || snippetMatches.length > 0;
+  const hasRows = openPathTarget !== null || fileEntries.length > 0 || snippetMatches.length > 0;
 
   // The server matches file entries against a normalized query (leading @ ./
   // stripped); highlighting must normalize the same way or rows that matched
@@ -414,6 +470,14 @@ function WorkspaceSearchPaletteContent(props: WorkspaceSearchPaletteProps) {
       </CommandStatus>
 
       <CommandList className={LIST_CLASS}>
+        {props.mode === "files" && openPathTarget ? (
+          <CommandGroup>
+            <CommandGroupLabel className={GROUP_LABEL_CLASS}>
+              {copy.openPathGroupLabel ?? "Open path"}
+            </CommandGroupLabel>
+            <OpenPathResultRow path={openPathTarget} index={0} onOpenFile={handleOpenFile} />
+          </CommandGroup>
+        ) : null}
         {props.mode === "files" && fileEntries.length > 0 ? (
           <CommandGroup>
             <CommandGroupLabel className={GROUP_LABEL_CLASS}>{copy.groupLabel}</CommandGroupLabel>
@@ -421,7 +485,7 @@ function WorkspaceSearchPaletteContent(props: WorkspaceSearchPaletteProps) {
               <FileResultRow
                 key={entry.path}
                 entry={entry}
-                index={index}
+                index={openPathIndexOffset + index}
                 highlightQuery={highlightQuery}
                 onOpenFile={handleOpenFile}
                 onOpenDirectory={handleOpenDirectory}

--- a/apps/web/src/terminal-links.ts
+++ b/apps/web/src/terminal-links.ts
@@ -1,3 +1,5 @@
+import { inferHomeFromCwd } from "@synara/shared/path";
+
 import { getNavigatorPlatform, isMacPlatform } from "./lib/utils";
 
 export type TerminalLinkKind = "url" | "path";
@@ -116,25 +118,6 @@ function joinPath(base: string, next: string, separator: "/" | "\\"): string {
     return `${cleanBase}\\${next.replaceAll("/", "\\")}`;
   }
   return `${cleanBase}/${next.replace(/^\/+/, "")}`;
-}
-
-function inferHomeFromCwd(cwd: string): string | undefined {
-  const posixUser = cwd.match(/^\/Users\/([^/]+)/);
-  if (posixUser?.[1]) {
-    return `/Users/${posixUser[1]}`;
-  }
-
-  const posixHome = cwd.match(/^\/home\/([^/]+)/);
-  if (posixHome?.[1]) {
-    return `/home/${posixHome[1]}`;
-  }
-
-  const windowsUser = cwd.match(/^([A-Za-z]:\\Users\\[^\\]+)/);
-  if (windowsUser?.[1]) {
-    return windowsUser[1];
-  }
-
-  return undefined;
 }
 
 function splitPathAndPosition(value: string): {

--- a/packages/shared/src/path.test.ts
+++ b/packages/shared/src/path.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  inferHomeFromCwd,
   isLocalAbsolutePath,
   isWorkspaceRelativePathSafe,
   joinWorkspaceRelativePath,
@@ -101,5 +102,18 @@ describe("joinWorkspaceRelativePath", () => {
   it("round-trips through workspaceRelativePathOf", () => {
     const joined = joinWorkspaceRelativePath("/repo/app", "src/page.tsx");
     expect(workspaceRelativePathOf(joined, "/repo/app")).toBe("src/page.tsx");
+  });
+});
+
+describe("inferHomeFromCwd", () => {
+  it("infers macOS, Linux, and Windows user homes", () => {
+    expect(inferHomeFromCwd("/Users/tester/project")).toBe("/Users/tester");
+    expect(inferHomeFromCwd("/home/tester/project")).toBe("/home/tester");
+    expect(inferHomeFromCwd("C:\\Users\\tester\\project")).toBe("C:\\Users\\tester");
+  });
+
+  it("returns undefined when the cwd does not encode a user home", () => {
+    expect(inferHomeFromCwd("/tmp/scratch")).toBeUndefined();
+    expect(inferHomeFromCwd("D:\\work\\repo")).toBeUndefined();
   });
 });

--- a/packages/shared/src/path.ts
+++ b/packages/shared/src/path.ts
@@ -35,6 +35,27 @@ export function isExplicitRelativePath(value: string): boolean {
   );
 }
 
+// Infers the user home directory from a workspace cwd when `~/…` needs expanding
+// and no explicit home is available (browser surfaces only know the project root).
+export function inferHomeFromCwd(cwd: string): string | undefined {
+  const posixUser = cwd.match(/^\/Users\/([^/]+)/);
+  if (posixUser?.[1]) {
+    return `/Users/${posixUser[1]}`;
+  }
+
+  const posixHome = cwd.match(/^\/home\/([^/]+)/);
+  if (posixHome?.[1]) {
+    return `/home/${posixHome[1]}`;
+  }
+
+  const windowsUser = cwd.match(/^([A-Za-z]:\\Users\\[^\\]+)/);
+  if (windowsUser?.[1]) {
+    return windowsUser[1];
+  }
+
+  return undefined;
+}
+
 function normalizePathSeparators(value: string): string {
   return value.replace(/\\/g, "/");
 }


### PR DESCRIPTION
## Summary
- Cmd+P file search now detects absolute and `~/` / `~\` filesystem-path queries and offers an **Open path** row instead of only fuzzy-searching the workspace index.
- In-workspace absolutes map to workspace-relative paths; out-of-workspace / home-expanded paths open via the existing dock file pane + preview-grant flow (same as chat file chips).
- Moves `inferHomeFromCwd` into `@synara/shared/path` so terminal links and the palette share one home-expansion helper.

Fixes #972

## Test plan
- [x] `bun run test:web:focused src/components/WorkspaceSearchPalette.logic.test.ts src/terminal-links.test.ts`
- [x] `bun run --cwd packages/shared test src/path.test.ts`
- [x] `bun run --cwd apps/web test:browser src/components/WorkspaceSearchPalette.browser.tsx`
- [x] `bun fmt && bun lint && bun typecheck`
- [ ] Manually: Cmd+P → paste `/Users/…/file` inside the workspace → Open path opens side panel
- [ ] Manually: Cmd+P → `~/…` outside workspace → Open path opens via preview grant
- [ ] Manually: ordinary fuzzy file search still works