### PR TITLE
Keep branch PR status visible after merge or close

### DIFF
--- a/apps/web/src/components/chat/environment/EnvironmentPullRequestSection.browser.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentPullRequestSection.browser.tsx
@@ -11,18 +11,31 @@ import {
   type GitPullRequestSnapshotResult,
   type GitResolvedPullRequest,
   type GitStatusResult,
+  type NativeApi,
 } from "@synara/contracts";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { page } from "vitest/browser";
-import { render } from "vitest-browser-react";
+import { cleanup, render } from "vitest-browser-react";
 
 import { useComposerDraftStore } from "~/composerDraftStore";
 import { gitPullRequestSnapshotQueryOptions, gitQueryKeys } from "~/lib/gitReactQuery";
 import { EnvironmentPullRequestSection } from "./EnvironmentPullRequestSection";
 
+const { getGitStatus, getPullRequestSnapshot } = vi.hoisted(() => ({
+  getGitStatus: vi.fn<NativeApi["git"]["status"]>(),
+  getPullRequestSnapshot: vi.fn<NativeApi["git"]["pullRequestSnapshot"]>(),
+}));
+
+vi.mock("~/nativeApi", () => ({
+  ensureNativeApi: () => ({
+    git: { status: getGitStatus, pullRequestSnapshot: getPullRequestSnapshot },
+  }),
+}));
+
 const cwd = "/repo";
 const threadId = ThreadId.makeUnsafe("thread-pr-fix-actions");
