### PR TITLE
fix(pi): keep extension status out of tool timeline

### DIFF
--- a/apps/server/src/orchestration/providerRuntimeActivityProjection.test.ts
+++ b/apps/server/src/orchestration/providerRuntimeActivityProjection.test.ts
@@ -55,6 +55,27 @@ function expectSchemaValidActivities(event: ProviderRuntimeEvent, sessionSequenc
   }
 }
 
+it.each(["info", "warning", "error"])("projects Pi %s notifications as notices", (type) => {
+  const [activity] = projectProviderRuntimeActivities(
+    runtimeEvent({
+      provider: "pi",
+      type: "runtime.warning",
+      eventId: "pi-notification",
+      turnId: TURN_ID,
+      payload: { message: "Extension notification", detail: { type } },
+      raw: { source: "pi.sdk.event", method: "extension/ui/notify", payload: { type } },
+    }),
+  );
+
+  expect(activity).toMatchObject({
+    tone: "info",
+    kind: "runtime.warning",
+    summary: type === "info" ? "Pi extension" : "Runtime warning",
+    payload: { message: "Extension notification", detail: "Extension notification" },
+  });
+  expect(() => decodeActivityAppendCommand(activity!)).not.toThrow();
+});
+
 describe("projected activities satisfy the orchestration command schema", () => {
   it("omits an absent approval request id instead of emitting an explicit undefined", () => {
     expectSchemaValidActivities(

--- a/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
+++ b/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
@@ -688,6 +688,10 @@ export function projectProviderRuntimeActivities(
       // line ("Moved to background: <work>"), not as a runtime warning.
       const detailSubtype = asString(asObject(event.payload.detail)?.subtype);
       const isBackgroundMove = detailSubtype === "background_tasks_changed";
+      const isPiInfoNotification =
+        event.provider === "pi" &&
+        raw?.method === "extension/ui/notify" &&
+        asObject(event.payload.detail)?.type === "info";
       const message = truncateDetail(event.payload.message);
       return [
         {
@@ -695,12 +699,14 @@ export function projectProviderRuntimeActivities(
           createdAt: event.createdAt,
           tone: "info",
           kind: "runtime.warning",
-          summary: isBackgroundMove
-            ? "Moved to background"
-            : event.provider === "opencode" &&
-                (nativeType === "session.next.retried" || nativeType === "session.status")
-              ? "OpenCode retrying"
-              : "Runtime warning",
+          summary: isPiInfoNotification
+            ? "Pi extension"
+            : isBackgroundMove
+              ? "Moved to background"
+              : event.provider === "opencode" &&
+                  (nativeType === "session.next.retried" || nativeType === "session.status")
+                ? "OpenCode retrying"
+                : "Runtime warning",
           // Keep the user-visible message even when raw detail is structured.
           payload: toActivityPayload({
             message,

--- a/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
@@ -215,6 +215,22 @@ async function expectNextTurn(
   expect(completions(events).filter((event) => event.turnId === previous)).toHaveLength(1);
 }
 
+it("does not turn extension footer status into transcript tool progress", async () => {
+  responses("success");
+  captured.extensions.push((pi) => {
+    pi.on("agent_start", (_event, context) => {
+      context.ui.setStatus("caveman", "\u001b[38;2;215;119;87m⠠\u001b[0m caveman level: FULL");
+      context.ui.setStatus("caveman", "\u001b[38;2;215;119;87m⠔\u001b[0m caveman level: FULL");
+    });
+  });
+
+  await withAdapter(async (adapter, events) => {
+    await send(adapter);
+    await waitFor(() => expect(completions(events)).toHaveLength(1));
+    expect(events.filter((event) => event.type === "tool.progress")).toHaveLength(0);
+  });
+});
+
 it("keeps one turn through a real SDK retry and settles text, reasoning and usage once", async () => {
   const calls = responses("error", "success");
   await withAdapter(async (adapter, events) => {

--- a/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
@@ -281,6 +281,8 @@ it("does not turn extension footer status into transcript tool progress", async 
     pi.on("agent_start", (_event, context) => {
       context.ui.setStatus("caveman", "\u001b[38;2;215;119;87m⠠\u001b[0m caveman level: FULL");
       context.ui.setStatus("caveman", "\u001b[38;2;215;119;87m⠔\u001b[0m caveman level: FULL");
+      context.ui.setWorkingMessage("Working...");
+      context.ui.setTitle("Pi terminal");
     });
   });
 
@@ -288,6 +290,66 @@ it("does not turn extension footer status into transcript tool progress", async 
     await send(adapter);
     await waitFor(() => expect(completions(events)).toHaveLength(1));
     expect(events.filter((event) => event.type === "tool.progress")).toHaveLength(0);
+  });
+});
+
+it("keeps extension notifications visible without inventing tool progress", async () => {
+  responses("success");
+  captured.extensions.push((pi) => {
+    pi.on("agent_start", (_event, context) => {
+      context.ui.notify("\u001b[31mEnabled [full] mode\u001b[0m");
+      context.ui.notify("Configuration saved", "info");
+      context.ui.notify("Please reconnect", "warning");
+      context.ui.notify("Tool failed", "error");
+    });
+  });
+
+  await withAdapter(async (adapter, events) => {
+    await send(adapter);
+    await waitFor(() => expect(completions(events)).toHaveLength(1));
+    const notices = events.filter((event) => event.raw?.method === "extension/ui/notify");
+    expect(notices.map((event) => ({ type: event.type, payload: event.payload }))).toEqual([
+      {
+        type: "runtime.warning",
+        payload: { message: "Enabled [full] mode", detail: { type: "info" } },
+      },
+      {
+        type: "runtime.warning",
+        payload: { message: "Configuration saved", detail: { type: "info" } },
+      },
+      {
+        type: "runtime.warning",
+        payload: { message: "Please reconnect", detail: { type: "warning" } },
+      },
+      { type: "runtime.warning", payload: { message: "Tool failed", detail: { type: "error" } } },
+    ]);
+    expect(events.filter((event) => event.type === "tool.progress")).toHaveLength(0);
+  });
+});
+
+it("cleans input prompt formatting while preserving the user's answer", async () => {
+  responses("success");
+  const answer = "items[0]; \u001b[31m";
+  let received: string | undefined;
+  captured.extensions.push((pi) => {
+    pi.on("agent_start", async (_event, context) => {
+      received = await context.ui.input("\u001b[31mExpression [code]\u001b[0m");
+    });
+  });
+
+  await withAdapter(async (adapter, events) => {
+    const sent = send(adapter);
+    await waitFor(() =>
+      expect(events.some((event) => event.type === "user-input.requested")).toBe(true),
+    );
+    const request = events.find((event) => event.type === "user-input.requested")!;
+    expect(request.payload.questions[0]?.question).toBe("Expression [code]");
+    await Effect.runPromise(
+      adapter.respondToUserInput(threadId, request.requestId!, { input: answer }),
+    );
+    await sent;
+    await waitFor(() => expect(completions(events)).toHaveLength(1));
+    expect(received).toBe(answer);
   });
 });
 

--- a/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
@@ -10,7 +10,12 @@ import type {
   InlineExtension,
 } from "@earendil-works/pi-coding-agent";
 import { Effect, Layer, Stream } from "effect";
-import { ThreadId, type ProviderRuntimeEvent, type TurnId } from "@synara/contracts";
+import {
+  ApprovalRequestId,
+  ThreadId,
+  type ProviderRuntimeEvent,
+  type TurnId,
+} from "@synara/contracts";
 import { afterEach, expect, it, vi } from "vitest";
 import {
   AgentGatewayCredentials,
@@ -345,7 +350,9 @@ it("cleans input prompt formatting while preserving the user's answer", async ()
     const request = events.find((event) => event.type === "user-input.requested")!;
     expect(request.payload.questions[0]?.question).toBe("Expression [code]");
     await Effect.runPromise(
-      adapter.respondToUserInput(threadId, request.requestId!, { input: answer }),
+      adapter.respondToUserInput(threadId, ApprovalRequestId.makeUnsafe(request.requestId!), {
+        input: answer,
+      }),
     );
     await sent;
     await waitFor(() => expect(completions(events)).toHaveLength(1));

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -39,6 +39,7 @@ import {
   spawnProcess as spawnPlatformProcess,
   type RuntimeSpawnOptions,
 } from "@synara/shared/processRuntime";
+import { stripTerminalControlSequences } from "@synara/shared/text";
 import { Effect, FileSystem, Layer, Option, Queue, Stream } from "effect";
 
 import { takeSynaraHarnessPolicyForProviderSession } from "../../agentGateway/harnessPolicy.ts";
@@ -512,7 +513,7 @@ function toMessage(cause: unknown, fallback: string): string {
 }
 
 function trimToUndefined(value: string | null | undefined): string | undefined {
-  const trimmed = typeof value === "string" ? value.trim() : "";
+  const trimmed = typeof value === "string" ? stripTerminalControlSequences(value).trim() : "";
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
@@ -1559,8 +1560,6 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
     // pending user-input flow; terminal/TUI-only APIs remain no-op by design.
     const makePiExtensionUIContext = (context: PiSessionContext): ExtensionUIContext => {
       const unsupportedWarnings = new Set<string>();
-      const statusTexts = new Map<string, string>();
-      let workingMessage: string | undefined;
       const warnUnsupported = (method: string) => {
         if (unsupportedWarnings.has(method)) return;
         unsupportedWarnings.add(method);
@@ -1578,21 +1577,6 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           },
         } satisfies ProviderRuntimeEvent);
       };
-      const emitPluginProgress = (summary: string) => {
-        const normalized = trimToUndefined(summary);
-        if (!normalized) return;
-        offerRuntimeEvent({
-          ...makeEventBase(context),
-          type: "tool.progress",
-          payload: { toolName: "Pi plugin", summary: normalized },
-          raw: {
-            source: "pi.sdk.event",
-            method: "extension/ui-progress",
-            payload: { summary: normalized },
-          },
-        } satisfies ProviderRuntimeEvent);
-      };
-
       const uiContext: ExtensionUIContext = {
         async select(title, options, opts) {
           const questionId = "selection";
@@ -1659,29 +1643,18 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             } satisfies ProviderRuntimeEvent);
             return;
           }
-          emitPluginProgress(normalized);
+          // Informational notifications are terminal UI chrome, not transcript
+          // content. Warning/error notifications remain visible as warnings.
         },
         onTerminalInput() {
           warnUnsupported("onTerminalInput");
           return () => undefined;
         },
-        setStatus(key, text) {
-          const normalizedKey = trimToUndefined(key) ?? "status";
-          const normalizedText = trimToUndefined(text);
-          if (!normalizedText) {
-            statusTexts.delete(normalizedKey);
-            return;
-          }
-          if (statusTexts.get(normalizedKey) === normalizedText) return;
-          statusTexts.set(normalizedKey, normalizedText);
-          emitPluginProgress(`${normalizedKey}: ${normalizedText}`);
-        },
-        setWorkingMessage(message) {
-          const normalizedMessage = trimToUndefined(message);
-          if (!normalizedMessage || normalizedMessage === workingMessage) return;
-          workingMessage = normalizedMessage;
-          emitPluginProgress(normalizedMessage);
-        },
+        // Pi extensions use status and working-message callbacks for terminal
+        // chrome. Synara has its own working header; neither belongs in the
+        // transcript as a fake tool call.
+        setStatus() {},
+        setWorkingMessage() {},
         setWorkingVisible() {},
         setWorkingIndicator() {},
         setHiddenThinkingLabel() {},
@@ -1694,9 +1667,9 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         setHeader() {
           warnUnsupported("setHeader");
         },
-        setTitle(title) {
-          if (title) emitPluginProgress(title);
-        },
+        // The browser owns document/thread chrome; do not turn terminal title
+        // changes into transcript rows.
+        setTitle() {},
         async custom() {
           warnUnsupported("custom");
           return undefined as never;
@@ -2457,7 +2430,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             type: "runtime.warning",
             payload: {
               message:
-                "Pi extensions are loaded with Synara's limited UI bridge. select/confirm/input/notify/status are supported; TUI-only widgets and editor hooks are ignored.",
+                "Pi extensions are loaded with Synara's limited UI bridge. select/confirm/input and warning/error notifications are supported; terminal status, widgets, and editor hooks are ignored.",
               detail: {
                 extensionCount: loadedExtensions.length,
                 extensions: extensionNames,

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -514,8 +514,12 @@ function toMessage(cause: unknown, fallback: string): string {
 }
 
 function trimToUndefined(value: string | null | undefined): string | undefined {
-  const trimmed = typeof value === "string" ? stripTerminalControlSequences(value).trim() : "";
+  const trimmed = typeof value === "string" ? value.trim() : "";
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function trimPiDisplayText(value: string | undefined): string | undefined {
+  return value === undefined ? undefined : trimToUndefined(stripTerminalControlSequences(value));
 }
 
 function isPiThinkingLevel(value: string | null | undefined): value is ThinkingLevel {
@@ -1300,7 +1304,7 @@ function extensionDisplayName(extension: {
 }
 
 function makePiUserInputOption(label: string): UserInputQuestion["options"][number] {
-  const normalizedLabel = trimToUndefined(label) ?? "Option";
+  const normalizedLabel = trimPiDisplayText(label) ?? "Option";
   return { label: normalizedLabel, description: normalizedLabel };
 }
 
@@ -1309,7 +1313,7 @@ export function makePiUserInputOptions(
 ): ReadonlyArray<PiUserInputOptionMapping> {
   const labelCounts = new Map<string, number>();
   return labels.map((label, index) => {
-    const baseLabel = trimToUndefined(label) ?? `Option ${index + 1}`;
+    const baseLabel = trimPiDisplayText(label) ?? `Option ${index + 1}`;
     const count = (labelCounts.get(baseLabel) ?? 0) + 1;
     labelCounts.set(baseLabel, count);
     const displayLabel = count === 1 ? baseLabel : `${baseLabel} (${count})`;
@@ -1587,8 +1591,8 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             opts,
             question: {
               id: questionId,
-              header: trimToUndefined(title) ?? "Pi plugin",
-              question: trimToUndefined(title) ?? "Choose an option.",
+              header: trimPiDisplayText(title) ?? "Pi plugin",
+              question: trimPiDisplayText(title) ?? "Choose an option.",
               options: optionMappings.map((mapping) => mapping.option),
             },
             rawPayload: { title, options },
@@ -1603,9 +1607,9 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             opts,
             question: {
               id: questionId,
-              header: trimToUndefined(title) ?? "Pi plugin",
+              header: trimPiDisplayText(title) ?? "Pi plugin",
               question:
-                trimToUndefined(message) ?? trimToUndefined(title) ?? "Confirm this action?",
+                trimPiDisplayText(message) ?? trimPiDisplayText(title) ?? "Confirm this action?",
               options: [makePiUserInputOption("Yes"), makePiUserInputOption("No")],
             },
             rawPayload: { title, message },
@@ -1619,33 +1623,28 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             opts,
             question: {
               id: questionId,
-              header: trimToUndefined(title) ?? "Pi plugin",
+              header: trimPiDisplayText(title) ?? "Pi plugin",
               question:
-                trimToUndefined(placeholder) ?? trimToUndefined(title) ?? "Type a response.",
+                trimPiDisplayText(placeholder) ?? trimPiDisplayText(title) ?? "Type a response.",
               options: [],
             },
             rawPayload: { title, placeholder },
           });
           return firstPiUserInputAnswer(answers, questionId);
         },
-        notify(message, type) {
-          const normalized = trimToUndefined(message);
+        notify(message, type = "info") {
+          const normalized = trimPiDisplayText(message);
           if (!normalized) return;
-          if (type === "warning" || type === "error") {
-            offerRuntimeEvent({
-              ...makeEventBase(context),
-              type: "runtime.warning",
-              payload: { message: normalized, detail: { type: type ?? "info" } },
-              raw: {
-                source: "pi.sdk.event",
-                method: "extension/ui/notify",
-                payload: { message: normalized, type },
-              },
-            } satisfies ProviderRuntimeEvent);
-            return;
-          }
-          // Informational notifications are terminal UI chrome, not transcript
-          // content. Warning/error notifications remain visible as warnings.
+          offerRuntimeEvent({
+            ...makeEventBase(context),
+            type: "runtime.warning",
+            payload: { message: normalized, detail: { type } },
+            raw: {
+              source: "pi.sdk.event",
+              method: "extension/ui/notify",
+              payload: { message: normalized, type },
+            },
+          } satisfies ProviderRuntimeEvent);
         },
         onTerminalInput() {
           warnUnsupported("onTerminalInput");
@@ -2459,7 +2458,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             type: "runtime.warning",
             payload: {
               message:
-                "Pi extensions are loaded with Synara's limited UI bridge. select/confirm/input and warning/error notifications are supported; terminal status, widgets, and editor hooks are ignored.",
+                "Pi extensions are loaded with Synara's limited UI bridge. select/confirm/input and notifications are supported; terminal status, widgets, and editor hooks are ignored.",
               detail: {
                 extensionCount: loadedExtensions.length,
                 extensions: extensionNames,

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -25,6 +25,26 @@ describe("deriveWorkLogEntries", () => {
     expect(entries.map((entry) => entry.id)).toEqual(["tool-start"]);
   });
 
+  it("strips terminal formatting from persisted provider activity details", () => {
+    const [entry] = deriveWorkLogEntries(
+      [
+        makeActivity({
+          id: "pi-plugin-status",
+          kind: "tool.updated",
+          summary: "Pi plugin",
+          payload: {
+            itemType: "mcp_tool_call",
+            title: "MCP tool call",
+            detail: "\u001b[38;2;215;119;87mTransmuting...\u001b[0m",
+          },
+        }),
+      ],
+      undefined,
+    );
+
+    expect(entry?.detail).toBe("Transmuting...");
+  });
+
   it("does not expose unmapped diagnostic data as a transcript preview", () => {
     const [entry] = deriveWorkLogEntries(
       [

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -45,6 +45,40 @@ describe("deriveWorkLogEntries", () => {
     expect(entry?.detail).toBe("Transmuting...");
   });
 
+  it("preserves bracketed source text in provider activity details", () => {
+    const detail = "const first = items[0]; // [example]";
+    const [entry] = deriveWorkLogEntries(
+      [
+        makeActivity({
+          id: "source-output",
+          kind: "tool.updated",
+          summary: "Read file",
+          payload: { detail },
+        }),
+      ],
+      undefined,
+    );
+
+    expect(entry?.detail).toBe(detail);
+  });
+
+  it("cleans persisted notice messages without losing bracketed content", () => {
+    const [entry] = deriveWorkLogEntries(
+      [
+        makeActivity({
+          id: "pi-notice",
+          kind: "runtime.warning",
+          summary: "Pi extension",
+          payload: { message: "\u001b[31mEnabled [full] mode\u001b[0m" },
+        }),
+      ],
+      undefined,
+    );
+
+    expect(entry?.detail).toBe("Enabled [full] mode");
+    expect(entry?.label).toBe("Pi extension");
+  });
+
   it("does not expose unmapped diagnostic data as a transcript preview", () => {
     const [entry] = deriveWorkLogEntries(
       [

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -21,7 +21,7 @@ import {
   stripTrailingToolExitCode,
   summarizeToolRawOutput,
 } from "@synara/shared/toolOutputSummary";
-import { pluralize } from "@synara/shared/text";
+import { pluralize, stripTerminalControlSequences } from "@synara/shared/text";
 import { PROVIDER_DESCRIPTORS } from "@synara/shared/providerMetadata";
 import {
   deriveReadableToolTitle,
@@ -602,7 +602,7 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   const itemType = extractWorkLogItemType(payload);
   const requestKind = extractWorkLogRequestKind(payload);
   if (payload && typeof payload.detail === "string" && payload.detail.length > 0) {
-    const detail = stripTrailingExitCode(payload.detail).output;
+    const detail = stripTrailingExitCode(stripTerminalControlSequences(payload.detail)).output;
     if (detail) {
       entry.detail = detail;
     }
@@ -610,11 +610,11 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   const outputDetail =
     activity.kind === "provider.event.unmapped" ? null : summarizeToolPayloadOutput(payload);
   if (outputDetail && (!entry.detail || toolStatus === "failed")) {
-    entry.detail = outputDetail;
+    entry.detail = stripTerminalControlSequences(outputDetail);
   }
   const collabTaskOutputDetail = extractCollabTaskOutputDetail(payload);
   if (collabTaskOutputDetail) {
-    entry.detail = collabTaskOutputDetail;
+    entry.detail = stripTerminalControlSequences(collabTaskOutputDetail);
   }
   const nativeEventType =
     payload && typeof payload.nativeEventType === "string" && payload.nativeEventType.length > 0
@@ -1576,7 +1576,7 @@ function asTrimmedString(value: unknown): string | null {
   if (typeof value !== "string") {
     return null;
   }
-  const trimmed = value.trim();
+  const trimmed = stripTerminalControlSequences(value).trim();
   return trimmed.length > 0 ? trimmed : null;
 }
 

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -627,7 +627,7 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
     activity.kind === "runtime.warning" &&
     typeof payload?.message === "string" &&
     payload.message.trim().length > 0
-      ? payload.message.trim()
+      ? stripTerminalControlSequences(payload.message).trim()
       : undefined;
   if (runtimeWarningMessage) {
     entry.detail = runtimeWarningMessage;
@@ -1576,7 +1576,7 @@ function asTrimmedString(value: unknown): string | null {
   if (typeof value !== "string") {
     return null;
   }
-  const trimmed = stripTerminalControlSequences(value).trim();
+  const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
 }
 

--- a/packages/shared/src/text.test.ts
+++ b/packages/shared/src/text.test.ts
@@ -36,10 +36,29 @@ describe("stripTerminalControlSequences", () => {
     ).toBe("Transmuting...");
   });
 
-  it("cleans CSI sequences that lost their escape prefix", () => {
-    expect(stripTerminalControlSequences("[38;2;215;119;87mCaveman level: FULL[0m")).toBe(
-      "Caveman level: FULL",
-    );
+  it.each([
+    "[test] completed",
+    "items[0]",
+    "/tmp/[draft]/project",
+    "[Open file](src/main.ts)",
+    "[38;2;215;119;87mCaveman level: FULL[0m",
+  ])("preserves ordinary bracketed text: %s", (value) => {
+    expect(stripTerminalControlSequences(value)).toBe(value);
+  });
+
+  it.each(["\u0007", "\u001b\\", "\u009c"])(
+    "preserves labels and text between OSC controls terminated by %j",
+    (terminator) => {
+      const link = `\u001b]8;;https://example.com${terminator}visible\u001b]8;;${terminator}`;
+      expect(stripTerminalControlSequences(`${link} after ${link}`)).toBe("visible after visible");
+    },
+  );
+
+  it("handles single-byte CSI and OSC introducers", () => {
+    expect(stripTerminalControlSequences("\u009b31mred\u009b0m")).toBe("red");
+    expect(
+      stripTerminalControlSequences("\u009d8;;https://example.com\u009cvisible\u009d8;;\u009c"),
+    ).toBe("visible");
   });
 });
 

--- a/packages/shared/src/text.test.ts
+++ b/packages/shared/src/text.test.ts
@@ -4,7 +4,12 @@
 // Depends on: Vitest and text helpers
 
 import { describe, expect, it } from "vitest";
-import { pluralize, splitsSurrogatePair, unicodeSafeEndOffset } from "./text";
+import {
+  pluralize,
+  splitsSurrogatePair,
+  stripTerminalControlSequences,
+  unicodeSafeEndOffset,
+} from "./text";
 
 describe("UTF-16 boundaries", () => {
   const text = "a📌b";
@@ -21,6 +26,20 @@ describe("UTF-16 boundaries", () => {
     expect(unicodeSafeEndOffset(text, 2)).toBe(1);
     expect(unicodeSafeEndOffset(text, 3)).toBe(3);
     expect(unicodeSafeEndOffset(text, text.length)).toBe(text.length);
+  });
+});
+
+describe("stripTerminalControlSequences", () => {
+  it("removes ANSI color and cursor sequences while preserving text", () => {
+    expect(
+      stripTerminalControlSequences("\u001b[38;2;215;119;87mTransmuting...\u001b[0m\u001b[?25l"),
+    ).toBe("Transmuting...");
+  });
+
+  it("cleans CSI sequences that lost their escape prefix", () => {
+    expect(stripTerminalControlSequences("[38;2;215;119;87mCaveman level: FULL[0m")).toBe(
+      "Caveman level: FULL",
+    );
   });
 });
 

--- a/packages/shared/src/text.ts
+++ b/packages/shared/src/text.ts
@@ -2,7 +2,7 @@
 // Purpose: Small, dependency-free text helpers shared across server and web so
 // repeated string semantics (count pluralization, etc.) live in one place.
 // Layer: Shared runtime utility
-// Exports: normalizeLineEndings, pluralize, nonEmptyTrimmed, splitsSurrogatePair, unicodeSafeEndOffset
+// Exports: normalizeLineEndings, pluralize, nonEmptyTrimmed, splitsSurrogatePair, stripTerminalControlSequences, unicodeSafeEndOffset
 
 // Workspace text buffers use LF; retain the separate on-disk format metadata
 // when this representation is used for editing or comparison.
@@ -45,6 +45,15 @@ export function nonEmptyTrimmed(value: string | null | undefined): string | unde
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+// Removes terminal formatting/control sequences from provider text before it
+// reaches chat or durable activity storage. The optional escape prefix handles
+// old rows where transport stripped ESC but left the visible CSI body behind.
+export function stripTerminalControlSequences(value: string): string {
+  return value
+    .replace(/(?:\u001B|\u009B)?\[[0-?]*[ -/]*[@-~]/gu, "")
+    .replace(/(?:\u001B\]|\u009D)[^\u0007]*(?:\u0007|\u001B\\)/gu, "");
 }
 
 // Returns the singular or plural form of a noun based on `count`. The plural

--- a/packages/shared/src/text.ts
+++ b/packages/shared/src/text.ts
@@ -47,13 +47,12 @@ export function nonEmptyTrimmed(value: string | null | undefined): string | unde
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-// Removes terminal formatting/control sequences from provider text before it
-// reaches chat or durable activity storage. The optional escape prefix handles
-// old rows where transport stripped ESC but left the visible CSI body behind.
+// Removes actual terminal control sequences while preserving ordinary brackets
+// and visible text between separate OSC controls (including hyperlink labels).
 export function stripTerminalControlSequences(value: string): string {
   return value
-    .replace(/(?:\u001B|\u009B)?\[[0-?]*[ -/]*[@-~]/gu, "")
-    .replace(/(?:\u001B\]|\u009D)[^\u0007]*(?:\u0007|\u001B\\)/gu, "");
+    .replace(/(?:\u001B\[|\u009B)[0-?]*[ -/]*[@-~]/gu, "")
+    .replace(/(?:\u001B\]|\u009D)[^\u0007\u001B\u009C]*(?:\u0007|\u001B\\|\u009C)/gu, "");
 }
 
 // Returns the singular or plural form of a noun based on `count`. The plural


### PR DESCRIPTION
## Problem
Pi extensions such as pi-caveman call `ui.setStatus` every 200ms for animated footer updates. Synara converted each callback into a generic `tool.progress` row, leaking ANSI sequences and burying real read/write/bash/MCP calls.

## Fix
- Ignore terminal-only extension status, working-message, title, and informational notify callbacks in transcript activity.
- Keep warning/error notifications visible.
- Strip terminal control sequences from Pi-facing text and persisted activity details.
- Add regression coverage for animated extension status and historical ANSI output.

### BEFORE
<img width="2248" height="1136" alt="image" src="https://github.com/user-attachments/assets/758e054a-8367-44a6-bdb3-cf221a6d950b" />

### AFTER
<img width="812" height="236" alt="Screenshot 2026-09-10 at 12 25 31 AM" src="https://github.com/user-attachments/assets/3c3c9d5c-c9a2-46a3-b355-cfb06b129514" />
<img width="991" height="431" alt="Screenshot 2026-09-10 at 12 16 48 AM" src="https://github.com/user-attachments/assets/9583dd57-a32c-4702-ad11-7bed7d106244" />



## Verification
- `bun run --cwd packages/shared test -- text.test.ts`
- `bun run --cwd apps/server test -- PiAdapter.lifecycle.test.ts providerRuntimeActivityProjection.test.ts`
- `bun run --cwd apps/web test -- workLog.test.ts`