### PR TITLE
Refine sidebar translucency and accent-tinted selection

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -1321,24 +1321,24 @@ describe("resolveThreadStatusPill", () => {
 describe("resolveThreadRowClassName", () => {
   it("keeps selected active rows on the selected sidebar background", () => {
     const className = resolveThreadRowClassName({ isActive: true, isSelected: true });
-    expect(className).toContain("bg-[var(--sidebar-accent-active)]");
-    expect(className).toContain("hover:bg-[var(--sidebar-accent-active)]");
+    expect(className).toContain("bg-[var(--sidebar-selected)]");
+    expect(className).toContain("hover:bg-[var(--sidebar-selected)]");
     expect(className).toContain("text-[var(--sidebar-accent-foreground)]");
     expect(className).not.toContain("bg-[var(--color-background-button-secondary-hover)]");
   });
 
   it("keeps selected rows visually aligned with hover", () => {
     const className = resolveThreadRowClassName({ isActive: false, isSelected: true });
-    expect(className).toContain("bg-[var(--sidebar-accent-active)]");
-    expect(className).toContain("hover:bg-[var(--sidebar-accent-active)]");
+    expect(className).toContain("bg-[var(--sidebar-selected)]");
+    expect(className).toContain("hover:bg-[var(--sidebar-selected)]");
     expect(className).toContain("text-[var(--sidebar-accent-foreground)]");
     expect(className).not.toContain("bg-[var(--color-background-button-secondary-hover)]");
   });
 
   it("uses the hover sidebar background for active-only threads", () => {
     const className = resolveThreadRowClassName({ isActive: true, isSelected: false });
-    expect(className).toContain("bg-[var(--sidebar-accent-active)]");
-    expect(className).toContain("hover:bg-[var(--sidebar-accent-active)]");
+    expect(className).toContain("bg-[var(--sidebar-selected)]");
+    expect(className).toContain("hover:bg-[var(--sidebar-selected)]");
   });
 
   it("uses the sidebar accent token for hover-only rows", () => {

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -896,7 +896,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full cursor-pointer items-center gap-2 overflow-hidden rounded-xl p-2 text-left text-sm outline-hidden ring-ring/60 transition-[width,height,padding] hover:bg-[var(--sidebar-accent)] focus-visible:ring-1 active:bg-[var(--sidebar-accent-active)] active:text-[var(--sidebar-accent-foreground)] disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pe-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-[var(--sidebar-accent-active)] data-[active=true]:text-[var(--sidebar-accent-foreground)] data-[state=open]:hover:bg-[var(--sidebar-accent)] group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg:not([class*='size-'])]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full cursor-pointer items-center gap-2 overflow-hidden rounded-xl p-2 text-left text-sm outline-hidden ring-ring/60 transition-[width,height,padding] hover:bg-[var(--sidebar-accent)] focus-visible:ring-1 active:bg-[var(--sidebar-accent-active)] active:text-[var(--sidebar-accent-foreground)] disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pe-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-[var(--sidebar-selected)] data-[active=true]:text-[var(--sidebar-accent-foreground)] data-[state=open]:hover:bg-[var(--sidebar-accent)] group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg:not([class*='size-'])]:size-4 [&>svg]:shrink-0",
   {
     defaultVariants: {
       size: "default",
@@ -1102,7 +1102,7 @@ function SidebarMenuSubButton({
   const defaultProps = {
     className: cn(
       "-translate-x-px flex h-7 min-w-0 cursor-pointer items-center gap-2 overflow-hidden rounded-lg px-2 text-sidebar-foreground outline-hidden ring-ring/60 hover:bg-[var(--sidebar-accent)] focus-visible:ring-1 active:bg-[var(--sidebar-accent-active)] active:text-[var(--sidebar-accent-foreground)] disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg:not([class*='size-'])]:size-4 [&>svg]:shrink-0",
-      "data-[active=true]:bg-[var(--sidebar-accent-active)] data-[active=true]:text-[var(--sidebar-accent-foreground)]",
+      "data-[active=true]:bg-[var(--sidebar-selected)] data-[active=true]:text-[var(--sidebar-accent-foreground)]",
       size === "sm" && "text-xs",
       size === "md" && "text-sm",
       "group-data-[collapsible=icon]:hidden",

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -407,8 +407,8 @@
   --font-chat-code-family: var(--theme-font-code-family, var(--font-mono-family));
   --terminal-font-family: "JetBrainsMono NFM", "JetBrainsMono NF", "JetBrains Mono", monospace;
   --app-shell-background: transparent;
-  --app-sidebar-backdrop-filter: blur(8px) saturate(135%);
-  --app-sidebar-surface: color-mix(in srgb, var(--card) 68%, transparent);
+  --app-sidebar-backdrop-filter: blur(6px) saturate(140%);
+  --app-sidebar-surface: color-mix(in srgb, var(--card) 52%, transparent);
   --background: #fcfcfc;
   --foreground: var(--color-neutral-800);
   --card: var(--color-white);
@@ -460,6 +460,7 @@
   --sidebar-primary-foreground: var(--primary-foreground);
   --sidebar-accent: var(--secondary);
   --sidebar-accent-active: var(--secondary);
+  --sidebar-selected: color-mix(in srgb, var(--info) 14%, transparent);
   --sidebar-accent-foreground: var(--color-text-foreground, var(--foreground));
   --sidebar-border: var(--border);
   --sidebar-ring: var(--ring);
@@ -514,11 +515,12 @@
     --sidebar-primary-foreground: var(--primary-foreground);
     --sidebar-accent: var(--secondary);
     --sidebar-accent-active: var(--secondary);
+    --sidebar-selected: color-mix(in srgb, var(--info) 14%, transparent);
     --sidebar-accent-foreground: var(--color-text-foreground, var(--foreground));
     --sidebar-border: var(--border);
     --sidebar-ring: var(--ring);
-    --app-sidebar-backdrop-filter: blur(8px) saturate(135%);
-    --app-sidebar-surface: color-mix(in srgb, var(--card) 56%, transparent);
+    --app-sidebar-backdrop-filter: blur(6px) saturate(140%);
+    --app-sidebar-surface: color-mix(in srgb, var(--card) 40%, transparent);
     --color-background-button-secondary-hover: var(--secondary);
     --color-background-elevated-secondary: var(--secondary);
     --warning: var(--color-amber-500);

--- a/apps/web/src/sidebarRowStyles.ts
+++ b/apps/web/src/sidebarRowStyles.ts
@@ -22,7 +22,7 @@ export const SIDEBAR_ROW_HOVER_CLASS_NAME =
   "hover:bg-[var(--sidebar-accent)] hover:text-[var(--sidebar-accent-foreground)]";
 
 export const SIDEBAR_ROW_ACTIVE_CLASS_NAME =
-  "bg-[var(--sidebar-accent-active)] text-[var(--sidebar-accent-foreground)] hover:bg-[var(--sidebar-accent-active)] hover:text-[var(--sidebar-accent-foreground)]";
+  "bg-[var(--sidebar-selected)] text-[var(--sidebar-accent-foreground)] hover:bg-[var(--sidebar-selected)] hover:text-[var(--sidebar-accent-foreground)]";
 
 export const SIDEBAR_ROW_IDLE_TEXT_CLASS_NAME = "text-foreground/89";
 

--- a/apps/web/src/theme/theme.logic.test.ts
+++ b/apps/web/src/theme/theme.logic.test.ts
@@ -335,8 +335,14 @@ describe("buildThemeCssVariables", () => {
     expect(cssVariables.variables["--card"]).toBe("#151517");
     expect(cssVariables.variables["--composer-surface"]).toBe("rgb(27, 27, 29)");
     expect(cssVariables.variables["--composer-surface"]).not.toBe(cssVariables.variables["--card"]);
-    expect(cssVariables.variables["--sidebar-accent"]).toBe("rgba(227, 228, 230, 0.058)");
-    expect(cssVariables.variables["--sidebar-accent-active"]).toBe("rgba(227, 228, 230, 0.058)");
+    expect(cssVariables.variables["--sidebar-accent"]).toBe("rgba(175, 179, 220, 0.058)");
+    expect(cssVariables.variables["--sidebar-accent-active"]).toBe("rgba(175, 179, 220, 0.058)");
+    expect(cssVariables.variables["--sidebar-selected"]).toBe(
+      cssVariables.variables["--color-background-sidebar-selected"],
+    );
+    expect(cssVariables.variables["--sidebar-selected"]).not.toBe(
+      cssVariables.variables["--sidebar-accent"],
+    );
     expect(cssVariables.variables["--theme-font-ui-family"]).toBe("Inter");
     expect(cssVariables.variables["--theme-font-code-family"]).toBe(
       `"Jetbrains Mono", ${DEFAULT_MONOSPACE_FONT_FAMILY_STACK}`,
@@ -365,7 +371,7 @@ describe("buildThemeCssVariables", () => {
     expect(tokens.computed.surfaceUnder).toBe("#0d0d0f");
     expect(tokens.computed.panel).toBe("#151517");
     expect(tokens.derived.textForegroundSecondary).toBe("rgba(227, 228, 230, 0.645)");
-    expect(tokens.derived.buttonSecondaryBackground).toBe("rgba(227, 228, 230, 0.039)");
+    expect(tokens.derived.buttonSecondaryBackground).toBe("rgba(175, 179, 220, 0.039)");
     expect(tokens.derived.iconAccent).toBe("rgb(143, 150, 219)");
     // Dark primary button label is the surface color (dark) on the white (ink) button.
     expect(tokens.derived.textButtonPrimary).toBe("#0f0f11");

--- a/apps/web/src/theme/theme.logic.ts
+++ b/apps/web/src/theme/theme.logic.ts
@@ -93,6 +93,7 @@ export interface ThemeDerivedTokens {
   iconPrimary: string;
   iconSecondary: string;
   iconTertiary: string;
+  sidebarSelectedBackground: string;
   simpleScrim: string;
   textAccent: string;
   textButtonPrimary: string;
@@ -745,18 +746,18 @@ export function buildThemeCssVariables(
     "--app-chat-code-surface": chatCodeSurface,
     "--app-user-message-background": chatCodeSurface,
     "--app-sidebar-backdrop-filter":
-      material === "translucent" ? "blur(8px) saturate(135%)" : "none",
+      material === "translucent" ? "blur(6px) saturate(140%)" : "none",
     // Settings mirrors the chat surface (opaque --color-background-surface) so every
     // settings element reads as outline-only. With an opaque page there is nothing to
     // frost, so we skip the backdrop blur (and its compositing cost) entirely.
     "--app-settings-backdrop-filter": "none",
-    // Translucent light mode raises the white share above the old 48% so the
-    // frost doesn't read grey; dark keeps the raw surface thinned over the vibrancy.
+    // Translucent shell: thin fill so the desktop shows through, with a light blur
+    // that softens the backdrop without smearing away its detail.
     "--app-sidebar-surface":
       material === "translucent"
         ? variant === "dark"
-          ? `color-mix(in srgb, ${sidebarSurface} 56%, transparent)`
-          : `color-mix(in srgb, ${sidebarSurface} 68%, transparent)`
+          ? `color-mix(in srgb, ${sidebarSurface} 40%, transparent)`
+          : `color-mix(in srgb, ${sidebarSurface} 52%, transparent)`
         : sidebarSurface,
     // Always opaque so the settings page background matches the chat surface exactly,
     // regardless of window material.
@@ -786,6 +787,7 @@ export function buildThemeCssVariables(
     "--sidebar": readCodexVariable("--color-background-surface"),
     "--sidebar-accent": readCodexVariable("--color-background-button-secondary-hover"),
     "--sidebar-accent-active": readCodexVariable("--color-background-button-secondary-hover"),
+    "--sidebar-selected": readCodexVariable("--color-background-sidebar-selected"),
     "--sidebar-accent-foreground": readCodexVariable("--color-text-foreground"),
     "--sidebar-border": readCodexVariable("--color-border"),
     "--sidebar-foreground": readCodexVariable("--color-text-foreground"),
@@ -836,6 +838,9 @@ export function buildResolvedThemeTokens(
   };
 }
 
+/** How far the subtle-wash ink leans toward the accent (0 = neutral ink). */
+const WASH_ACCENT_SHARE = 0.4;
+
 function buildComputedTheme(theme: ChromeTheme, variant: ThemeVariant) {
   const contrast = normalizeContrastStrength(theme.contrast, variant);
   const surface = parseHexColor(theme.surface);
@@ -851,6 +856,11 @@ function buildComputedTheme(theme: ChromeTheme, variant: ThemeVariant) {
     surfaceUnder: buildSurfaceUnder(theme, surface, ink, variant),
     theme,
     variant,
+    // Ink pulled toward the accent. The low-alpha washes behind tool calls, work
+    // entries, thinking blocks, hover rows and secondary buttons are painted with
+    // this instead of raw ink, so they carry the theme's hue instead of reading
+    // as one identical neutral gray across every pack. Alpha values are unchanged.
+    wash: mixRgb(ink, parseHexColor(theme.accent), WASH_ACCENT_SHARE),
   };
 }
 
@@ -895,6 +905,7 @@ function buildCodexCssVariables(
     "--color-background-elevated-secondary": derivedTokens.elevatedSecondary,
     "--color-background-elevated-secondary-opaque": derivedTokens.elevatedSecondaryOpaque,
     "--color-background-panel": panelBackground,
+    "--color-background-sidebar-selected": derivedTokens.sidebarSelectedBackground,
     "--color-background-surface": theme.theme.surface,
     "--color-background-surface-under": theme.surfaceUnder,
     // The user message bubble has always reused the subtle secondary surface
@@ -1089,23 +1100,26 @@ function buildLightDerivedTokens(theme: ReturnType<typeof buildComputedTheme>) {
     buttonPrimaryBackgroundActive: formatRgba(theme.ink, 0.1 + theme.contrast * 0.12),
     buttonPrimaryBackgroundHover: formatRgba(theme.ink, 0.05 + theme.contrast * 0.06),
     buttonPrimaryBackgroundInactive: formatRgba(theme.ink, 0.18 + theme.contrast * 0.14),
-    buttonSecondaryBackground: formatRgba(theme.ink, 0.04),
-    buttonSecondaryBackgroundActive: formatRgba(theme.ink, 0.03 + theme.contrast * 0.02),
-    buttonSecondaryBackgroundHover: formatRgba(theme.ink, 0.04),
-    buttonSecondaryBackgroundInactive: formatRgba(theme.ink, 0.01 + theme.contrast * 0.02),
+    buttonSecondaryBackground: formatRgba(theme.wash, 0.04),
+    buttonSecondaryBackgroundActive: formatRgba(theme.wash, 0.03 + theme.contrast * 0.02),
+    buttonSecondaryBackgroundHover: formatRgba(theme.wash, 0.04),
+    buttonSecondaryBackgroundInactive: formatRgba(theme.wash, 0.01 + theme.contrast * 0.02),
     buttonTertiaryBackground: formatRgba(theme.ink, 0),
-    buttonTertiaryBackgroundActive: formatRgba(theme.ink, 0.16 + theme.contrast * 0.08),
-    buttonTertiaryBackgroundHover: formatRgba(theme.ink, 0.08 + theme.contrast * 0.04),
+    buttonTertiaryBackgroundActive: formatRgba(theme.wash, 0.16 + theme.contrast * 0.08),
+    buttonTertiaryBackgroundHover: formatRgba(theme.wash, 0.08 + theme.contrast * 0.04),
     controlBackground: formatRgba(controlBase, 0.96),
     controlBackgroundOpaque: formatOpaqueRgb(controlBase),
     elevatedPrimary: formatRgba(elevatedPrimaryBase, 0.96),
     elevatedPrimaryOpaque: formatOpaqueRgb(elevatedPrimaryBase),
-    elevatedSecondary: formatRgba(theme.ink, 0.04),
+    elevatedSecondary: formatRgba(theme.wash, 0.04),
     elevatedSecondaryOpaque: formatOpaqueRgb(elevatedSecondaryBase),
     iconAccent: theme.theme.accent,
     iconPrimary: theme.theme.ink,
     iconSecondary: formatRgba(theme.ink, 0.65 + theme.contrast * 0.1),
     iconTertiary: formatRgba(theme.ink, 0.45 + theme.contrast * 0.1),
+    // Selected sidebar row: a thin wash of the theme accent instead of neutral
+    // ink, so the selection follows the theme rather than reading as a fixed gray.
+    sidebarSelectedBackground: formatRgba(theme.accent, 0.12 + theme.contrast * 0.04),
     simpleScrim: formatRgba(BLACK, 0.08 + theme.contrast * 0.04),
     textAccent: theme.theme.accent,
     textButtonPrimary: theme.theme.surface,
@@ -1138,18 +1152,18 @@ function buildDarkDerivedTokens(theme: ReturnType<typeof buildComputedTheme>) {
     buttonPrimaryBackgroundActive: formatRgba(theme.ink, 0.07 + theme.contrast * 0.05),
     buttonPrimaryBackgroundHover: formatRgba(theme.ink, 0.04 + theme.contrast * 0.03),
     buttonPrimaryBackgroundInactive: formatRgba(theme.ink, 0.02 + theme.contrast * 0.02),
-    buttonSecondaryBackground: formatRgba(theme.ink, 0.04 + theme.contrast * 0.02),
-    buttonSecondaryBackgroundActive: formatRgba(theme.ink, 0.09 + theme.contrast * 0.05),
-    buttonSecondaryBackgroundHover: formatRgba(theme.ink, 0.06 + theme.contrast * 0.03),
-    buttonSecondaryBackgroundInactive: formatRgba(theme.ink, 0.02 + theme.contrast * 0.03),
+    buttonSecondaryBackground: formatRgba(theme.wash, 0.04 + theme.contrast * 0.02),
+    buttonSecondaryBackgroundActive: formatRgba(theme.wash, 0.09 + theme.contrast * 0.05),
+    buttonSecondaryBackgroundHover: formatRgba(theme.wash, 0.06 + theme.contrast * 0.03),
+    buttonSecondaryBackgroundInactive: formatRgba(theme.wash, 0.02 + theme.contrast * 0.03),
     buttonTertiaryBackground: formatRgba(theme.ink, 0.02 + theme.contrast * 0.015),
-    buttonTertiaryBackgroundActive: formatRgba(theme.ink, 0.07 + theme.contrast * 0.05),
-    buttonTertiaryBackgroundHover: formatRgba(theme.ink, 0.05 + theme.contrast * 0.03),
+    buttonTertiaryBackgroundActive: formatRgba(theme.wash, 0.07 + theme.contrast * 0.05),
+    buttonTertiaryBackgroundHover: formatRgba(theme.wash, 0.05 + theme.contrast * 0.03),
     controlBackground: formatRgba(controlBase, 0.96),
     controlBackgroundOpaque: formatOpaqueRgb(controlBase),
     elevatedPrimary: formatRgba(elevatedPrimaryBase, 0.96),
     elevatedPrimaryOpaque: formatOpaqueRgb(elevatedPrimaryBase),
-    elevatedSecondary: formatRgba(theme.ink, 0.02 + theme.contrast * 0.02),
+    elevatedSecondary: formatRgba(theme.wash, 0.02 + theme.contrast * 0.02),
     elevatedSecondaryOpaque: mixHex(
       theme.theme.surface,
       theme.theme.ink,
@@ -1159,6 +1173,10 @@ function buildDarkDerivedTokens(theme: ReturnType<typeof buildComputedTheme>) {
     iconPrimary: formatRgba(theme.ink, 0.82 + theme.contrast * 0.14),
     iconSecondary: formatRgba(theme.ink, 0.65 + theme.contrast * 0.1),
     iconTertiary: formatRgba(theme.ink, 0.45 + theme.contrast * 0.1),
+    // Selected sidebar row: accent-tinted (see the light derivation). Dark uses the
+    // same brightened focus mix as text-accent so the tint stays visible over the
+    // frosted sidebar.
+    sidebarSelectedBackground: formatRgba(focusBase, 0.16 + theme.contrast * 0.06),
     simpleScrim: formatRgba(theme.ink, 0.08 + theme.contrast * 0.04),
     // Codex brightens dark accent affordances through the same focus mix used
     // for the border, rather than using the raw accent directly.


### PR DESCRIPTION
## What Changed

- Refined translucent sidebar surfaces with lighter blur and thinner material fills.
- Added a dedicated accent-tinted selected-row background token for sidebar items and sub-items.
- Applied accent-tinted washes to secondary and tertiary UI surfaces while preserving existing alpha levels.
- Updated sidebar and theme logic tests for the new tokens and colors.

## Why

The previous sidebar treatment was too opaque and made selected rows read as neutral gray. This change gives the sidebar more visible translucency while keeping content legible, and makes selection and subtle UI washes follow the active theme accent consistently.

## UI Changes

Sidebar translucency, selected-row styling, and accent-tinted secondary surfaces have changed. Before/after screenshots are not included in the supplied change context.

## Verification

- Updated `Sidebar.logic.test.ts` and `theme.logic.test.ts` expectations.
- Full formatting, lint, typecheck, and test results were not provided.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and CSS-token changes only; no auth, data, or API behavior. Minor risk of inconsistent selection styling where components still reference `--sidebar-accent-active` (e.g. SpaceSwitcher).
> 
> **Overview**
> **Refines the translucent sidebar shell** and **splits selected-row styling from neutral hover/active fills.**
> 
> The app shell sidebar uses a lighter blur (`6px` / higher saturation) and thinner `color-mix` fills so more desktop shows through in light and dark modes; the same tuning is applied in `theme.logic.ts` for translucent Codex/Electron material.
> 
> A new **`--sidebar-selected`** token (default: thin `--info` wash; theme packs: accent-tinted `--color-background-sidebar-selected`) replaces **`--sidebar-accent-active`** for thread rows (`sidebarRowStyles.ts`, `resolveThreadRowClassName`), menu buttons, and sub-buttons. Press/active states still use `--sidebar-accent-active`.
> 
> Theme derivation adds an accent-leaning **`wash`** ink (40% toward accent) and uses it for secondary/tertiary buttons and elevated surfaces at unchanged alphas, so hovers and subtle fills pick up theme hue instead of identical neutral gray. Tests in `Sidebar.logic.test.ts` and `theme.logic.test.ts` were updated for the new colors and token wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd98d5cd77047aac6fe9ed82027be09a26e6e80c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->