### PR TITLE
Allow inactive Antigravity PreToolUse hooks

### DIFF
--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -512,10 +512,10 @@ describe("Antigravity CLI integration helpers", () => {
 
     expect(result.error).toBeUndefined();
     expect(result.status).toBe(0);
-    // Neutral for PreToolUse means preserving the permission flow: Antigravity
-    // requires a `decision`, and an empty object is treated as a denial with
-    // an empty reason that blocks every tool call (#490).
-    expect(result.stdout.trim()).toBe('{"decision":"ask"}');
+    // Neutral for PreToolUse means a valid no-op decision: Antigravity
+    // requires a `decision`, an empty object is treated as a denial (#490),
+    // and `"ask"` is rejected by protojson so print-mode tool calls fail.
+    expect(result.stdout.trim()).toBe('{"decision":"allow"}');
 
     const postToolResult = runCaptureCommand(
       buildAntigravityCaptureCommand(
@@ -565,7 +565,7 @@ describe("Antigravity CLI integration helpers", () => {
 
       expect(result.error).toBeUndefined();
       expect(result.status).toBe(0);
-      expect(result.stdout.trim()).toBe('{"decision":"ask"}');
+      expect(result.stdout.trim()).toBe('{"decision":"allow"}');
     } finally {
       await fs.rm(directory, { recursive: true, force: true });
     }
@@ -614,7 +614,7 @@ describe("Antigravity CLI integration helpers", () => {
         "darwin",
       ),
     ).toBe(
-      `if [ -z "\${SYNARA_ANTIGRAVITY_EVENTS:-}" ]; then cat >/dev/null 2>&1 || :; printf '%s\\n' '{"decision":"ask"}'; else ELECTRON_RUN_AS_NODE=1 '/Applications/Synara.app/Contents/MacOS/Synara' '/tmp/synara-capture/capture.cjs' 'pre-tool'; fi`,
+      `if [ -z "\${SYNARA_ANTIGRAVITY_EVENTS:-}" ]; then cat >/dev/null 2>&1 || :; printf '%s\\n' '{"decision":"allow"}'; else ELECTRON_RUN_AS_NODE=1 '/Applications/Synara.app/Contents/MacOS/Synara' '/tmp/synara-capture/capture.cjs' 'pre-tool'; fi`,
     );
     expect(
       buildAntigravityCaptureCommand(
@@ -628,7 +628,7 @@ describe("Antigravity CLI integration helpers", () => {
       // escapes intact, so `"` arrives as `\"` and quoted paths fail to
       // execute ("not recognized as an internal or external command"). The
       // win32 command must stay free of double quotes.
-      String.raw`if not defined SYNARA_ANTIGRAVITY_EVENTS (more >nul 2>nul & echo {"decision":"ask"}) else (set ELECTRON_RUN_AS_NODE=1&& C:\Users\test\AppData\Local\Programs\Synara\Synara.exe C:\Users\test\.gemini\capture.cjs pre-tool)`,
+      String.raw`if not defined SYNARA_ANTIGRAVITY_EVENTS (more >nul 2>nul & echo {"decision":"allow"}) else (set ELECTRON_RUN_AS_NODE=1&& C:\Users\test\AppData\Local\Programs\Synara\Synara.exe C:\Users\test\.gemini\capture.cjs pre-tool)`,
     );
     // PreInvocation gates the LLM invocation: answer allow so subagent
     // launches are not denied (which would make the parent CLI exit 1).

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -236,7 +236,9 @@ function shellQuote(value: string, platform: NodeJS.Platform = process.platform)
  * Antigravity requires PreToolUse output to carry a `decision`: an empty
  * object is treated as a denial with an empty reason, which blocks every tool
  * call because the hook is installed globally with `matcher: "*"` (#490).
- * "ask" preserves the permission flow the user would have without the hook.
+ * `"ask"` is not a valid Antigravity protojson decision; print-mode CLI
+ * sessions reject it and skip native tool steps. `"allow"` is the no-op that
+ * lets non-Synara Antigravity use, including MAGI CLI Google seats, proceed.
  *
  * PreInvocation fires immediately before an LLM invocation and is a veto
  * point with the same decision semantics: an empty object is treated as a
@@ -256,7 +258,7 @@ function shellQuote(value: string, platform: NodeJS.Platform = process.platform)
  * "Working" and Cancel has nothing left to kill (#465).
  */
 function inactiveHookOutput(event: string): string {
-  if (event === "pre-tool") return '{"decision":"ask"}';
+  if (event === "pre-tool") return '{"decision":"allow"}';
   if (event === "pre-invocation") return '{"decision":"allow"}';
   return "{}";
 }
@@ -292,13 +294,13 @@ process.stdin.on("data", (chunk) => { payload += chunk; });
 process.stdin.on("end", () => {
   const target = process.env.SYNARA_ANTIGRAVITY_EVENTS;
   if (!target) {
-    // Mirrors the shell wrapper's inactive fallback: PreToolUse must carry a
-    // decision or Antigravity denies the tool call with an empty reason, and
-    // PreInvocation must carry "allow" or the subagent launch it gates is
-    // denied and the parent CLI exits with code 1.
+    // Mirrors the shell wrapper's inactive fallback: PreToolUse must carry
+    // "allow" ("ask" is not a valid protojson decision) or the CLI rejects
+    // the hook and skips tools, and PreInvocation must carry "allow" or the
+    // subagent launch it gates is denied and the parent CLI exits with code 1.
     process.stdout.write(
       (event === "pre-tool"
-        ? '{"decision":"ask"}'
+        ? '{"decision":"allow"}'
         : event === "pre-invocation"
           ? '{"decision":"allow"}'
           : "{}") + "\\n",


### PR DESCRIPTION
## Summary
- Inactive Antigravity `PreToolUse` now returns `{"decision":"allow"}` instead of `{"decision":"ask"}`.
- The same no-op is used by the shell wrapper and `capture.cjs` when `SYNARA_ANTIGRAVITY_EVENTS` is unset.

## Why
The capture plugin is installed globally. `"ask"` is not a valid Antigravity protojson decision, so print-mode CLI sessions (including MAGI CLI Google seats) fail every tool call with `jsonhook__synara-capture_PreToolUse` even though they are not Synara-managed. Empty output is already a denial (#490); `"allow"` is the valid inactive no-op. Synara-managed sessions still set `SYNARA_ANTIGRAVITY_HOOK_DECISION=allow` and keep writing capture events.

## Test plan
- [x] Adapter unit expectations updated for inactive PreToolUse allow on Unix and Windows command strings
- [x] Live `capture.cjs pre-tool` with unset events env prints `{"decision":"allow"}`
- [ ] Synara-managed Antigravity turns still capture tools
- [ ] Non-Synara `agy --print` tool use succeeds while Synara is installed
