### PR TITLE
fix(images): keep inspected images out of generated outputs

### DIFF
--- a/apps/server/src/codexGeneratedImages.ts
+++ b/apps/server/src/codexGeneratedImages.ts
@@ -25,7 +25,6 @@ const CODEX_GENERATED_IMAGE_ITEM_TYPES = new Set([
   "imagegeneration",
   "imagegenerationcall",
   "imagegenerationend",
-  "imageview",
 ]);
 
 const IMAGE_PATH_KEYS = ["saved_path", "savedPath", "path", "file_path"] as const;

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -817,7 +817,10 @@ export const localImageEffectRouteLayer = HttpRouter.add(
       }).catch(() => null),
     );
     if (!previewFile) {
-      return HttpServerResponse.text("Not Found", { status: 404 });
+      return HttpServerResponse.text("Not Found", {
+        status: 404,
+        headers: localPreviewCorsHeaders({ config, request, url }),
+      });
     }
 
     // Stream (don't use HttpServerResponse.file, which depends on

--- a/apps/server/src/localImageRoute.test.ts
+++ b/apps/server/src/localImageRoute.test.ts
@@ -274,6 +274,24 @@ describe("localImageEffectRouteLayer", () => {
     });
   });
 
+  it("exposes missing-file errors to desktop downloads without allowing untrusted origins", async () => {
+    const workspace = makeTempDir("synara-effect-missing-image-");
+    const config = makeServerConfig({ cwd: workspace });
+    await withEffectServer(config, localImageEffectRouteLayer, async (origin) => {
+      const params = new URLSearchParams({ path: "missing.png", cwd: workspace, download: "1" });
+      for (const requestOrigin of ["synara://app", "https://example.test"]) {
+        const response = await fetch(`${origin}/api/local-image?${params}`, {
+          headers: { Origin: requestOrigin },
+        });
+        expect(response.status).toBe(404);
+        expect(await response.text()).toBe("Not Found");
+        expect(response.headers.get("access-control-allow-origin")).toBe(
+          requestOrigin === "synara://app" ? requestOrigin : null,
+        );
+      }
+    });
+  });
+
   it("returns 404 when the requested path has an unsupported extension", async () => {
     const workspace = makeTempDir("synara-effect-image-bad-ext-");
     writeFileSync(path.join(workspace, ".git"), "gitdir: .git");

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -771,6 +771,40 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
     }),
   );
 
+  it.effect("keeps inspected images out of generated output artifacts", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+      const payload = {
+        item: {
+          type: "imageView",
+          id: "view_1",
+          path: "/attachments/objects/upload.png",
+        },
+      };
+      lifecycleManager.emit("event", {
+        id: asEventId("evt-image-view"),
+        kind: "notification",
+        provider: "codex",
+        createdAt: new Date().toISOString(),
+        method: "item/completed",
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-1"),
+        itemId: asItemId("view_1"),
+        payload,
+      } satisfies ProviderEvent);
+
+      const firstEvent = yield* Fiber.join(firstEventFiber);
+      assert.equal(firstEvent._tag, "Some");
+      if (firstEvent._tag !== "Some") return;
+      assert.equal(firstEvent.value.type, "item.completed");
+      if (firstEvent.value.type !== "item.completed") return;
+      assert.equal(firstEvent.value.payload.itemType, "image_view");
+      assert.equal(firstEvent.value.payload.title, "Image view");
+      assert.deepStrictEqual(firstEvent.value.payload.data, payload);
+    }),
+  );
+
   it.effect("maps completed generated-image items to structured image artifacts", () =>
     Effect.gen(function* () {
       const adapter = yield* CodexAdapter;


### PR DESCRIPTION
Codex image inspection events were treated as generated outputs. This added broken image cards to assistant replies when the inspected files were attachments or outside the workspace. Keep these events as image views; actual image generation retains its existing handling.

Return trusted-origin CORS headers on local-preview 404 responses so desktop downloads can read the error instead of failing with a CORS error.

Validation: 55 focused tests passed; the full workspace test run passed (8 tasks). Fmt, lint, and typecheck were not run. Existing saved messages are not rewritten, and automatic output copying remains limited to Studio workspaces.