+const queryClients = new Set<QueryClient>();
 const pullRequest = {
   number: 321,
   title: "Keep PR context visible",
@@ -40,6 +53,7 @@ const pullRequest = {
 // Seeds both cached queries so the component renders without calling the native API.
 function createQueryClient(commentsOverride?: GitPullRequestSnapshotResult["comments"]) {
   const queryClient = new QueryClient();
+  queryClients.add(queryClient);
   const gitStatus = {
     branch: pullRequest.headBranch,
     hasWorkingTreeChanges: false,
@@ -90,12 +104,12 @@ function createQueryClient(commentsOverride?: GitPullRequestSnapshotResult["comm
   return queryClient;
 }
 
-function renderSection(queryClient: QueryClient, onClose = vi.fn()) {
-  return render(
+function section(queryClient: QueryClient, onClose = vi.fn(), enabled = true) {
+  return (
     <QueryClientProvider client={queryClient}>
       <EnvironmentPullRequestSection
         gitCwd={cwd}
-        enabled
+        enabled={enabled}
         activeThreadId={threadId}
         // No project: Merge/Status stay hidden and View PR falls back to the URL handler.
         projectId={null}
@@ -103,8 +117,12 @@ function renderSection(queryClient: QueryClient, onClose = vi.fn()) {
         onOpenUrl={vi.fn()}
         onClose={onClose}
       />
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
+}
+
+function renderSection(queryClient: QueryClient, onClose = vi.fn()) {
+  return render(section(queryClient, onClose));
 }
 
 async function openRepairSubmenu() {
@@ -119,9 +137,82 @@ function draftCards() {
 }
 
 describe("EnvironmentPullRequestSection", () => {
-  afterEach(() => {
+  afterEach(async () => {
+    await cleanup();
+    for (const queryClient of queryClients) {
+      queryClient.clear();
+    }
+    queryClients.clear();
+    vi.resetAllMocks();
     useComposerDraftStore.getState().clearDraftThread(threadId);
-    document.body.innerHTML = "";
+  });
+
+  it("refreshes an old missing PR when the mounted panel opens", async () => {
+    const queryClient = createQueryClient();
+    const status = queryClient.getQueryData<GitStatusResult>(gitQueryKeys.status(cwd))!;
+    getGitStatus.mockResolvedValue(status);
+    const view = await render(section(queryClient, vi.fn(), false));
+    queryClient.setQueryData(
+      gitQueryKeys.status(cwd),
+      { ...status, pr: null },
+      { updatedAt: Date.now() - 60_000 },
+    );
+    await expect
+      .element(page.getByText("#321 Keep PR context visible", { exact: true }))
+      .not.toBeInTheDocument();
+
+    await view.rerender(section(queryClient));
+
+    await expect
+      .element(page.getByText("#321 Keep PR context visible", { exact: true }))
+      .toBeVisible();
+    expect(getGitStatus).toHaveBeenCalledExactlyOnceWith({ cwd });
+  });
+
+  it.each(["merged", "closed"] as const)(
+    "shows a branch's %s PR on first open without loading active PR details",
+    async (state) => {
+      const queryClient = createQueryClient();
+      queryClient.setQueryData<GitStatusResult>(gitQueryKeys.status(cwd), (status) =>
+        status ? { ...status, pr: { ...pullRequest, state } } : status,
+      );
+      queryClient.removeQueries({ queryKey: gitQueryKeys.pullRequest(cwd) });
+      await renderSection(queryClient);
+
+      const stateLabel = state === "merged" ? "Merged" : "Closed";
+      const prRow = page.getByRole("button", { name: `#321 Keep PR context visible ${stateLabel}` });
+      await expect.element(prRow).toBeVisible();
+      await expect.element(page.getByText(`${stateLabel} on GitHub`, { exact: true })).toBeVisible();
+      expect(queryClient.isFetching()).toBe(0);
+      expect(getPullRequestSnapshot).not.toHaveBeenCalled();
+
+      await prRow.click();
+      await expect.element(page.getByText("View PR", { exact: true })).toBeVisible();
+      await expect.element(page.getByText("Code changes", { exact: true })).toBeVisible();
+      await expect.element(page.getByText("Add to chat", { exact: true })).toBeVisible();
+      await expect.element(page.getByText("Open in GitHub", { exact: true })).toBeVisible();
+      await expect.element(page.getByText("Repair", { exact: true })).not.toBeInTheDocument();
+      await expect.element(page.getByText("Merge", { exact: true })).not.toBeInTheDocument();
+    },
+  );
+
+  it("keeps the PR visible when git status settles after an open snapshot was cached", async () => {
+    const queryClient = createQueryClient();
+    await renderSection(queryClient);
+    await expect
+      .element(page.getByText("#321 Keep PR context visible", { exact: true }))
+      .toBeVisible();
+
+    queryClient.setQueryData<GitStatusResult>(gitQueryKeys.status(cwd), (status) =>
+      status ? { ...status, pr: { ...pullRequest, state: "merged" } } : status,
+    );
+
+    await expect
+      .element(page.getByText("#321 Keep PR context visible", { exact: true }))
+      .toBeVisible();
+    await expect.element(page.getByText("Merged on GitHub", { exact: true })).toBeVisible();
+    await page.getByText("#321 Keep PR context visible", { exact: true }).click();
+    await expect.element(page.getByText("Repair", { exact: true })).not.toBeInTheDocument();
   });
 
   it("attaches one Repair card per scope instead of pasting prompt text", async () => {

--- a/apps/web/src/components/chat/environment/EnvironmentPullRequestSection.browser.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentPullRequestSection.browser.tsx
@@ -180,9 +180,13 @@ describe("EnvironmentPullRequestSection", () => {
       await renderSection(queryClient);
 
       const stateLabel = state === "merged" ? "Merged" : "Closed";
-      const prRow = page.getByRole("button", { name: `#321 Keep PR context visible ${stateLabel}` });
+      const prRow = page.getByRole("button", {
+        name: `#321 Keep PR context visible ${stateLabel}`,
+      });
       await expect.element(prRow).toBeVisible();
-      await expect.element(page.getByText(`${stateLabel} on GitHub`, { exact: true })).toBeVisible();
+      await expect
+        .element(page.getByText(`${stateLabel} on GitHub`, { exact: true }))
+        .toBeVisible();
       expect(queryClient.isFetching()).toBe(0);
       expect(getPullRequestSnapshot).not.toHaveBeenCalled();
 

--- a/apps/web/src/components/chat/environment/EnvironmentPullRequestSection.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentPullRequestSection.tsx
@@ -304,8 +304,9 @@ export function EnvironmentPullRequestSection({
   const queryClient = useQueryClient();
   const [menuOpen, setMenuOpen] = useState(false);
   const [confirmMerge, setConfirmMerge] = useState<PullRequestMergeMethod | null>(null);
-  // Shares the cached git status the git block already fetches — no extra RPC.
-  const { data: gitStatus } = useQuery(gitStatusQueryOptions(gitCwd));
+  // Share the git block's cache, but revalidate stale status when this always-mounted
+  // panel opens so an earlier missing PR does not linger until the next polling tick.
+  const { data: gitStatus } = useQuery(gitStatusQueryOptions(gitCwd, enabled));
   const pr = gitStatus?.pr ?? null;
 
   const snapshotQuery = useQuery(
@@ -316,11 +317,10 @@ export function EnvironmentPullRequestSection({
     }),
   );
 
-  // The snapshot's own PR summary is fresher than the cached git status: prefer its
-  // title/number/url for display, and when it reports the PR merged/closed between
-  // git-status polls, show a state row instead of rendering stale "open" data.
+  // The snapshot can report a merge/close before git status catches up. Once git status
+  // also settles, prefer it over a cached open snapshot whose polling is now disabled.
   const livePr = snapshotQuery.data?.pullRequest ?? null;
-  const displayPr = livePr ?? pr;
+  const displayPr = pr?.state === "open" ? (livePr ?? pr) : pr;
 
   const pullRequestRepository = displayPr
     ? parseGitHubRepositoryNameWithOwnerFromPullRequestUrl(displayPr.url)
@@ -342,7 +342,7 @@ export function EnvironmentPullRequestSection({
   });
   const actionMutation = useMutation(pullRequestActionMutationOptions(queryClient));
 
-  if (!pr || pr.state !== "open" || !displayPr) {
+  if (!displayPr) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- Revalidate stale git status when the environment PR panel opens.
- Keep merged and closed branch PRs visible with appropriate read-only actions.
- Prefer settled git status over cached open PR snapshots.

## Testing
- Added Vitest browser UI coverage for stale refresh, merged/closed PR display, and status transitions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Environment panel PR display and query gating only; behavior is covered by new Vitest browser tests with no auth or data-persistence changes.
> 
> **Overview**
> Updates the Environment panel **Pull request** row so branch PR context does not disappear or show stale “open” state after merge/close.
> 
> **`EnvironmentPullRequestSection`** now passes the panel’s `enabled` flag into `gitStatusQueryOptions`, so opening the panel can refetch stale git status (e.g. when cached status still has `pr: null`). Rendering no longer requires an open PR: merged/closed PRs from git status stay visible with read-only UI (no Repair/Merge; “Merged/Closed on GitHub”). Display logic prefers **settled** git status over a cached open snapshot once `pr.state` is not `open`, while still using the live snapshot for open PRs.
> 
> **Browser tests** mock `~/nativeApi`, add cleanup/query-client teardown, and cover stale refresh on enable, first paint for merged/closed without `pullRequestSnapshot`, and visibility when status transitions from open to merged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0789219200b864561cd8eaf89e20fc85627e8dee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->