### PR TITLE
feat(web): add manual sidebar thread reordering

### DIFF
--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -591,6 +591,13 @@ describe("sidebar sort defaults", () => {
   it("defaults thread sorting to updated_at", () => {
     expect(DEFAULT_SIDEBAR_THREAD_SORT_ORDER).toBe("updated_at");
   });
+
+  it("decodes manual thread sorting", () => {
+    const decoded = Schema.decodeSync(Schema.fromJsonString(AppSettingsSchema))(
+      JSON.stringify({ sidebarThreadSortOrder: "manual" }),
+    );
+    expect(decoded.sidebarThreadSortOrder).toBe("manual");
+  });
 });
 
 describe("normalizeStoredAppSettings", () => {

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -102,7 +102,7 @@ export const DEFAULT_TIMESTAMP_FORMAT: TimestampFormat = "locale";
 export const SidebarProjectSortOrder = Schema.Literals(["updated_at", "created_at", "manual"]);
 export type SidebarProjectSortOrder = typeof SidebarProjectSortOrder.Type;
 export const DEFAULT_SIDEBAR_PROJECT_SORT_ORDER: SidebarProjectSortOrder = "manual";
-export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at"]);
+export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at", "manual"]);
 
 const SidebarNavItemId = Schema.Literals([...SIDEBAR_NAV_ITEM_IDS]);
 export type SidebarThreadSortOrder = typeof SidebarThreadSortOrder.Type;

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -39,6 +39,7 @@ import {
   getScrollContainerDistanceFromBottom,
 } from "../chat-scroll";
 import { useLatestProjectStore } from "../latestProjectStore";
+import { useSidebarThreadOrderStore } from "../sidebarThreadOrderStore";
 import {
   INLINE_TERMINAL_CONTEXT_PLACEHOLDER,
   type TerminalContextDraft,
@@ -72,6 +73,7 @@ import { useTerminalStateStore } from "../terminalStateStore";
 import { resetRetainedThreadDetailSubscriptionsForTests } from "../threadDetailSubscriptionRetention";
 import { useWorkspacePathsStore } from "../workspacePathsStore";
 import { resetWsNativeApiForTest } from "../wsNativeApi";
+import { THREAD_DRAG_MIME } from "./chat-drop-overlay/ChatPaneDropOverlay";
 // Pre-transform the compiler-heavy component outside the first case's timeout.
 // The router's auto-split route otherwise requests this module on first mount.
 import "./ChatView";
@@ -173,6 +175,58 @@ interface ChatLayoutMeasurement {
 
 function isoAt(offsetSeconds: number): string {
   return new Date(BASE_TIME_MS + offsetSeconds * 1_000).toISOString();
+}
+
+async function dragSidebarThreadHandle(sourceId: ThreadId, targetId: ThreadId): Promise<void> {
+  const source = document.querySelector<HTMLElement>(
+    `[data-thread-reorder-handle="${sourceId}"]`,
+  );
+  const target = document.querySelector<HTMLElement>(
+    `[data-thread-reorder-handle="${targetId}"]`,
+  );
+  if (!source || !target) throw new Error("Expected sidebar reorder handles to be rendered");
+  const sourceRect = source.getBoundingClientRect();
+  const targetRect = target.getBoundingClientRect();
+  const pointer = {
+    bubbles: true,
+    cancelable: true,
+    pointerId: 41,
+    pointerType: "mouse",
+    isPrimary: true,
+    button: 0,
+    buttons: 1,
+  } as const;
+  source.dispatchEvent(
+    new PointerEvent("pointerdown", {
+      ...pointer,
+      clientX: sourceRect.left + sourceRect.width / 2,
+      clientY: sourceRect.top + sourceRect.height / 2,
+    }),
+  );
+  document.dispatchEvent(
+    new PointerEvent("pointermove", {
+      ...pointer,
+      clientX: sourceRect.left + sourceRect.width / 2,
+      clientY: sourceRect.top + sourceRect.height / 2 + 8,
+    }),
+  );
+  await nextFrame();
+  document.dispatchEvent(
+    new PointerEvent("pointermove", {
+      ...pointer,
+      clientX: targetRect.left + targetRect.width / 2,
+      clientY: targetRect.top + targetRect.height / 2,
+    }),
+  );
+  await nextFrame();
+  document.dispatchEvent(
+    new PointerEvent("pointerup", {
+      ...pointer,
+      buttons: 0,
+      clientX: targetRect.left + targetRect.width / 2,
+      clientY: targetRect.top + targetRect.height / 2,
+    }),
+  );
 }
 
 function createBaseServerConfig(): ServerConfig {
@@ -2127,6 +2181,7 @@ describe("ChatView transcript geometry (full app)", () => {
     attachmentCancelBarrier = null;
     localStorage.clear();
     useLatestProjectStore.setState({ latestProjectId: null });
+    useSidebarThreadOrderStore.setState({ orderedThreadIds: [] });
     useWorkspacePathsStore.setState({
       homeDir: null,
       chatWorkspaceRoot: null,
@@ -6077,6 +6132,60 @@ describe("ChatView transcript geometry (full app)", () => {
 
       // The empty thread view and composer should still be visible.
       await expect.element(page.getByTestId("composer-editor")).toBeInTheDocument();
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("reorders sidebar conversations, switches to manual order, and preserves split dragging", async () => {
+    const snapshot = addThreadToSnapshot(
+      createSnapshotForTargetUser({
+        targetMessageId: "msg-user-sidebar-reorder" as MessageId,
+        targetText: "sidebar reorder test",
+      }),
+      OTHER_THREAD_ID,
+    );
+    const mounted = await mountChatView({ viewport: DEFAULT_VIEWPORT, snapshot });
+
+    try {
+      await vi.waitFor(() => {
+        expect(
+          document.querySelector(`[data-thread-reorder-handle="${OTHER_THREAD_ID}"]`),
+        ).not.toBeNull();
+        expect(
+          document.querySelector(`[data-thread-reorder-handle="${THREAD_ID}"]`),
+        ).not.toBeNull();
+      });
+
+      await dragSidebarThreadHandle(OTHER_THREAD_ID, THREAD_ID);
+
+      await vi.waitFor(() => {
+        expect(useSidebarThreadOrderStore.getState().orderedThreadIds).toEqual([
+          THREAD_ID,
+          OTHER_THREAD_ID,
+        ]);
+        expect(localStorage.getItem("synara:app-settings:v1")).toContain(
+          '"sidebarThreadSortOrder":"manual"',
+        );
+      });
+
+      const orderedHandles = Array.from(
+        document.querySelectorAll<HTMLElement>("[data-thread-reorder-handle]"),
+      ).map((handle) => handle.dataset.threadReorderHandle);
+      expect(orderedHandles).toEqual([THREAD_ID, OTHER_THREAD_ID]);
+
+      const reorderedHandle = document.querySelector<HTMLElement>(
+        `[data-thread-reorder-handle="${THREAD_ID}"]`,
+      );
+      const draggableRow = reorderedHandle
+        ?.closest("[data-thread-item]")
+        ?.querySelector<HTMLElement>("[draggable='true']");
+      expect(draggableRow).not.toBeNull();
+      const splitDragData = new DataTransfer();
+      draggableRow?.dispatchEvent(
+        new DragEvent("dragstart", { bubbles: true, cancelable: true, dataTransfer: splitDragData }),
+      );
+      expect(JSON.parse(splitDragData.getData(THREAD_DRAG_MIME))).toEqual({ threadId: THREAD_ID });
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -178,12 +178,8 @@ function isoAt(offsetSeconds: number): string {
 }
 
 async function dragSidebarThreadHandle(sourceId: ThreadId, targetId: ThreadId): Promise<void> {
-  const source = document.querySelector<HTMLElement>(
-    `[data-thread-reorder-handle="${sourceId}"]`,
-  );
-  const target = document.querySelector<HTMLElement>(
-    `[data-thread-reorder-handle="${targetId}"]`,
-  );
+  const source = document.querySelector<HTMLElement>(`[data-thread-reorder-handle="${sourceId}"]`);
+  const target = document.querySelector<HTMLElement>(`[data-thread-reorder-handle="${targetId}"]`);
   if (!source || !target) throw new Error("Expected sidebar reorder handles to be rendered");
   const sourceRect = source.getBoundingClientRect();
   const targetRect = target.getBoundingClientRect();
@@ -6183,7 +6179,11 @@ describe("ChatView transcript geometry (full app)", () => {
       expect(draggableRow).not.toBeNull();
       const splitDragData = new DataTransfer();
       draggableRow?.dispatchEvent(
-        new DragEvent("dragstart", { bubbles: true, cancelable: true, dataTransfer: splitDragData }),
+        new DragEvent("dragstart", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: splitDragData,
+        }),
       );
       expect(JSON.parse(splitDragData.getData(THREAD_DRAG_MIME))).toEqual({ threadId: THREAD_ID });
     } finally {

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -2009,10 +2009,7 @@ describe("sortThreadsForSidebar", () => {
         }),
       ],
       "manual",
-      [
-        ThreadId.makeUnsafe("thread-manual-first"),
-        ThreadId.makeUnsafe("thread-manual-second"),
-      ],
+      [ThreadId.makeUnsafe("thread-manual-first"), ThreadId.makeUnsafe("thread-manual-second")],
     );
 
     expect(sorted.map((thread) => thread.id)).toEqual([

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -1992,6 +1992,55 @@ describe("deriveSidebarProjectData", () => {
 });
 
 describe("sortThreadsForSidebar", () => {
+  it("uses the persisted manual order and keeps new threads at the top", () => {
+    const sorted = sortThreadsForSidebar(
+      [
+        makeThread({
+          id: ThreadId.makeUnsafe("thread-manual-first"),
+          createdAt: "2026-03-09T09:00:00.000Z",
+        }),
+        makeThread({
+          id: ThreadId.makeUnsafe("thread-new"),
+          createdAt: "2026-03-09T12:00:00.000Z",
+        }),
+        makeThread({
+          id: ThreadId.makeUnsafe("thread-manual-second"),
+          createdAt: "2026-03-09T11:00:00.000Z",
+        }),
+      ],
+      "manual",
+      [
+        ThreadId.makeUnsafe("thread-manual-first"),
+        ThreadId.makeUnsafe("thread-manual-second"),
+      ],
+    );
+
+    expect(sorted.map((thread) => thread.id)).toEqual([
+      ThreadId.makeUnsafe("thread-new"),
+      ThreadId.makeUnsafe("thread-manual-first"),
+      ThreadId.makeUnsafe("thread-manual-second"),
+    ]);
+  });
+
+  it("keeps manual order stable while a conversation is working", () => {
+    const sorted = sortThreadsForSidebar(
+      [
+        {
+          ...makeThread({ id: ThreadId.makeUnsafe("thread-working") }),
+          hasLiveTailWork: true,
+        },
+        makeThread({ id: ThreadId.makeUnsafe("thread-first") }),
+      ],
+      "manual",
+      [ThreadId.makeUnsafe("thread-first"), ThreadId.makeUnsafe("thread-working")],
+    );
+
+    expect(sorted.map((thread) => thread.id)).toEqual([
+      ThreadId.makeUnsafe("thread-first"),
+      ThreadId.makeUnsafe("thread-working"),
+    ]);
+  });
+
   it("sorts threads by the latest user message in recency mode", () => {
     const sorted = sortThreadsForSidebar(
       [

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -12,6 +12,7 @@ import { pluralize } from "@synara/shared/text";
 import { resolveThreadEnvironmentMode } from "@synara/shared/threadEnvironment";
 import { isWorkspaceRootWithin, workspaceRootsEqual } from "@synara/shared/threadWorkspace";
 import type { SidebarProjectSortOrder, SidebarThreadSortOrder } from "../appSettings";
+import { compareSidebarThreadsByManualOrder } from "../sidebarThreadOrdering";
 import { resolveRestorableThreadRoute, type LastThreadRoute } from "../chatRouteRestore";
 import type { ChatMessage, Project, SidebarThreadSummary, Thread } from "../types";
 import { cn } from "../lib/utils";
@@ -531,7 +532,7 @@ export function pruneProjectThreadListPagingForCollapsedProjects<
  * - A status/loader (or keyboard-jump) glyph occupies a ~2.25rem slot, and each
  *   fork/worktree/handoff meta chip adds width; the reserve grows only for the
  *   badges that are present.
- * - The wider reserve that clears the hover pin/archive actions is applied only
+ * - The wider reserve that clears the hover reorder/pin/archive actions is applied only
  *   on hover/focus (mirroring the project header row), so the title gives up that
  *   width exactly when those actions appear and not a moment sooner.
  *
@@ -541,10 +542,10 @@ export function resolveThreadRowTrailingReserveClass(input: {
   metaChipCount: number;
   hasTrailingGlyph: boolean;
 }): string {
-  // Hover/focus reveals the pin/archive actions; the meta chips + glyph fade out
+  // Hover/focus reveals the reorder/pin/archive actions; the meta chips + glyph fade out
   // at the same time, so the hover reserve is constant regardless of rest content.
   const hoverReserve =
-    "transition-[padding] duration-150 ease-out group-hover/thread-row:pr-[4.75rem] group-focus-within/thread-row:pr-[4.75rem]";
+    "transition-[padding] duration-150 ease-out group-hover/thread-row:pr-[5.5rem] group-focus-within/thread-row:pr-[5.5rem]";
   const { metaChipCount, hasTrailingGlyph } = input;
   if (metaChipCount <= 0) {
     return cn(hasTrailingGlyph ? "pr-[1.75rem]" : "pr-2", hoverReserve);
@@ -1228,7 +1229,7 @@ function getLatestUserMessageTimestamp(thread: SidebarThreadSortInput): number {
 
 function getThreadSortTimestamp(
   thread: SidebarThreadSortInput,
-  sortOrder: SidebarThreadSortOrder | Exclude<SidebarProjectSortOrder, "manual">,
+  sortOrder: Exclude<SidebarThreadSortOrder | SidebarProjectSortOrder, "manual">,
 ): number {
   if (sortOrder === "created_at") {
     return toSortableTimestamp(thread.createdAt) ?? Number.NEGATIVE_INFINITY;
@@ -1267,18 +1268,31 @@ function threadSortAttentionRank(thread: SidebarThreadSortInput): number {
 export function sortThreadsForSidebar<T extends { id: Thread["id"] } & SidebarThreadSortInput>(
   threads: readonly T[],
   sortOrder: SidebarThreadSortOrder,
+  manualThreadIds: readonly T["id"][] = [],
 ): T[] {
-  return threads.toSorted((left, right) => {
-    if (sortOrder !== "created_at") {
+  const rankById = new Map(manualThreadIds.map((threadId, index) => [threadId, index] as const));
+  const automaticSortOrder = sortOrder === "created_at" ? "created_at" : "updated_at";
+  const compareAutomatically = (left: T, right: T) => {
+    if (automaticSortOrder !== "created_at") {
       const byAttentionRank = threadSortAttentionRank(right) - threadSortAttentionRank(left);
       if (byAttentionRank !== 0) return byAttentionRank;
     }
-    const rightTimestamp = getThreadSortTimestamp(right, sortOrder);
-    const leftTimestamp = getThreadSortTimestamp(left, sortOrder);
+    const rightTimestamp = getThreadSortTimestamp(right, automaticSortOrder);
+    const leftTimestamp = getThreadSortTimestamp(left, automaticSortOrder);
     const byTimestamp =
       rightTimestamp === leftTimestamp ? 0 : rightTimestamp > leftTimestamp ? 1 : -1;
     if (byTimestamp !== 0) return byTimestamp;
     return right.id.localeCompare(left.id);
+  };
+
+  return threads.toSorted((left, right) => {
+    if (sortOrder !== "manual") return compareAutomatically(left, right);
+    return compareSidebarThreadsByManualOrder({
+      leftId: left.id,
+      rightId: right.id,
+      rankById,
+      compareFallback: () => compareAutomatically(left, right),
+    });
   });
 }
 
@@ -1289,8 +1303,9 @@ export function getFallbackThreadIdAfterDelete<
   deletedThreadId: T["id"];
   sortOrder: SidebarThreadSortOrder;
   deletedThreadIds?: ReadonlySet<T["id"]>;
+  manualThreadIds?: readonly T["id"][];
 }): T["id"] | null {
-  const { deletedThreadId, deletedThreadIds, sortOrder, threads } = input;
+  const { deletedThreadId, deletedThreadIds, manualThreadIds, sortOrder, threads } = input;
   const deletedThread = threads.find((thread) => thread.id === deletedThreadId);
   if (!deletedThread) {
     return null;
@@ -1305,6 +1320,7 @@ export function getFallbackThreadIdAfterDelete<
           !deletedThreadIds?.has(thread.id),
       ),
       sortOrder,
+      manualThreadIds,
     )[0]?.id ?? null
   );
 }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2193,12 +2193,7 @@ export default function Sidebar() {
 
       return (await handleNewThread(projectId).catch(() => null)) !== null;
     },
-    [
-      appSettings.sidebarThreadSortOrder,
-      handleNewThread,
-      manualThreadIds,
-      navigate,
-    ],
+    [appSettings.sidebarThreadSortOrder, handleNewThread, manualThreadIds, navigate],
   );
 
   const openExistingProjectFromSnapshot = useCallback(

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -299,6 +299,8 @@ import {
   SidebarTrigger,
 } from "./ui/sidebar";
 import { useThreadSelectionStore } from "../threadSelectionStore";
+import { useSidebarThreadOrderStore } from "../sidebarThreadOrderStore";
+import { usePinnedThreadsStore } from "../pinnedThreadsStore";
 import {
   buildProjectThreadTree,
   derivePinnedProjectIdsForSidebar,
@@ -377,6 +379,12 @@ import {
   SIDEBAR_SECTION_LABEL_CLASS_NAME,
 } from "../sidebarRowStyles";
 import { SettingsSidebarNav } from "./SettingsSidebarNav";
+import {
+  SidebarSortableThreadItem,
+  SidebarSortableThreadList,
+  SidebarThreadReorderHandle,
+  type SidebarSortableThreadRenderProps,
+} from "./SidebarSortableThreadList";
 import {
   ComposerPickerMenuPopup,
   ComposerPickerMenuSubPopup,
@@ -462,6 +470,7 @@ const SIDEBAR_SORT_LABELS: Record<SidebarProjectSortOrder, string> = {
 const SIDEBAR_THREAD_SORT_LABELS: Record<SidebarThreadSortOrder, string> = {
   updated_at: "Last user message",
   created_at: "Created at",
+  manual: "Manual",
 };
 const SIDEBAR_LIST_ANIMATION_OPTIONS = {
   duration: 180,
@@ -1452,6 +1461,10 @@ export default function Sidebar() {
     [automationListQuery.data],
   );
   const { settings: appSettings, serverSettings, updateSettings } = useAppSettings();
+  const manualThreadIds = useSidebarThreadOrderStore((state) => state.orderedThreadIds);
+  const moveThreadInManualOrder = useSidebarThreadOrderStore((state) => state.moveThread);
+  const pruneManualThreadOrder = useSidebarThreadOrderStore((state) => state.pruneThreads);
+  const movePinnedThread = usePinnedThreadsStore((state) => state.movePinnedThread);
   // Projects is always available; Studio and the standalone Chats footer can be hidden
   // independently from Settings.
   const chatsSectionVisible = appSettings.showChatsSection;
@@ -1658,6 +1671,7 @@ export default function Sidebar() {
     timestamp: number;
   } | null>(null);
   const dragInProgressRef = useRef(false);
+  const reorderPointerThreadIdRef = useRef<ThreadId | null>(null);
   const suppressProjectClickAfterDragRef = useRef(false);
   const optimisticPinnedStateByProjectIdRef = useRef(new Map<ProjectId, boolean>());
   const latestPinnedMutationVersionByProjectIdRef = useRef(new Map<ProjectId, number>());
@@ -1687,6 +1701,29 @@ export default function Sidebar() {
   );
   const sidebarThreads = useStore(selectSidebarThreads);
   const sidebarTreeThreads = useStore(selectSidebarTreeThreads);
+  useEffect(() => {
+    if (!threadsHydrated) return;
+    pruneManualThreadOrder(
+      Object.keys(sidebarThreadSummaryById).map((threadId) => ThreadId.makeUnsafe(threadId)),
+    );
+  }, [pruneManualThreadOrder, sidebarThreadSummaryById, threadsHydrated]);
+
+  const finishThreadReorder = useCallback(() => {
+    reorderPointerThreadIdRef.current = null;
+  }, []);
+  const moveSidebarThread = useCallback(
+    (input: {
+      scopeThreadIds: readonly ThreadId[];
+      activeThreadId: ThreadId;
+      overThreadId: ThreadId;
+    }) => {
+      const changed = moveThreadInManualOrder(input);
+      if (changed && appSettings.sidebarThreadSortOrder !== "manual") {
+        updateSettings({ sidebarThreadSortOrder: "manual" });
+      }
+    },
+    [appSettings.sidebarThreadSortOrder, moveThreadInManualOrder, updateSettings],
+  );
   const selectProjectLastActivityAt = useMemo(() => createProjectLastActivityAtSelector(), []);
   const projectLastActivityAt = useStore(selectProjectLastActivityAt);
   const studioProjectIdSet = useMemo(
@@ -1835,6 +1872,7 @@ export default function Sidebar() {
     appSettings,
     clearTerminalState,
     handleNewChat,
+    manualThreadIds,
     projectById,
     routeSplitViewId: routeSearch.splitViewId ?? null,
     routeThreadId,
@@ -1923,6 +1961,10 @@ export default function Sidebar() {
         pinnedThreadIds,
       ),
     [activeSpaceNonStudioSidebarTreeThreads, isOnStudio, pinnedThreadIds, studioSidebarTreeThreads],
+  );
+  const pinnedSortableThreads = useMemo(
+    () => pinnedThreads.filter((thread) => !thread.parentThreadId),
+    [pinnedThreads],
   );
   const openPrLink = useCallback((event: MouseEvent<HTMLElement>, prUrl: string) => {
     event.preventDefault();
@@ -2103,6 +2145,7 @@ export default function Sidebar() {
             isSidebarThreadVisible(thread, { hideAutomationRunThreads }),
         ),
         appSettings.sidebarThreadSortOrder,
+        manualThreadIds,
       )[0];
       if (!latestThread) return;
 
@@ -2111,7 +2154,13 @@ export default function Sidebar() {
         params: { threadId: latestThread.id },
       });
     },
-    [appSettings.sidebarThreadSortOrder, hideAutomationRunThreads, navigate, sidebarThreads],
+    [
+      appSettings.sidebarThreadSortOrder,
+      hideAutomationRunThreads,
+      manualThreadIds,
+      navigate,
+      sidebarThreads,
+    ],
   );
 
   const openOrCreateProjectThreadFromSnapshot = useCallback(
@@ -2131,6 +2180,7 @@ export default function Sidebar() {
             latestUserMessageAt: thread.latestUserMessageAt,
           })),
         appSettings.sidebarThreadSortOrder,
+        manualThreadIds,
       )[0];
       if (latestThread) {
         await navigate({
@@ -2150,6 +2200,7 @@ export default function Sidebar() {
       appSettings.defaultThreadEnvMode,
       appSettings.sidebarThreadSortOrder,
       handleNewThread,
+      manualThreadIds,
       navigate,
     ],
   );
@@ -2174,6 +2225,7 @@ export default function Sidebar() {
             latestUserMessageAt: thread.latestUserMessageAt,
           })),
         appSettings.sidebarThreadSortOrder,
+        manualThreadIds,
       )[0];
       if (latestThread) {
         await navigate({
@@ -2194,6 +2246,7 @@ export default function Sidebar() {
       appSettings.defaultThreadEnvMode,
       appSettings.sidebarThreadSortOrder,
       handleNewThread,
+      manualThreadIds,
       navigate,
       setProjectExpanded,
     ],
@@ -2336,7 +2389,8 @@ export default function Sidebar() {
   const resolveBackTargetForThreads = useCallback(
     (threads: readonly SidebarThreadSummary[], extraAvailableThreadIds?: ReadonlySet<string>) => {
       const latestThread =
-        sortThreadsForSidebar(threads, appSettings.sidebarThreadSortOrder)[0] ?? null;
+        sortThreadsForSidebar(threads, appSettings.sidebarThreadSortOrder, manualThreadIds)[0] ??
+        null;
       const availableThreadIds = new Set<string>(threads.map((thread) => thread.id));
       if (extraAvailableThreadIds) {
         for (const threadId of extraAvailableThreadIds) {
@@ -2352,7 +2406,7 @@ export default function Sidebar() {
         latestThreadId: latestThread?.id ?? null,
       });
     },
-    [appSettings.sidebarThreadSortOrder, lastThreadRoute, splitViewsById],
+    [appSettings.sidebarThreadSortOrder, lastThreadRoute, manualThreadIds, splitViewsById],
   );
 
   // Fresh unsent chats have a route id but no persisted sidebar summary yet. Keep those draft
@@ -3372,6 +3426,7 @@ export default function Sidebar() {
     projectById,
     sidebarThreads,
     sidebarThreadSortOrder: appSettings.sidebarThreadSortOrder,
+    manualThreadIds,
     routeThreadId,
     routeProjectId,
     isOnKanban,
@@ -3832,11 +3887,15 @@ export default function Sidebar() {
     for (const [projectId, projectThreads] of sidebarThreadsByProjectId) {
       byProjectId.set(
         projectId,
-        sortThreadsForSidebar(projectThreads, appSettings.sidebarThreadSortOrder),
+        sortThreadsForSidebar(
+          projectThreads,
+          appSettings.sidebarThreadSortOrder,
+          manualThreadIds,
+        ),
       );
     }
     return byProjectId;
-  }, [appSettings.sidebarThreadSortOrder, sidebarThreadsByProjectId]);
+  }, [appSettings.sidebarThreadSortOrder, manualThreadIds, sidebarThreadsByProjectId]);
   const handleProjectTitlePointerDownCapture = useCallback(() => {
     suppressProjectClickAfterDragRef.current = false;
   }, []);
@@ -3879,6 +3938,7 @@ export default function Sidebar() {
       threads: sortThreadsForSidebar(
         chatProjects.flatMap((project) => sortedSidebarThreadsByProjectId.get(project.id) ?? []),
         appSettings.sidebarThreadSortOrder,
+        manualThreadIds,
       ),
       forceVisibleThreadId: activeSidebarThreadId ?? undefined,
     });
@@ -3887,10 +3947,18 @@ export default function Sidebar() {
     appSettings.sidebarThreadSortOrder,
     chatSectionExpanded,
     chatProjects,
+    manualThreadIds,
     sortedSidebarThreadsByProjectId,
   ]);
   const visibleChatThreadIds = useMemo(
     () => visibleChatThreadRows.map((row) => row.thread.id),
+    [visibleChatThreadRows],
+  );
+  const chatReorderScopeThreadIds = useMemo(
+    () =>
+      visibleChatThreadRows
+        .filter((row) => !row.thread.parentThreadId)
+        .map((row) => row.thread.id),
     [visibleChatThreadRows],
   );
   // Studio threads, flattened the same way the home Chats list is. Skipped entirely while the
@@ -3910,6 +3978,7 @@ export default function Sidebar() {
           pinnedThreadIds,
         ),
         appSettings.sidebarThreadSortOrder,
+        manualThreadIds,
       ),
       forceVisibleThreadId: activeSidebarThreadId ?? undefined,
     });
@@ -3917,12 +3986,20 @@ export default function Sidebar() {
     activeSidebarThreadId,
     appSettings.sidebarThreadSortOrder,
     isOnStudio,
+    manualThreadIds,
     pinnedThreadIds,
     sortedSidebarThreadsByProjectId,
     studioProjects,
   ]);
   const studioChatThreadIds = useMemo(
     () => studioChatThreadRows.map((row) => row.thread.id),
+    [studioChatThreadRows],
+  );
+  const studioSortableThreads = useMemo(
+    () =>
+      studioChatThreadRows
+        .filter((row) => !row.thread.parentThreadId)
+        .map((row) => ({ id: row.thread.id, title: row.thread.title })),
     [studioChatThreadRows],
   );
   const visibleChatPreviewEntries = useMemo(
@@ -3965,6 +4042,14 @@ export default function Sidebar() {
       renderedChatEntries: visibleEntries,
     };
   }, [activeChatPreviewEntry?.rowId, chatThreadListExtraPages, visibleChatPreviewEntries]);
+  const chatSortableThreads = useMemo(
+    () =>
+      renderedChatEntries
+        .map((entry) => entry.row.thread)
+        .filter((thread) => !thread.parentThreadId)
+        .map((thread) => ({ id: thread.id, title: thread.title })),
+    [renderedChatEntries],
+  );
   const allStandardProjectsBase = useMemo(
     () =>
       sortedProjects.filter((project) =>
@@ -4342,6 +4427,7 @@ export default function Sidebar() {
     threadId: ThreadId;
     toneClassName: string;
     isPinned: boolean;
+    reorderHandle?: ReactNode;
     includePinToggle?: boolean;
     compact?: boolean;
   }) {
@@ -4351,6 +4437,7 @@ export default function Sidebar() {
     return (
       <SidebarRowHoverActions threadId={input.threadId}>
         <div className="pointer-events-auto inline-flex items-center gap-2">
+          {input.reorderHandle}
           {includePinToggle ? (
             <ThreadPinToggleButton
               pinned={input.isPinned}
@@ -4449,9 +4536,27 @@ export default function Sidebar() {
         <div className="my-1 flex items-center justify-between px-2 py-1">
           <span className={SIDEBAR_SECTION_LABEL_CLASS_NAME}>Pinned</span>
         </div>
-        <div className="flex flex-col gap-0.5">
-          {pinnedThreads.map((thread) => renderPinnedThreadRow(thread))}
-        </div>
+        <SidebarSortableThreadList
+          items={pinnedSortableThreads.map((thread) => ({
+            id: thread.id,
+            title: thread.title,
+          }))}
+          onDragStart={(threadId) => {
+            reorderPointerThreadIdRef.current = threadId;
+          }}
+          onDragFinish={finishThreadReorder}
+          onMove={({ activeThreadId, overThreadId }) => {
+            movePinnedThread({
+              scopeThreadIds: pinnedSortableThreads.map((thread) => thread.id),
+              activeThreadId,
+              overThreadId,
+            });
+          }}
+        >
+          <div className="flex flex-col gap-0.5">
+            {pinnedThreads.map((thread) => renderPinnedThreadRow(thread))}
+          </div>
+        </SidebarSortableThreadList>
       </div>
     );
   }
@@ -4522,6 +4627,42 @@ export default function Sidebar() {
     );
   }
 
+  function renderSortableThread(
+    thread: SidebarThreadSummary,
+    reorderable: boolean,
+    render: (sortable: SidebarSortableThreadRenderProps | null) => ReactNode,
+  ) {
+    if (!reorderable || thread.parentThreadId) return render(null);
+    return (
+      <SidebarSortableThreadItem key={thread.id} threadId={thread.id}>
+        {render}
+      </SidebarSortableThreadItem>
+    );
+  }
+
+  function renderThreadReorderHandle(
+    thread: SidebarThreadSummary,
+    sortable: SidebarSortableThreadRenderProps | null,
+  ) {
+    if (!sortable) return undefined;
+    return (
+      <SidebarThreadReorderHandle
+        threadId={thread.id}
+        title={thread.title}
+        manualOrder={appSettings.sidebarThreadSortOrder === "manual"}
+        sortable={sortable}
+        onPointerIntent={() => {
+          reorderPointerThreadIdRef.current = thread.id;
+        }}
+        onPointerRelease={() => {
+          if (reorderPointerThreadIdRef.current === thread.id) {
+            reorderPointerThreadIdRef.current = null;
+          }
+        }}
+      />
+    );
+  }
+
   function renderPinnedThreadRow(thread: SidebarThreadSummary) {
     const threadTerminalState = selectThreadTerminalState(terminalStateByThreadId, thread.id);
     const threadEntryPoint = threadTerminalState.entryPoint;
@@ -4557,14 +4698,19 @@ export default function Sidebar() {
       scope: "pinned",
       threadId: thread.id,
     });
-    return (
+    return renderSortableThread(thread, true, (sortable) => (
       <Tooltip key={thread.id}>
         <TooltipTrigger
           {...SIDEBAR_HOVER_CARD_TRIGGER_PROPS}
           render={
             <div
+              ref={sortable?.setNodeRef}
+              style={sortable?.style}
               data-thread-hover-anchor={hoverAnchorId}
-              className="group/thread-row relative w-full"
+              className={cn(
+                "group/thread-row relative w-full",
+                sortable?.sortableClassName,
+              )}
             />
           }
         >
@@ -4604,6 +4750,7 @@ export default function Sidebar() {
             }}
             onPointerUp={(event) => handleThreadRenamePointerUp(event, thread.id)}
             onKeyDown={(event) => {
+              if ((event.target as Element).closest("[data-thread-reorder-handle]")) return;
               if (event.key === "Enter" || event.key === " ") {
                 event.preventDefault();
                 activateThreadFromSidebarIntent(thread.id);
@@ -4659,6 +4806,7 @@ export default function Sidebar() {
                   threadId: thread.id,
                   toneClassName: "text-muted-foreground/42",
                   isPinned: true,
+                  reorderHandle: renderThreadReorderHandle(thread, sortable),
                   compact: isSubagentThread,
                 }),
               })}
@@ -4667,7 +4815,7 @@ export default function Sidebar() {
         </TooltipTrigger>
         {renderThreadHoverCardPopup(thread, hoverAnchorId, isActive)}
       </Tooltip>
-    );
+    ));
   }
 
   function renderThreadRow(
@@ -4678,6 +4826,7 @@ export default function Sidebar() {
     // their top-level rows align flush like pinned rows instead of the indented
     // column used for project-nested threads.
     topLevel = false,
+    reorderable = false,
   ) {
     const threadTerminalState = selectThreadTerminalState(terminalStateByThreadId, thread.id);
     const threadEntryPoint = threadTerminalState.entryPoint;
@@ -4720,11 +4869,13 @@ export default function Sidebar() {
       threadId: thread.id,
     });
 
-    return (
+    return renderSortableThread(thread, reorderable, (sortable) => (
       <SidebarMenuSubItem
         key={thread.id}
+        ref={sortable?.setNodeRef}
+        style={sortable?.style}
         data-thread-hover-anchor={hoverAnchorId}
-        className="group/thread-row w-full"
+        className={cn("group/thread-row w-full", sortable?.sortableClassName)}
         data-thread-item
       >
         {leadingPr ? (
@@ -4758,6 +4909,10 @@ export default function Sidebar() {
                 )}
                 draggable
                 onDragStart={(event) => {
+                  if (reorderPointerThreadIdRef.current === thread.id) {
+                    event.preventDefault();
+                    return;
+                  }
                   const dragImage = event.currentTarget as HTMLElement | null;
                   event.dataTransfer.effectAllowed = "move";
                   event.dataTransfer.setData(
@@ -4784,6 +4939,7 @@ export default function Sidebar() {
                 }}
                 onPointerUp={(event) => handleThreadRenamePointerUp(event, thread.id)}
                 onKeyDown={(event) => {
+                  if ((event.target as Element).closest("[data-thread-reorder-handle]")) return;
                   if (event.key !== "Enter" && event.key !== " ") return;
                   event.preventDefault();
                   activateThreadFromSidebarIntent(thread.id);
@@ -4854,6 +5010,7 @@ export default function Sidebar() {
                   threadId: thread.id,
                   toneClassName: secondaryMetaClass,
                   isPinned,
+                  reorderHandle: renderThreadReorderHandle(thread, sortable),
                   compact: isSubagentThread,
                 }),
               })}
@@ -4862,7 +5019,7 @@ export default function Sidebar() {
           {renderThreadHoverCardPopup(thread, hoverAnchorId, isActive)}
         </Tooltip>
       </SidebarMenuSubItem>
-    );
+    ));
   }
 
   function renderProjectItem(
@@ -4876,6 +5033,7 @@ export default function Sidebar() {
     }
     const {
       orderedProjectThreadIds,
+      projectThreads,
       allProjectThreadCount,
       projectStatus,
       visibleEntries,
@@ -5100,9 +5258,34 @@ export default function Sidebar() {
                 disclosureContentClassName(project.expanded),
               )}
             >
-              {visibleEntries.map((entry) =>
-                renderThreadRow(entry.thread, orderedProjectThreadIds, entry.depth),
-              )}
+              <SidebarSortableThreadList
+                items={visibleEntries
+                  .filter((entry) => !entry.thread.parentThreadId)
+                  .map((entry) => ({ id: entry.thread.id, title: entry.thread.title }))}
+                onDragStart={(threadId) => {
+                  reorderPointerThreadIdRef.current = threadId;
+                }}
+                onDragFinish={finishThreadReorder}
+                onMove={({ activeThreadId, overThreadId }) => {
+                  moveSidebarThread({
+                    scopeThreadIds: projectThreads
+                      .filter((thread) => !thread.parentThreadId)
+                      .map((thread) => thread.id),
+                    activeThreadId,
+                    overThreadId,
+                  });
+                }}
+              >
+                {visibleEntries.map((entry) =>
+                  renderThreadRow(
+                    entry.thread,
+                    orderedProjectThreadIds,
+                    entry.depth,
+                    false,
+                    true,
+                  ),
+                )}
+              </SidebarSortableThreadList>
 
               {(canShowMoreThreads || canShowLessThreads) && (
                 <SidebarMenuSubItem className="w-full">
@@ -6121,17 +6304,38 @@ export default function Sidebar() {
                       />
                     </>,
                   )}
-                  <SidebarMenu ref={attachProjectListAutoAnimateRef} className="gap-1">
-                    {studioChatThreadRows.length > 0 ? (
-                      studioChatThreadRows.map((row) =>
-                        renderThreadRow(row.thread, studioChatThreadIds, row.depth, true),
-                      )
-                    ) : (
-                      <div className="px-2 pt-4 text-center text-[length:var(--app-font-size-ui,12px)] text-muted-foreground/58">
-                        {threadsHydrated ? "No studio chats yet" : "Loading Studio..."}
-                      </div>
-                    )}
-                  </SidebarMenu>
+                  <SidebarSortableThreadList
+                    items={studioSortableThreads}
+                    onDragStart={(threadId) => {
+                      reorderPointerThreadIdRef.current = threadId;
+                    }}
+                    onDragFinish={finishThreadReorder}
+                    onMove={({ activeThreadId, overThreadId }) => {
+                      moveSidebarThread({
+                        scopeThreadIds: studioSortableThreads.map((thread) => thread.id),
+                        activeThreadId,
+                        overThreadId,
+                      });
+                    }}
+                  >
+                    <SidebarMenu ref={attachProjectListAutoAnimateRef} className="gap-1">
+                      {studioChatThreadRows.length > 0 ? (
+                        studioChatThreadRows.map((row) =>
+                          renderThreadRow(
+                            row.thread,
+                            studioChatThreadIds,
+                            row.depth,
+                            true,
+                            true,
+                          ),
+                        )
+                      ) : (
+                        <div className="px-2 pt-4 text-center text-[length:var(--app-font-size-ui,12px)] text-muted-foreground/58">
+                          {threadsHydrated ? "No studio chats yet" : "Loading Studio..."}
+                        </div>
+                      )}
+                    </SidebarMenu>
+                  </SidebarSortableThreadList>
                 </SidebarGroup>
               ) : activityViewEnabled ? (
                 <SidebarGroup className="px-1.5 py-1.5">
@@ -6354,62 +6558,80 @@ export default function Sidebar() {
 
               <div className={cn(disclosureShellClassName(chatSectionExpanded), "pt-1")}>
                 <div className={DISCLOSURE_INNER_CLASS}>
-                  <SidebarMenu
-                    className={cn("gap-1", disclosureContentClassName(chatSectionExpanded))}
+                  <SidebarSortableThreadList
+                    items={chatSortableThreads}
+                    onDragStart={(threadId) => {
+                      reorderPointerThreadIdRef.current = threadId;
+                    }}
+                    onDragFinish={finishThreadReorder}
+                    onMove={({ activeThreadId, overThreadId }) => {
+                      moveSidebarThread({
+                        scopeThreadIds: chatReorderScopeThreadIds,
+                        activeThreadId,
+                        overThreadId,
+                      });
+                    }}
                   >
-                    {visibleChatThreadRows.length > 0 ? (
-                      renderedChatEntries.map((entry) =>
-                        renderThreadRow(
-                          entry.row.thread,
-                          visibleChatThreadIds,
-                          entry.row.depth,
-                          true,
-                        ),
-                      )
-                    ) : (
-                      <div className="px-2 py-2 text-[length:var(--app-font-size-ui,12px)] text-muted-foreground/48">
-                        No chats yet
-                      </div>
-                    )}
-                    {canShowMoreChatThreads || canShowLessChatThreads ? (
-                      <SidebarMenuItem className="w-full">
-                        <div className="flex w-full items-center gap-1">
-                          {canShowMoreChatThreads ? (
-                            <SidebarMenuButton
-                              size="sm"
-                              className="h-7 flex-1 justify-start rounded-lg pr-2 pl-8 text-left text-[length:var(--app-font-size-ui,12px)] font-normal text-muted-foreground/79 hover:bg-transparent hover:text-foreground active:bg-transparent active:text-foreground"
-                              onMouseDown={preventFocusOnMouseDown}
-                              onClick={() =>
-                                setChatThreadListExtraPages(chatThreadListEffectiveExtraPages + 1)
-                              }
-                            >
-                              <span>Show more</span>
-                            </SidebarMenuButton>
-                          ) : null}
-                          {canShowLessChatThreads ? (
-                            <SidebarMenuButton
-                              size="sm"
-                              className={cn(
-                                "h-7 justify-start rounded-lg text-left text-[length:var(--app-font-size-ui,12px)] font-normal text-muted-foreground/79 hover:bg-transparent hover:text-foreground active:bg-transparent active:text-foreground",
-                                // Keep the left indent when "Show less" is the only affordance left.
-                                canShowMoreChatThreads
-                                  ? "w-auto flex-none px-2"
-                                  : "flex-1 pr-2 pl-8",
-                              )}
-                              onMouseDown={preventFocusOnMouseDown}
-                              onClick={() =>
-                                setChatThreadListExtraPages(
-                                  Math.max(0, chatThreadListEffectiveExtraPages - 1),
-                                )
-                              }
-                            >
-                              <span>Show less</span>
-                            </SidebarMenuButton>
-                          ) : null}
+                    <SidebarMenu
+                      className={cn("gap-1", disclosureContentClassName(chatSectionExpanded))}
+                    >
+                      {visibleChatThreadRows.length > 0 ? (
+                        renderedChatEntries.map((entry) =>
+                          renderThreadRow(
+                            entry.row.thread,
+                            visibleChatThreadIds,
+                            entry.row.depth,
+                            true,
+                            true,
+                          ),
+                        )
+                      ) : (
+                        <div className="px-2 py-2 text-[length:var(--app-font-size-ui,12px)] text-muted-foreground/48">
+                          No chats yet
                         </div>
-                      </SidebarMenuItem>
-                    ) : null}
-                  </SidebarMenu>
+                      )}
+                      {canShowMoreChatThreads || canShowLessChatThreads ? (
+                        <SidebarMenuItem className="w-full">
+                          <div className="flex w-full items-center gap-1">
+                            {canShowMoreChatThreads ? (
+                              <SidebarMenuButton
+                                size="sm"
+                                className="h-7 flex-1 justify-start rounded-lg pr-2 pl-8 text-left text-[length:var(--app-font-size-ui,12px)] font-normal text-muted-foreground/79 hover:bg-transparent hover:text-foreground active:bg-transparent active:text-foreground"
+                                onMouseDown={preventFocusOnMouseDown}
+                                onClick={() =>
+                                  setChatThreadListExtraPages(
+                                    chatThreadListEffectiveExtraPages + 1,
+                                  )
+                                }
+                              >
+                                <span>Show more</span>
+                              </SidebarMenuButton>
+                            ) : null}
+                            {canShowLessChatThreads ? (
+                              <SidebarMenuButton
+                                size="sm"
+                                className={cn(
+                                  "h-7 justify-start rounded-lg text-left text-[length:var(--app-font-size-ui,12px)] font-normal text-muted-foreground/79 hover:bg-transparent hover:text-foreground active:bg-transparent active:text-foreground",
+                                  // Keep the left indent when "Show less" is the only affordance left.
+                                  canShowMoreChatThreads
+                                    ? "w-auto flex-none px-2"
+                                    : "flex-1 pr-2 pl-8",
+                                )}
+                                onMouseDown={preventFocusOnMouseDown}
+                                onClick={() =>
+                                  setChatThreadListExtraPages(
+                                    Math.max(0, chatThreadListEffectiveExtraPages - 1),
+                                  )
+                                }
+                              >
+                                <span>Show less</span>
+                              </SidebarMenuButton>
+                            ) : null}
+                          </div>
+                        </SidebarMenuItem>
+                      ) : null}
+                    </SidebarMenu>
+                  </SidebarSortableThreadList>
                 </div>
               </div>
             </div>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3887,11 +3887,7 @@ export default function Sidebar() {
     for (const [projectId, projectThreads] of sidebarThreadsByProjectId) {
       byProjectId.set(
         projectId,
-        sortThreadsForSidebar(
-          projectThreads,
-          appSettings.sidebarThreadSortOrder,
-          manualThreadIds,
-        ),
+        sortThreadsForSidebar(projectThreads, appSettings.sidebarThreadSortOrder, manualThreadIds),
       );
     }
     return byProjectId;
@@ -3956,9 +3952,7 @@ export default function Sidebar() {
   );
   const chatReorderScopeThreadIds = useMemo(
     () =>
-      visibleChatThreadRows
-        .filter((row) => !row.thread.parentThreadId)
-        .map((row) => row.thread.id),
+      visibleChatThreadRows.filter((row) => !row.thread.parentThreadId).map((row) => row.thread.id),
     [visibleChatThreadRows],
   );
   // Studio threads, flattened the same way the home Chats list is. Skipped entirely while the
@@ -4707,10 +4701,7 @@ export default function Sidebar() {
               ref={sortable?.setNodeRef}
               style={sortable?.style}
               data-thread-hover-anchor={hoverAnchorId}
-              className={cn(
-                "group/thread-row relative w-full",
-                sortable?.sortableClassName,
-              )}
+              className={cn("group/thread-row relative w-full", sortable?.sortableClassName)}
             />
           }
         >
@@ -5277,13 +5268,7 @@ export default function Sidebar() {
                 }}
               >
                 {visibleEntries.map((entry) =>
-                  renderThreadRow(
-                    entry.thread,
-                    orderedProjectThreadIds,
-                    entry.depth,
-                    false,
-                    true,
-                  ),
+                  renderThreadRow(entry.thread, orderedProjectThreadIds, entry.depth, false, true),
                 )}
               </SidebarSortableThreadList>
 
@@ -6321,13 +6306,7 @@ export default function Sidebar() {
                     <SidebarMenu ref={attachProjectListAutoAnimateRef} className="gap-1">
                       {studioChatThreadRows.length > 0 ? (
                         studioChatThreadRows.map((row) =>
-                          renderThreadRow(
-                            row.thread,
-                            studioChatThreadIds,
-                            row.depth,
-                            true,
-                            true,
-                          ),
+                          renderThreadRow(row.thread, studioChatThreadIds, row.depth, true, true),
                         )
                       ) : (
                         <div className="px-2 pt-4 text-center text-[length:var(--app-font-size-ui,12px)] text-muted-foreground/58">
@@ -6599,9 +6578,7 @@ export default function Sidebar() {
                                 className="h-7 flex-1 justify-start rounded-lg pr-2 pl-8 text-left text-[length:var(--app-font-size-ui,12px)] font-normal text-muted-foreground/79 hover:bg-transparent hover:text-foreground active:bg-transparent active:text-foreground"
                                 onMouseDown={preventFocusOnMouseDown}
                                 onClick={() =>
-                                  setChatThreadListExtraPages(
-                                    chatThreadListEffectiveExtraPages + 1,
-                                  )
+                                  setChatThreadListExtraPages(chatThreadListEffectiveExtraPages + 1)
                                 }
                               >
                                 <span>Show more</span>

--- a/apps/web/src/components/SidebarSortableThreadList.browser.tsx
+++ b/apps/web/src/components/SidebarSortableThreadList.browser.tsx
@@ -70,12 +70,8 @@ function pressFocusedKey(code: string, key = code) {
 }
 
 async function dragHandleTo(sourceId: string, targetId: string) {
-  const source = document.querySelector<HTMLElement>(
-    `[data-thread-reorder-handle="${sourceId}"]`,
-  );
-  const target = document.querySelector<HTMLElement>(
-    `[data-thread-reorder-handle="${targetId}"]`,
-  );
+  const source = document.querySelector<HTMLElement>(`[data-thread-reorder-handle="${sourceId}"]`);
+  const target = document.querySelector<HTMLElement>(`[data-thread-reorder-handle="${targetId}"]`);
   if (!source || !target) throw new Error("Expected sortable handles to be rendered");
   const sourceRect = source.getBoundingClientRect();
   const targetRect = target.getBoundingClientRect();
@@ -137,17 +133,17 @@ describe("SidebarSortableThreadList", () => {
     pressFocusedKey("ArrowDown");
     await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
     pressFocusedKey("Space", " ");
-    await expect.element(page.getByRole("list", { name: "Conversations" })).toHaveTextContent(
-      "BravoAlphaCharlie",
-    );
+    await expect
+      .element(page.getByRole("list", { name: "Conversations" }))
+      .toHaveTextContent("BravoAlphaCharlie");
   });
 
   it("reorders a conversation using the pointer handle", async () => {
     await render(<SortableHarness />);
     await dragHandleTo("thread-a", "thread-c");
-    await expect.element(page.getByRole("list", { name: "Conversations" })).toHaveTextContent(
-      "BravoCharlieAlpha",
-    );
+    await expect
+      .element(page.getByRole("list", { name: "Conversations" }))
+      .toHaveTextContent("BravoCharlieAlpha");
   });
 
   it("keeps the order when a keyboard drag is cancelled", async () => {
@@ -157,8 +153,8 @@ describe("SidebarSortableThreadList", () => {
     await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
     pressFocusedKey("ArrowDown");
     pressFocusedKey("Escape");
-    await expect.element(page.getByRole("list", { name: "Conversations" })).toHaveTextContent(
-      "AlphaBravoCharlie",
-    );
+    await expect
+      .element(page.getByRole("list", { name: "Conversations" }))
+      .toHaveTextContent("AlphaBravoCharlie");
   });
 });

--- a/apps/web/src/components/SidebarSortableThreadList.browser.tsx
+++ b/apps/web/src/components/SidebarSortableThreadList.browser.tsx
@@ -1,0 +1,164 @@
+// FILE: SidebarSortableThreadList.browser.tsx
+// Purpose: Browser coverage for keyboard-accessible conversation reordering and cancellation.
+// Layer: Sidebar UI browser test
+
+import "../index.css";
+
+import { ThreadId } from "@synara/contracts";
+import { useState } from "react";
+import { page, userEvent } from "vitest/browser";
+import { afterEach, describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import {
+  SidebarSortableThreadItem,
+  SidebarSortableThreadList,
+  SidebarThreadReorderHandle,
+} from "./SidebarSortableThreadList";
+
+const INITIAL_ITEMS = [
+  { id: ThreadId.makeUnsafe("thread-a"), title: "Alpha" },
+  { id: ThreadId.makeUnsafe("thread-b"), title: "Bravo" },
+  { id: ThreadId.makeUnsafe("thread-c"), title: "Charlie" },
+];
+
+function SortableHarness() {
+  const [items, setItems] = useState(INITIAL_ITEMS);
+  return (
+    <SidebarSortableThreadList
+      items={items}
+      onMove={({ activeThreadId, overThreadId }) => {
+        setItems((current) => {
+          const next = [...current];
+          const activeIndex = next.findIndex((item) => item.id === activeThreadId);
+          const overIndex = next.findIndex((item) => item.id === overThreadId);
+          const [active] = next.splice(activeIndex, 1);
+          if (active) next.splice(overIndex, 0, active);
+          return next;
+        });
+      }}
+    >
+      <ol aria-label="Conversations">
+        {items.map((item) => (
+          <SidebarSortableThreadItem key={item.id} threadId={item.id}>
+            {(sortable) => (
+              <li
+                ref={sortable.setNodeRef}
+                style={sortable.style}
+                className={sortable.sortableClassName}
+              >
+                <span>{item.title}</span>
+                <SidebarThreadReorderHandle
+                  threadId={item.id}
+                  title={item.title}
+                  manualOrder
+                  sortable={sortable}
+                />
+              </li>
+            )}
+          </SidebarSortableThreadItem>
+        ))}
+      </ol>
+    </SidebarSortableThreadList>
+  );
+}
+
+function pressFocusedKey(code: string, key = code) {
+  document.activeElement?.dispatchEvent(
+    new KeyboardEvent("keydown", { bubbles: true, cancelable: true, code, key }),
+  );
+}
+
+async function dragHandleTo(sourceId: string, targetId: string) {
+  const source = document.querySelector<HTMLElement>(
+    `[data-thread-reorder-handle="${sourceId}"]`,
+  );
+  const target = document.querySelector<HTMLElement>(
+    `[data-thread-reorder-handle="${targetId}"]`,
+  );
+  if (!source || !target) throw new Error("Expected sortable handles to be rendered");
+  const sourceRect = source.getBoundingClientRect();
+  const targetRect = target.getBoundingClientRect();
+  const init = {
+    bubbles: true,
+    cancelable: true,
+    pointerId: 1,
+    pointerType: "mouse",
+    isPrimary: true,
+    button: 0,
+    buttons: 1,
+  } as const;
+  source.dispatchEvent(
+    new PointerEvent("pointerdown", {
+      ...init,
+      clientX: sourceRect.left + sourceRect.width / 2,
+      clientY: sourceRect.top + sourceRect.height / 2,
+    }),
+  );
+  document.dispatchEvent(
+    new PointerEvent("pointermove", {
+      ...init,
+      clientX: sourceRect.left + sourceRect.width / 2,
+      clientY: sourceRect.top + sourceRect.height / 2 + 8,
+    }),
+  );
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  document.dispatchEvent(
+    new PointerEvent("pointermove", {
+      ...init,
+      clientX: targetRect.left + targetRect.width / 2,
+      clientY: targetRect.top + targetRect.height / 2,
+    }),
+  );
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  document.dispatchEvent(
+    new PointerEvent("pointerup", {
+      ...init,
+      buttons: 0,
+      clientX: targetRect.left + targetRect.width / 2,
+      clientY: targetRect.top + targetRect.height / 2,
+    }),
+  );
+}
+
+describe("SidebarSortableThreadList", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("reorders a conversation using the keyboard", async () => {
+    await render(<SortableHarness />);
+    const handle = page.getByRole("button", { name: "Reorder Alpha" });
+    await userEvent.click(handle);
+    await expect.element(handle).toHaveFocus();
+    pressFocusedKey("Space", " ");
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    expect(document.body.textContent).toContain("Alpha, position 1 of 3 picked up.");
+    pressFocusedKey("ArrowDown");
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    pressFocusedKey("Space", " ");
+    await expect.element(page.getByRole("list", { name: "Conversations" })).toHaveTextContent(
+      "BravoAlphaCharlie",
+    );
+  });
+
+  it("reorders a conversation using the pointer handle", async () => {
+    await render(<SortableHarness />);
+    await dragHandleTo("thread-a", "thread-c");
+    await expect.element(page.getByRole("list", { name: "Conversations" })).toHaveTextContent(
+      "BravoCharlieAlpha",
+    );
+  });
+
+  it("keeps the order when a keyboard drag is cancelled", async () => {
+    await render(<SortableHarness />);
+    await userEvent.click(page.getByRole("button", { name: "Reorder Alpha" }));
+    pressFocusedKey("Space", " ");
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    pressFocusedKey("ArrowDown");
+    pressFocusedKey("Escape");
+    await expect.element(page.getByRole("list", { name: "Conversations" })).toHaveTextContent(
+      "AlphaBravoCharlie",
+    );
+  });
+});

--- a/apps/web/src/components/SidebarSortableThreadList.tsx
+++ b/apps/web/src/components/SidebarSortableThreadList.tsx
@@ -1,0 +1,290 @@
+// FILE: SidebarSortableThreadList.tsx
+// Purpose: Accessible drag-and-drop primitives for manually ordering sidebar conversations.
+// Layer: Sidebar UI primitive
+// Exports: sortable list/item wrappers and the dedicated conversation reorder handle.
+
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragCancelEvent,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { ThreadId } from "@synara/contracts";
+import {
+  createContext,
+  useContext,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type PointerEvent,
+  type ReactNode,
+} from "react";
+
+import { DragHandleIcon } from "~/lib/icons";
+import { cn } from "~/lib/utils";
+import { SIDEBAR_TRAILING_ICON_CLASS } from "./sidebarGlyphs";
+
+export type SidebarSortableThreadRenderProps = Pick<
+  ReturnType<typeof useSortable>,
+  "attributes" | "listeners" | "setActivatorNodeRef" | "setNodeRef"
+> & {
+  style: CSSProperties;
+  sortableClassName: string;
+};
+
+type KeyboardReorderContextValue = {
+  activeId: ThreadId | null;
+  overId: ThreadId | null;
+  handleKeyDown: (threadId: ThreadId, event: KeyboardEvent<HTMLButtonElement>) => boolean;
+};
+
+const KeyboardReorderContext = createContext<KeyboardReorderContextValue | null>(null);
+
+export function SidebarSortableThreadList({
+  items,
+  onMove,
+  onDragStart,
+  onDragFinish,
+  children,
+}: {
+  items: readonly { id: ThreadId; title: string }[];
+  onMove: (input: {
+    activeThreadId: ThreadId;
+    overThreadId: ThreadId;
+  }) => void;
+  onDragStart?: (threadId: ThreadId) => void;
+  onDragFinish?: () => void;
+  children: ReactNode;
+}) {
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
+  const [keyboardPosition, setKeyboardPosition] = useState<{
+    activeId: ThreadId;
+    overId: ThreadId;
+  } | null>(null);
+  const [keyboardAnnouncement, setKeyboardAnnouncement] = useState("");
+  const titleById = new Map(items.map((item) => [item.id, item.title] as const));
+  const positionOf = (id: ThreadId) => items.findIndex((item) => item.id === id) + 1;
+  const describePosition = (id: ThreadId) =>
+    `${titleById.get(id) ?? "Conversation"}, position ${positionOf(id)} of ${items.length}`;
+  const toThreadId = (id: string | number): ThreadId => ThreadId.makeUnsafe(String(id));
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setKeyboardPosition(null);
+    onDragStart?.(toThreadId(event.active.id));
+  };
+  const handleDragCancel = (_event: DragCancelEvent) => {
+    onDragFinish?.();
+  };
+  const handleDragEnd = (event: DragEndEvent) => {
+    onDragFinish?.();
+    if (!event.over || event.active.id === event.over.id) return;
+    onMove({
+      activeThreadId: toThreadId(event.active.id),
+      overThreadId: toThreadId(event.over.id),
+    });
+  };
+  const handleKeyboardReorder = (
+    threadId: ThreadId,
+    event: KeyboardEvent<HTMLButtonElement>,
+  ): boolean => {
+    const isToggleKey = event.key === " " || event.key === "Enter";
+    if (!keyboardPosition) {
+      if (!isToggleKey) return false;
+      event.preventDefault();
+      event.stopPropagation();
+      setKeyboardPosition({ activeId: threadId, overId: threadId });
+      setKeyboardAnnouncement(`${describePosition(threadId)} picked up.`);
+      onDragStart?.(threadId);
+      return true;
+    }
+
+    if (keyboardPosition.activeId !== threadId) return false;
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      setKeyboardAnnouncement(
+        `Moving ${titleById.get(keyboardPosition.activeId) ?? "conversation"} cancelled.`,
+      );
+      setKeyboardPosition(null);
+      onDragFinish?.();
+      return true;
+    }
+    if (isToggleKey) {
+      event.preventDefault();
+      event.stopPropagation();
+      const { activeId, overId } = keyboardPosition;
+      if (activeId !== overId) onMove({ activeThreadId: activeId, overThreadId: overId });
+      setKeyboardAnnouncement(
+        activeId === overId
+          ? `${titleById.get(activeId) ?? "Conversation"} was not moved.`
+          : `${titleById.get(activeId) ?? "Conversation"} moved to position ${positionOf(overId)} of ${items.length}.`,
+      );
+      setKeyboardPosition(null);
+      onDragFinish?.();
+      return true;
+    }
+    if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return false;
+
+    event.preventDefault();
+    event.stopPropagation();
+    const currentIndex = items.findIndex((item) => item.id === keyboardPosition.overId);
+    const direction = event.key === "ArrowUp" ? -1 : 1;
+    const nextIndex = Math.max(0, Math.min(items.length - 1, currentIndex + direction));
+    const nextOverId = items[nextIndex]?.id ?? keyboardPosition.overId;
+    setKeyboardPosition({ ...keyboardPosition, overId: nextOverId });
+    setKeyboardAnnouncement(`Moving to ${describePosition(nextOverId)}.`);
+    return true;
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      modifiers={[restrictToVerticalAxis]}
+      accessibility={{
+        screenReaderInstructions: {
+          draggable:
+            "Press Space to pick up a conversation, use the arrow keys to move it, then press Space to drop or Escape to cancel.",
+        },
+        announcements: {
+          onDragStart: ({ active }) => `${describePosition(toThreadId(active.id))} picked up.`,
+          onDragOver: ({ over }) =>
+            over ? `Moving to ${describePosition(toThreadId(over.id))}.` : "Not over a position.",
+          onDragEnd: ({ active, over }) =>
+            over
+              ? `${titleById.get(toThreadId(active.id)) ?? "Conversation"} moved to position ${positionOf(toThreadId(over.id))} of ${items.length}.`
+              : "Conversation was not moved.",
+          onDragCancel: ({ active }) =>
+            `Moving ${titleById.get(toThreadId(active.id)) ?? "conversation"} cancelled.`,
+        },
+      }}
+      onDragStart={handleDragStart}
+      onDragCancel={handleDragCancel}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext items={items.map((item) => item.id)} strategy={verticalListSortingStrategy}>
+        <KeyboardReorderContext.Provider
+          value={{
+            activeId: keyboardPosition?.activeId ?? null,
+            overId: keyboardPosition?.overId ?? null,
+            handleKeyDown: handleKeyboardReorder,
+          }}
+        >
+          {children}
+          <span className="sr-only" role="status" aria-live="assertive" aria-atomic="true">
+            {keyboardAnnouncement}
+          </span>
+        </KeyboardReorderContext.Provider>
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+export function SidebarSortableThreadItem({
+  threadId,
+  children,
+}: {
+  threadId: ThreadId;
+  children: (props: SidebarSortableThreadRenderProps) => ReactNode;
+}) {
+  const keyboardReorder = useContext(KeyboardReorderContext);
+  const {
+    attributes,
+    listeners,
+    setActivatorNodeRef,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+    isOver,
+  } = useSortable({ id: threadId });
+  const reduceMotion = globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true;
+  return children({
+    attributes,
+    listeners,
+    setActivatorNodeRef,
+    setNodeRef,
+    style: {
+      transform: CSS.Translate.toString(transform),
+      transition: reduceMotion ? undefined : transition,
+    },
+    sortableClassName: cn(
+      isDragging && "z-20 opacity-65",
+      keyboardReorder?.activeId === threadId && "z-20 ring-1 ring-primary/40",
+      (isOver || keyboardReorder?.overId === threadId) &&
+        !isDragging &&
+        "after:pointer-events-none after:absolute after:inset-x-2 after:-top-px after:z-30 after:h-px after:rounded-full after:bg-primary/75",
+    ),
+  });
+}
+
+export function SidebarThreadReorderHandle({
+  threadId,
+  title,
+  manualOrder,
+  sortable,
+  onPointerIntent,
+  onPointerRelease,
+}: {
+  threadId: ThreadId;
+  title: string;
+  manualOrder: boolean;
+  sortable: Pick<
+    SidebarSortableThreadRenderProps,
+    "attributes" | "listeners" | "setActivatorNodeRef"
+  >;
+  onPointerIntent?: () => void;
+  onPointerRelease?: () => void;
+}) {
+  const keyboardReorder = useContext(KeyboardReorderContext);
+  const label = manualOrder ? `Reorder ${title}` : `Set a custom order starting with ${title}`;
+  const pointerDownListener = sortable.listeners?.onPointerDown;
+  const handlePointerDown = (event: PointerEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onPointerIntent?.();
+    pointerDownListener?.(event);
+  };
+  const handlePointerRelease = (event: PointerEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onPointerRelease?.();
+  };
+  return (
+    <button
+      type="button"
+      ref={sortable.setActivatorNodeRef}
+      data-thread-reorder-handle={threadId}
+      aria-label={label}
+      title={manualOrder ? "Drag to reorder" : "Drag to set a custom order"}
+      className="sidebar-icon-button pointer-events-auto relative z-10 inline-flex size-5 shrink-0 touch-none cursor-grab items-center justify-center rounded-sm text-muted-foreground/42 transition-colors hover:text-foreground/89 active:cursor-grabbing focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
+      {...sortable.attributes}
+      {...sortable.listeners}
+      aria-pressed={keyboardReorder?.activeId === threadId ? true : undefined}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerRelease}
+      onPointerCancel={handlePointerRelease}
+      onKeyDown={(event) => {
+        if (keyboardReorder?.handleKeyDown(threadId, event)) return;
+        event.stopPropagation();
+      }}
+      onClick={(event) => event.stopPropagation()}
+      onDoubleClick={(event) => event.stopPropagation()}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+    >
+      <DragHandleIcon className={SIDEBAR_TRAILING_ICON_CLASS} />
+    </button>
+  );
+}

--- a/apps/web/src/components/SidebarSortableThreadList.tsx
+++ b/apps/web/src/components/SidebarSortableThreadList.tsx
@@ -14,11 +14,7 @@ import {
   type DragStartEvent,
 } from "@dnd-kit/core";
 import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
-import {
-  SortableContext,
-  useSortable,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
+import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { ThreadId } from "@synara/contracts";
 import {
@@ -59,10 +55,7 @@ export function SidebarSortableThreadList({
   children,
 }: {
   items: readonly { id: ThreadId; title: string }[];
-  onMove: (input: {
-    activeThreadId: ThreadId;
-    overThreadId: ThreadId;
-  }) => void;
+  onMove: (input: { activeThreadId: ThreadId; overThreadId: ThreadId }) => void;
   onDragStart?: (threadId: ThreadId) => void;
   onDragFinish?: () => void;
   children: ReactNode;

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -53,6 +53,7 @@ import { useAppSettings } from "../../appSettings";
 import { useStore } from "../../store";
 import { createSidebarDisplayThreadsSelector } from "../../storeSelectors";
 import { sortThreadsForSidebar } from "../Sidebar.logic";
+import { useSidebarThreadOrderStore } from "../../sidebarThreadOrderStore";
 import {
   readEditorRailChatTabs,
   storeEditorRailChatTabs,
@@ -175,6 +176,7 @@ function EditorChatHistoryMenu(props: {
   onNavigateToThread: (threadId: ThreadId) => void;
 }) {
   const { settings } = useAppSettings();
+  const manualThreadIds = useSidebarThreadOrderStore((state) => state.orderedThreadIds);
   const selectDisplayThreads = createSidebarDisplayThreadsSelector({
     hideAutomationRunThreads: !settings.showAutomationRunThreads,
   });
@@ -182,6 +184,7 @@ function EditorChatHistoryMenu(props: {
   const historyThreads = sortThreadsForSidebar(
     displayThreads.filter((thread) => thread.projectId === props.projectId),
     settings.sidebarThreadSortOrder,
+    manualThreadIds,
   ).slice(0, EDITOR_CHAT_HISTORY_LIMIT);
 
   return (
@@ -249,6 +252,7 @@ function EditorRailTabs(props: {
   onNavigateToThread: (threadId: ThreadId) => void;
 }) {
   const { settings } = useAppSettings();
+  const manualThreadIds = useSidebarThreadOrderStore((state) => state.orderedThreadIds);
   const [openChatTabs, setOpenChatTabs] = useState<ReadonlyArray<EditorRailChatTab>>(() => {
     const storedTabs = readEditorRailChatTabs(props.projectId);
     return storedTabs.length > 0
@@ -341,6 +345,7 @@ function EditorRailTabs(props: {
   const sortedProjectThreads = sortThreadsForSidebar(
     displayThreads.filter((thread) => thread.projectId === props.projectId),
     settings.sidebarThreadSortOrder,
+    manualThreadIds,
   );
   const sidebarThreadById = new Map(
     sortedProjectThreads.map((thread) => [

--- a/apps/web/src/components/chat/SingleChatSurface.tsx
+++ b/apps/web/src/components/chat/SingleChatSurface.tsx
@@ -83,6 +83,7 @@ import {
   createThreadWorkspaceMetadataSelector,
 } from "../../storeSelectors";
 import { sortThreadsForSidebar } from "../Sidebar.logic";
+import { useSidebarThreadOrderStore } from "../../sidebarThreadOrderStore";
 import { ChatPaneDropOverlay } from "../chat-drop-overlay/ChatPaneDropOverlay";
 import {
   ChatMountLoader,
@@ -249,6 +250,7 @@ export function SingleChatSurface(props: {
   const projects = useStore((store) => store.projects);
   const threadsHydrated = useStore((store) => store.threadsHydrated);
   const { settings: appSettings } = useAppSettings();
+  const manualThreadIds = useSidebarThreadOrderStore((state) => state.orderedThreadIds);
   const { handleNewThread } = useHandleNewThread();
   const queryClient = useQueryClient();
   const lastAppliedRoutePanelSearchKeyRef = useRef<string | null>(null);
@@ -812,6 +814,7 @@ export function SingleChatSurface(props: {
     const latestThread = sortThreadsForSidebar(
       threadSummaries.filter((thread) => thread.projectId === projectId),
       appSettings.sidebarThreadSortOrder,
+      manualThreadIds,
     )[0];
 
     if (latestThread) {

--- a/apps/web/src/components/useSpacesController.ts
+++ b/apps/web/src/components/useSpacesController.ts
@@ -60,6 +60,7 @@ export function useSpacesController(input: {
   projectById: ReadonlyMap<ProjectId, Project>;
   sidebarThreads: readonly SidebarThreadSummary[];
   sidebarThreadSortOrder: SidebarThreadSortOrder;
+  manualThreadIds: readonly ThreadId[];
   routeThreadId: ThreadId | null;
   routeProjectId: ProjectId | null;
   isOnKanban: boolean;
@@ -74,6 +75,7 @@ export function useSpacesController(input: {
     activeRouteProject,
     activeRouteProjectId,
     isOnKanban,
+    manualThreadIds,
     onCloseProjectContextMenu,
     ordinarySpaceProjects,
     projectById,
@@ -209,7 +211,8 @@ export function useSpacesController(input: {
         rememberedThreadId: getLastSpaceThreadId(spaceId),
         rememberedProjectId: getLastSpaceProjectId(spaceId),
         paths: workspacePaths,
-        sortThreads: (threads) => sortThreadsForSidebar(threads, sidebarThreadSortOrder),
+        sortThreads: (threads) =>
+          sortThreadsForSidebar(threads, sidebarThreadSortOrder, manualThreadIds),
       });
 
       if (target.kind === "thread") {
@@ -241,6 +244,7 @@ export function useSpacesController(input: {
       activeSpaceId,
       getLastSpaceProjectId,
       getLastSpaceThreadId,
+      manualThreadIds,
       navigate,
       ordinarySpaceProjects,
       projectById,

--- a/apps/web/src/hooks/useSidebarThreadActions.ts
+++ b/apps/web/src/hooks/useSidebarThreadActions.ts
@@ -50,6 +50,7 @@ import { useThreadSelectionStore } from "../threadSelectionStore";
 import type { Project, SidebarThreadSummary } from "../types";
 
 const ARCHIVE_UNDO_TOAST_DURATION_MS = 8000;
+const EMPTY_MANUAL_THREAD_IDS: readonly ThreadId[] = [];
 /**
  * How long a confirmed settle override may outlive its projection push. Well
  * past normal push latency: the expiry is a last resort against a lost or
@@ -91,6 +92,7 @@ export function useSidebarThreadActions(input: {
   >;
   readonly clearTerminalState: (threadId: ThreadId) => void;
   readonly handleNewChat: (options?: { fresh?: boolean }) => Promise<unknown>;
+  readonly manualThreadIds?: readonly ThreadId[];
   readonly projectById: ReadonlyMap<ProjectId, Project>;
   readonly routeSplitViewId: string | null;
   readonly routeThreadId: ThreadId | null;
@@ -112,6 +114,7 @@ export function useSidebarThreadActions(input: {
     sidebarThreadSummaryById,
     threadsHydrated,
   } = input;
+  const manualThreadIds = input.manualThreadIds ?? EMPTY_MANUAL_THREAD_IDS;
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const removeWorktreeMutation = useMutation(gitRemoveWorktreeMutationOptions({ queryClient }));
@@ -473,6 +476,7 @@ export function useSidebarThreadActions(input: {
             deletedThreadId: threadId,
             deletedThreadIds: opts.deletedThreadIds ?? new Set<ThreadId>(),
             sortOrder: appSettings.sidebarThreadSortOrder,
+            manualThreadIds,
           }),
           deletedPaneInActiveSplit: activeSplitView
             ? resolveSplitViewPaneIdForThread(activeSplitView, threadId)
@@ -531,6 +535,7 @@ export function useSidebarThreadActions(input: {
       clearTemporaryThread,
       clearTerminalState,
       handleNewChat,
+      manualThreadIds,
       navigate,
       removeThreadFromSplitViews,
       removeWorktreeMutation,
@@ -579,6 +584,7 @@ export function useSidebarThreadActions(input: {
             deletedThreadId: threadId,
             deletedThreadIds: new Set<ThreadId>(),
             sortOrder: appSettings.sidebarThreadSortOrder,
+            manualThreadIds,
           });
           if (fallbackThreadId) {
             await navigate({
@@ -596,7 +602,14 @@ export function useSidebarThreadActions(input: {
         pendingThreadIds.delete(threadId);
       });
     },
-    [appSettings.sidebarThreadSortOrder, handleNewChat, routeThreadId, sidebarThreads, navigate],
+    [
+      appSettings.sidebarThreadSortOrder,
+      handleNewChat,
+      manualThreadIds,
+      routeThreadId,
+      sidebarThreads,
+      navigate,
+    ],
   );
 
   const restoreArchivedThreadFromToast = useCallback(

--- a/apps/web/src/pinnedThreadsStore.test.ts
+++ b/apps/web/src/pinnedThreadsStore.test.ts
@@ -27,4 +27,23 @@ describe("usePinnedThreadsStore", () => {
     usePinnedThreadsStore.getState().prunePinnedThreads(["thread-1" as ThreadId]);
     expect(usePinnedThreadsStore.getState().pinnedThreadIds).toEqual(["thread-1"]);
   });
+
+  it("reorders only the pinned ids in the current sidebar surface", () => {
+    usePinnedThreadsStore.setState({
+      pinnedThreadIds: ["studio-1", "thread-1", "thread-2"].map(ThreadId.makeUnsafe),
+    });
+
+    const changed = usePinnedThreadsStore.getState().movePinnedThread({
+      scopeThreadIds: ["thread-1", "thread-2"].map(ThreadId.makeUnsafe),
+      activeThreadId: ThreadId.makeUnsafe("thread-2"),
+      overThreadId: ThreadId.makeUnsafe("thread-1"),
+    });
+
+    expect(changed).toBe(true);
+    expect(usePinnedThreadsStore.getState().pinnedThreadIds).toEqual([
+      "studio-1",
+      "thread-2",
+      "thread-1",
+    ]);
+  });
 });

--- a/apps/web/src/pinnedThreadsStore.test.ts
+++ b/apps/web/src/pinnedThreadsStore.test.ts
@@ -30,11 +30,11 @@ describe("usePinnedThreadsStore", () => {
 
   it("reorders only the pinned ids in the current sidebar surface", () => {
     usePinnedThreadsStore.setState({
-      pinnedThreadIds: ["studio-1", "thread-1", "thread-2"].map(ThreadId.makeUnsafe),
+      pinnedThreadIds: ["studio-1", "thread-1", "thread-2"].map((id) => ThreadId.makeUnsafe(id)),
     });
 
     const changed = usePinnedThreadsStore.getState().movePinnedThread({
-      scopeThreadIds: ["thread-1", "thread-2"].map(ThreadId.makeUnsafe),
+      scopeThreadIds: ["thread-1", "thread-2"].map((id) => ThreadId.makeUnsafe(id)),
       activeThreadId: ThreadId.makeUnsafe("thread-2"),
       overThreadId: ThreadId.makeUnsafe("thread-1"),
     });

--- a/apps/web/src/pinnedThreadsStore.ts
+++ b/apps/web/src/pinnedThreadsStore.ts
@@ -7,12 +7,18 @@ import { type ThreadId } from "@synara/contracts";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import { normalizePinnedIds, pinId, prunePinnedIds, unpinId } from "./pinning.logic";
+import { moveSidebarThreadWithinScope } from "./sidebarThreadOrdering";
 
 interface PinnedThreadsStoreState {
   pinnedThreadIds: ThreadId[];
   pinThread: (threadId: ThreadId) => void;
   unpinThread: (threadId: ThreadId) => void;
   togglePinnedThread: (threadId: ThreadId) => void;
+  movePinnedThread: (input: {
+    scopeThreadIds: readonly ThreadId[];
+    activeThreadId: ThreadId;
+    overThreadId: ThreadId;
+  }) => boolean;
   prunePinnedThreads: (threadIds: readonly ThreadId[]) => void;
 }
 
@@ -54,6 +60,20 @@ export const usePinnedThreadsStore = create<PinnedThreadsStoreState>()(
           }
           return { pinnedThreadIds: pinId(state.pinnedThreadIds, threadId).pinnedIds };
         });
+      },
+      movePinnedThread: (input) => {
+        let changed = false;
+        set((state) => {
+          const result = moveSidebarThreadWithinScope({
+            orderedIds: state.pinnedThreadIds,
+            scopeIds: input.scopeThreadIds,
+            activeId: input.activeThreadId,
+            overId: input.overThreadId,
+          });
+          changed = result.changed;
+          return result.changed ? { pinnedThreadIds: result.orderedIds } : state;
+        });
+        return changed;
       },
       prunePinnedThreads: (threadIds) => {
         set((state) => {

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -172,6 +172,7 @@ const SIDEBAR_PROJECT_SORT_ORDER_LABELS = {
 const SIDEBAR_THREAD_SORT_ORDER_LABELS = {
   updated_at: "Recently active",
   created_at: "Newest first",
+  manual: "Manual order",
 } as const;
 
 const FOLLOW_UP_BEHAVIOR_OPTIONS = [
@@ -582,7 +583,7 @@ function SettingsRouteView() {
 
         <SettingsRow
           title="Thread order"
-          description="Controls how threads are arranged inside each project in the main sidebar."
+          description="Controls how conversations are arranged in Projects, Chats, and Studio. Dragging a conversation switches this to Manual."
           resetAction={
             settings.sidebarThreadSortOrder !== defaults.sidebarThreadSortOrder ? (
               <SettingResetButton
@@ -599,7 +600,7 @@ function SettingsRouteView() {
             <SettingsSelectControl
               value={settings.sidebarThreadSortOrder}
               onValueChange={(value) => {
-                if (value !== "updated_at" && value !== "created_at") {
+                if (value !== "updated_at" && value !== "created_at" && value !== "manual") {
                   return;
                 }
                 updateSettings({ sidebarThreadSortOrder: value });
@@ -612,6 +613,9 @@ function SettingsRouteView() {
               </SelectItem>
               <SelectItem hideIndicator value="created_at">
                 {SIDEBAR_THREAD_SORT_ORDER_LABELS.created_at}
+              </SelectItem>
+              <SelectItem hideIndicator value="manual">
+                {SIDEBAR_THREAD_SORT_ORDER_LABELS.manual}
               </SelectItem>
             </SettingsSelectControl>
           }

--- a/apps/web/src/routes/_chat.studio.index.tsx
+++ b/apps/web/src/routes/_chat.studio.index.tsx
@@ -25,6 +25,7 @@ import { useHandleNewStudioChat } from "../hooks/useHandleNewStudioChat";
 import { collectStudioProjectIds, findStudioDraftThreadId } from "../lib/studioProjects";
 import { EMPTY_THREAD_IDS, useStore } from "../store";
 import { useWorkspacePathsStore } from "../workspacePathsStore";
+import { useSidebarThreadOrderStore } from "../sidebarThreadOrderStore";
 
 // How long the splash below waits for the welcome's Studio root before surfacing an error —
 // generous next to a normal welcome round-trip, mirroring the home route's eventual error+retry.
@@ -32,6 +33,7 @@ const WORKSPACE_PATHS_TIMEOUT_MS = 10_000;
 
 function StudioIndexRouteView() {
   const { settings: appSettings } = useAppSettings();
+  const manualThreadIds = useSidebarThreadOrderStore((state) => state.orderedThreadIds);
   const { handleNewStudioChat } = useHandleNewStudioChat();
   const threadIds = useStore((state) => state.threadIds ?? EMPTY_THREAD_IDS);
   const projects = useStore((state) => state.projects);
@@ -72,7 +74,11 @@ function StudioIndexRouteView() {
   // The most recent Studio chat (if any), used to restore the surface instead of always opening
   // a brand-new draft.
   const latestStudioThreadId =
-    sortThreadsForSidebar(studioThreadSummaries, appSettings.sidebarThreadSortOrder)[0]?.id ?? null;
+    sortThreadsForSidebar(
+      studioThreadSummaries,
+      appSettings.sidebarThreadSortOrder,
+      manualThreadIds,
+    )[0]?.id ?? null;
 
   // Same landing policy as the Studio segment switch and settings back: remembered route first
   // (scoped to Studio threads plus the stored draft), then the stored draft, then the latest

--- a/apps/web/src/sidebarThreadOrderStore.test.ts
+++ b/apps/web/src/sidebarThreadOrderStore.test.ts
@@ -1,0 +1,36 @@
+// FILE: sidebarThreadOrderStore.test.ts
+// Purpose: Verifies the persisted manual sidebar thread-order store.
+// Layer: UI state store test
+
+import { ThreadId } from "@synara/contracts";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useSidebarThreadOrderStore } from "./sidebarThreadOrderStore";
+
+describe("useSidebarThreadOrderStore", () => {
+  beforeEach(() => {
+    useSidebarThreadOrderStore.setState({ orderedThreadIds: [] });
+  });
+
+  it("snapshots a scope and moves a thread", () => {
+    const changed = useSidebarThreadOrderStore.getState().moveThread({
+      scopeThreadIds: ["thread-1", "thread-2", "thread-3"].map(ThreadId.makeUnsafe),
+      activeThreadId: ThreadId.makeUnsafe("thread-3"),
+      overThreadId: ThreadId.makeUnsafe("thread-1"),
+    });
+
+    expect(changed).toBe(true);
+    expect(useSidebarThreadOrderStore.getState().orderedThreadIds).toEqual([
+      "thread-3",
+      "thread-1",
+      "thread-2",
+    ]);
+  });
+
+  it("prunes threads that no longer exist", () => {
+    useSidebarThreadOrderStore.setState({
+      orderedThreadIds: ["thread-2", "thread-1"].map(ThreadId.makeUnsafe),
+    });
+    useSidebarThreadOrderStore.getState().pruneThreads([ThreadId.makeUnsafe("thread-1")]);
+    expect(useSidebarThreadOrderStore.getState().orderedThreadIds).toEqual(["thread-1"]);
+  });
+});

--- a/apps/web/src/sidebarThreadOrderStore.test.ts
+++ b/apps/web/src/sidebarThreadOrderStore.test.ts
@@ -13,7 +13,7 @@ describe("useSidebarThreadOrderStore", () => {
 
   it("snapshots a scope and moves a thread", () => {
     const changed = useSidebarThreadOrderStore.getState().moveThread({
-      scopeThreadIds: ["thread-1", "thread-2", "thread-3"].map(ThreadId.makeUnsafe),
+      scopeThreadIds: ["thread-1", "thread-2", "thread-3"].map((id) => ThreadId.makeUnsafe(id)),
       activeThreadId: ThreadId.makeUnsafe("thread-3"),
       overThreadId: ThreadId.makeUnsafe("thread-1"),
     });
@@ -28,7 +28,7 @@ describe("useSidebarThreadOrderStore", () => {
 
   it("prunes threads that no longer exist", () => {
     useSidebarThreadOrderStore.setState({
-      orderedThreadIds: ["thread-2", "thread-1"].map(ThreadId.makeUnsafe),
+      orderedThreadIds: ["thread-2", "thread-1"].map((id) => ThreadId.makeUnsafe(id)),
     });
     useSidebarThreadOrderStore.getState().pruneThreads([ThreadId.makeUnsafe("thread-1")]);
     expect(useSidebarThreadOrderStore.getState().orderedThreadIds).toEqual(["thread-1"]);

--- a/apps/web/src/sidebarThreadOrderStore.ts
+++ b/apps/web/src/sidebarThreadOrderStore.ts
@@ -1,0 +1,74 @@
+// FILE: sidebarThreadOrderStore.ts
+// Purpose: Persists the user's manual conversation order across sidebar surfaces.
+// Layer: UI state store
+// Exports: useSidebarThreadOrderStore
+
+import { type ThreadId } from "@synara/contracts";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import {
+  moveSidebarThreadWithinScope,
+  normalizeSidebarThreadOrder,
+  pruneSidebarThreadOrder,
+} from "./sidebarThreadOrdering";
+
+interface SidebarThreadOrderStoreState {
+  orderedThreadIds: ThreadId[];
+  moveThread: (input: {
+    scopeThreadIds: readonly ThreadId[];
+    activeThreadId: ThreadId;
+    overThreadId: ThreadId;
+  }) => boolean;
+  pruneThreads: (threadIds: readonly ThreadId[]) => void;
+}
+
+const SIDEBAR_THREAD_ORDER_STORAGE_KEY = "synara:sidebar-thread-order:v1";
+
+export const useSidebarThreadOrderStore = create<SidebarThreadOrderStoreState>()(
+  persist(
+    (set) => ({
+      orderedThreadIds: [],
+      moveThread: (input) => {
+        let changed = false;
+        set((state) => {
+          const result = moveSidebarThreadWithinScope({
+            orderedIds: state.orderedThreadIds,
+            scopeIds: input.scopeThreadIds,
+            activeId: input.activeThreadId,
+            overId: input.overThreadId,
+          });
+          changed = result.changed;
+          return result.changed ? { orderedThreadIds: result.orderedIds } : state;
+        });
+        return changed;
+      },
+      pruneThreads: (threadIds) => {
+        set((state) => {
+          const nextOrderedThreadIds = pruneSidebarThreadOrder(state.orderedThreadIds, threadIds);
+          return nextOrderedThreadIds.length === state.orderedThreadIds.length
+            ? state
+            : { orderedThreadIds: nextOrderedThreadIds };
+        });
+      },
+    }),
+    {
+      name: SIDEBAR_THREAD_ORDER_STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        orderedThreadIds: normalizeSidebarThreadOrder(state.orderedThreadIds),
+      }),
+      merge: (persistedState, currentState) => {
+        const candidate =
+          (
+            persistedState as
+              | Partial<Pick<SidebarThreadOrderStoreState, "orderedThreadIds">>
+              | undefined
+          )?.orderedThreadIds ?? [];
+        return {
+          ...currentState,
+          orderedThreadIds: normalizeSidebarThreadOrder(candidate),
+        };
+      },
+    },
+  ),
+);

--- a/apps/web/src/sidebarThreadOrdering.test.ts
+++ b/apps/web/src/sidebarThreadOrdering.test.ts
@@ -1,0 +1,70 @@
+// FILE: sidebarThreadOrdering.test.ts
+// Purpose: Verifies immutable manual sidebar thread-order behavior.
+// Layer: UI state logic test
+
+import { describe, expect, it } from "vitest";
+import {
+  compareSidebarThreadsByManualOrder,
+  moveSidebarThreadWithinScope,
+  normalizeSidebarThreadOrder,
+  pruneSidebarThreadOrder,
+} from "./sidebarThreadOrdering";
+
+describe("sidebar thread ordering", () => {
+  it("normalizes duplicate and empty ids", () => {
+    expect(normalizeSidebarThreadOrder(["a", "", "b", "a"])).toEqual(["a", "b"]);
+  });
+
+  it("moves a thread inside its complete scope and preserves other scopes", () => {
+    expect(
+      moveSidebarThreadWithinScope({
+        orderedIds: ["elsewhere-1", "scope-1", "scope-2", "elsewhere-2"],
+        scopeIds: ["scope-1", "scope-2", "scope-3"],
+        activeId: "scope-3",
+        overId: "scope-1",
+      }),
+    ).toEqual({
+      orderedIds: ["elsewhere-1", "elsewhere-2", "scope-3", "scope-1", "scope-2"],
+      changed: true,
+    });
+  });
+
+  it("does not move across scopes or for a cancelled same-position drop", () => {
+    const input = { orderedIds: ["a", "b"], scopeIds: ["a", "b"] } as const;
+    expect(moveSidebarThreadWithinScope({ ...input, activeId: "a", overId: "outside" })).toEqual({
+      orderedIds: ["a", "b"],
+      changed: false,
+    });
+    expect(moveSidebarThreadWithinScope({ ...input, activeId: "a", overId: "a" })).toEqual({
+      orderedIds: ["a", "b"],
+      changed: false,
+    });
+  });
+
+  it("prunes deleted ids while retaining manual order", () => {
+    expect(pruneSidebarThreadOrder(["c", "a", "b"], ["a", "c"])).toEqual(["c", "a"]);
+  });
+
+  it("keeps new ids above ranked ids while preserving fallback order", () => {
+    const rankById = new Map([
+      ["ranked-a", 0],
+      ["ranked-b", 1],
+    ]);
+    const ids = ["ranked-b", "new-older", "ranked-a", "new-newer"];
+    const fallbackRanks = new Map([
+      ["new-newer", 0],
+      ["new-older", 1],
+    ]);
+    expect(
+      ids.toSorted((leftId, rightId) =>
+        compareSidebarThreadsByManualOrder({
+          leftId,
+          rightId,
+          rankById,
+          compareFallback: () =>
+            (fallbackRanks.get(leftId) ?? 0) - (fallbackRanks.get(rightId) ?? 0),
+        }),
+      ),
+    ).toEqual(["new-newer", "new-older", "ranked-a", "ranked-b"]);
+  });
+});

--- a/apps/web/src/sidebarThreadOrdering.ts
+++ b/apps/web/src/sidebarThreadOrdering.ts
@@ -1,0 +1,78 @@
+// FILE: sidebarThreadOrdering.ts
+// Purpose: Normalizes, applies, and mutates the persisted manual sidebar thread order.
+// Layer: UI state logic
+// Exports: immutable helpers shared by the ordering store, pinned store, and sidebar sorting.
+
+export type ScopedOrderMoveResult<TId extends string> = {
+  orderedIds: TId[];
+  changed: boolean;
+};
+
+export function normalizeSidebarThreadOrder<TId extends string>(ids: readonly TId[]): TId[] {
+  const seen = new Set<TId>();
+  const normalized: TId[] = [];
+  for (const id of ids) {
+    if (id.length === 0 || seen.has(id)) continue;
+    seen.add(id);
+    normalized.push(id);
+  }
+  return normalized;
+}
+
+/**
+ * Reorders one visible container without disturbing persisted ids from other
+ * projects/surfaces. `scopeIds` must be the complete current order for that
+ * container, including rows hidden behind pagination.
+ */
+export function moveSidebarThreadWithinScope<TId extends string>(input: {
+  readonly orderedIds: readonly TId[];
+  readonly scopeIds: readonly TId[];
+  readonly activeId: TId;
+  readonly overId: TId;
+}): ScopedOrderMoveResult<TId> {
+  const orderedIds = normalizeSidebarThreadOrder(input.orderedIds);
+  const scopeIds = normalizeSidebarThreadOrder(input.scopeIds);
+  const activeIndex = scopeIds.indexOf(input.activeId);
+  const overIndex = scopeIds.indexOf(input.overId);
+  if (activeIndex < 0 || overIndex < 0 || activeIndex === overIndex) {
+    return { orderedIds, changed: orderedIds.length !== input.orderedIds.length };
+  }
+
+  const movedScopeIds = [...scopeIds];
+  const [activeId] = movedScopeIds.splice(activeIndex, 1);
+  if (!activeId) {
+    return { orderedIds, changed: false };
+  }
+  movedScopeIds.splice(overIndex, 0, activeId);
+
+  const scopeIdSet = new Set(scopeIds);
+  const outsideScopeIds = orderedIds.filter((id) => !scopeIdSet.has(id));
+  return {
+    orderedIds: [...outsideScopeIds, ...movedScopeIds],
+    changed: true,
+  };
+}
+
+export function pruneSidebarThreadOrder<TId extends string>(
+  orderedIds: readonly TId[],
+  allowedIds: readonly TId[],
+): TId[] {
+  const allowedIdSet = new Set(allowedIds);
+  return normalizeSidebarThreadOrder(orderedIds).filter((id) => allowedIdSet.has(id));
+}
+
+/** Known ids follow the manual rank. New/unranked ids stay discoverable at the
+ * top and retain the caller's automatic fallback order among themselves. */
+export function compareSidebarThreadsByManualOrder<TId extends string>(input: {
+  readonly leftId: TId;
+  readonly rightId: TId;
+  readonly rankById: ReadonlyMap<TId, number>;
+  readonly compareFallback: () => number;
+}): number {
+  const leftRank = input.rankById.get(input.leftId);
+  const rightRank = input.rankById.get(input.rightId);
+  if (leftRank === undefined && rightRank === undefined) return input.compareFallback();
+  if (leftRank === undefined) return -1;
+  if (rightRank === undefined) return 1;
+  return leftRank - rightRank;
+}


### PR DESCRIPTION
## Summary
- add persistent manual conversation ordering to Projects, Chats, Studio, and Pinned lists
- provide polished pointer and keyboard reordering with clear drag feedback and reduced-motion support
- switch thread sorting to Manual after the first successful reorder while preserving existing automatic sort options
- keep subagent rows attached to their parent and preserve existing split-view dragging

## Verification
- 4,428 unit tests passed with 3 pre-existing skips (full suite excluding two import-heavy files with fixed short timeouts)
- the two excluded import-heavy files and React Compiler coverage passed separately: 80 tests
- sortable component browser tests passed: 3 tests
- full ChatView browser integration for sidebar reorder passed
- production web build passed
- Impeccable UI detector reported no findings