### PR TITLE
Map Claude overage telemetry to the Fable weekly sublimit

### DIFF
--- a/apps/web/src/components/RateLimitsPanel.test.tsx
+++ b/apps/web/src/components/RateLimitsPanel.test.tsx
@@ -229,7 +229,7 @@ describe("RateLimitsPanel helpers", () => {
     ]);
   });
 
-  it("humanizes the claude seven_day_overage_included window instead of leaking the raw key", () => {
+  it("maps Claude's overage-included weekly telemetry to the Fable sublimit", () => {
     const rateLimits = deriveAccountRateLimits([
       {
         activities: [
@@ -250,11 +250,55 @@ describe("RateLimitsPanel helpers", () => {
 
     expect(rows).toEqual([
       {
-        id: "claudeAgent-Weekly (overage)",
-        label: "Weekly (overage)",
+        id: "claudeAgent-Fable",
+        label: "Fable",
         remainingPercent: 22,
         resetsAt: "2099-04-04T08:03:00.000Z",
+        windowDurationMins: 10080,
       },
+    ]);
+  });
+
+  it("keeps paid usage credits separate from Fable's included weekly allowance", () => {
+    const rateLimits = deriveAccountRateLimits([
+      {
+        activities: [
+          makeActivity("credits", "account.rate-limits.updated", {
+            provider: "claudeAgent",
+            rate_limit_info: {
+              status: "allowed_warning",
+              rateLimitType: "overage",
+              utilization: 0.8,
+            },
+          }),
+        ],
+      },
+    ]);
+
+    expect(deriveVisibleRateLimitRows(rateLimits)).toEqual([
+      { id: "claudeAgent-Usage credits", label: "Usage credits", remainingPercent: 20 },
+    ]);
+  });
+
+  it("preserves model-specific weekly windows with the same duration", () => {
+    const rows = deriveVisibleRateLimitRows([
+      {
+        provider: "claudeAgent",
+        updatedAt: "2099-04-08T18:00:00.000Z",
+        limits: [
+          { window: "Weekly", usedPercent: 30, windowDurationMins: 10080 },
+          { window: "Fable", usedPercent: 89, windowDurationMins: 10080 },
+          { window: "seven_day_sonnet", usedPercent: 20, windowDurationMins: 10080 },
+          { window: "seven_day_opus", usedPercent: 10, windowDurationMins: 10080 },
+        ],
+      },
+    ]);
+
+    expect(rows.map(({ label, remainingPercent }) => ({ label, remainingPercent }))).toEqual([
+      { label: "Weekly", remainingPercent: 70 },
+      { label: "Fable", remainingPercent: 11 },
+      { label: "Sonnet", remainingPercent: 80 },
+      { label: "Opus", remainingPercent: 90 },
     ]);
   });
 });

--- a/apps/web/src/hooks/useProviderUsageSummary.test.tsx
+++ b/apps/web/src/hooks/useProviderUsageSummary.test.tsx
@@ -8,7 +8,7 @@ import type { ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
-import type { ProviderRateLimit } from "~/lib/rateLimits";
+import { deriveVisibleRateLimitRows, type ProviderRateLimit } from "~/lib/rateLimits";
 import { openUsageProviderSnapshotQueryOptions } from "~/lib/openUsageReactQuery";
 import { serverQueryKeys } from "~/lib/serverReactQuery";
 import { useProviderUsageSummary } from "./useProviderUsageSummary";
@@ -165,6 +165,45 @@ describe("useProviderUsageSummary", () => {
     expect(summary.rateLimits).toHaveLength(1);
     expect(summary.rateLimits[0]?.limits?.[0]?.window).toBe("5h");
     expect(summary.rateLimits[0]?.limits?.[0]?.usedPercent).toBe(12);
+  });
+
+  it.each([
+    ["2099-04-08T18:05:00.000Z", 10],
+    ["2099-04-08T17:55:00.000Z", 11],
+  ])("merges Fable telemetry at %s without replacing the weekly allowance", (updatedAt, remaining) => {
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(serverQueryKeys.allProviderUsage(), [
+      snapshot({
+        updatedAt: "2099-04-08T18:00:00.000Z",
+        limits: [
+          { window: "5h", usedPercent: 0, windowDurationMins: 300 },
+          { window: "Weekly", usedPercent: 45, windowDurationMins: 10080 },
+          { window: "Fable", usedPercent: 89, windowDurationMins: 10080 },
+        ],
+      }),
+    ]);
+
+    const summary = readProviderUsageSummary({
+      queryClient,
+      threadRateLimits: [
+        {
+          provider: "claudeAgent",
+          updatedAt,
+          limits: [{ window: "seven_day_overage_included", usedPercent: 90 }],
+        },
+      ],
+    });
+
+    expect(
+      deriveVisibleRateLimitRows(summary.rateLimits).map(({ label, remainingPercent }) => ({
+        label,
+        remainingPercent,
+      })),
+    ).toEqual([
+      { label: "5h", remainingPercent: 100 },
+      { label: "Weekly", remainingPercent: 55 },
+      { label: "Fable", remainingPercent: remaining },
+    ]);
   });
 
   it("surfaces the throttle notice from an ok snapshot that carries a detail", () => {

--- a/apps/web/src/hooks/useProviderUsageSummary.test.tsx
+++ b/apps/web/src/hooks/useProviderUsageSummary.test.tsx
@@ -170,41 +170,44 @@ describe("useProviderUsageSummary", () => {
   it.each([
     ["2099-04-08T18:05:00.000Z", 10],
     ["2099-04-08T17:55:00.000Z", 11],
-  ])("merges Fable telemetry at %s without replacing the weekly allowance", (updatedAt, remaining) => {
-    const queryClient = createQueryClient();
-    queryClient.setQueryData(serverQueryKeys.allProviderUsage(), [
-      snapshot({
-        updatedAt: "2099-04-08T18:00:00.000Z",
-        limits: [
-          { window: "5h", usedPercent: 0, windowDurationMins: 300 },
-          { window: "Weekly", usedPercent: 45, windowDurationMins: 10080 },
-          { window: "Fable", usedPercent: 89, windowDurationMins: 10080 },
+  ])(
+    "merges Fable telemetry at %s without replacing the weekly allowance",
+    (updatedAt, remaining) => {
+      const queryClient = createQueryClient();
+      queryClient.setQueryData(serverQueryKeys.allProviderUsage(), [
+        snapshot({
+          updatedAt: "2099-04-08T18:00:00.000Z",
+          limits: [
+            { window: "5h", usedPercent: 0, windowDurationMins: 300 },
+            { window: "Weekly", usedPercent: 45, windowDurationMins: 10080 },
+            { window: "Fable", usedPercent: 89, windowDurationMins: 10080 },
+          ],
+        }),
+      ]);
+
+      const summary = readProviderUsageSummary({
+        queryClient,
+        threadRateLimits: [
+          {
+            provider: "claudeAgent",
+            updatedAt,
+            limits: [{ window: "seven_day_overage_included", usedPercent: 90 }],
+          },
         ],
-      }),
-    ]);
+      });
 
-    const summary = readProviderUsageSummary({
-      queryClient,
-      threadRateLimits: [
-        {
-          provider: "claudeAgent",
-          updatedAt,
-          limits: [{ window: "seven_day_overage_included", usedPercent: 90 }],
-        },
-      ],
-    });
-
-    expect(
-      deriveVisibleRateLimitRows(summary.rateLimits).map(({ label, remainingPercent }) => ({
-        label,
-        remainingPercent,
-      })),
-    ).toEqual([
-      { label: "5h", remainingPercent: 100 },
-      { label: "Weekly", remainingPercent: 55 },
-      { label: "Fable", remainingPercent: remaining },
-    ]);
-  });
+      expect(
+        deriveVisibleRateLimitRows(summary.rateLimits).map(({ label, remainingPercent }) => ({
+          label,
+          remainingPercent,
+        })),
+      ).toEqual([
+        { label: "5h", remainingPercent: 100 },
+        { label: "Weekly", remainingPercent: 55 },
+        { label: "Fable", remainingPercent: remaining },
+      ]);
+    },
+  );
 
   it("surfaces the throttle notice from an ok snapshot that carries a detail", () => {
     const queryClient = createQueryClient();

--- a/apps/web/src/lib/rateLimits.ts
+++ b/apps/web/src/lib/rateLimits.ts
@@ -43,10 +43,10 @@ const WINDOW_ORDER = new Map([
   ["5h", 0],
   ["Daily", 1],
   ["Weekly", 2],
-  ["Weekly (overage)", 3],
-  ["Fable", 4],
-  ["Sonnet", 5],
-  ["Opus", 6],
+  ["Fable", 3],
+  ["Sonnet", 4],
+  ["Opus", 5],
+  ["Usage credits", 6],
   ["Current", 7],
 ]);
 
@@ -110,15 +110,18 @@ export function normalizeRateLimitLabel(
   if (normalized.startsWith("core_")) {
     return humanizeLabel(label);
   }
-  const durationLabel = windowLabelFromDuration(windowDurationMins);
-  if (durationLabel) return durationLabel;
-  if (normalized === "session" || normalized === "five_hour" || normalized === "5h") {
-    return "5h";
-  }
-  if (normalized === "weekly" || normalized === "seven_day" || normalized === "7d") {
-    return "Weekly";
-  }
-  if (normalized === "seven_day_fable" || normalized === "weekly_fable" || normalized === "fable") {
+  // Claude Code calls `seven_day_overage_included` the Fable limit. It is a model
+  // sublimit, distinct from both the account's weekly limit and paid usage credits.
+  // Resolve named buckets before duration so all weekly models keep their identity.
+  if (
+    normalized === "seven_day_fable" ||
+    normalized === "weekly_fable" ||
+    normalized === "fable" ||
+    normalized === "seven_day_overage_included" ||
+    normalized === "weekly_overage_included" ||
+    normalized === "weekly_overage" ||
+    normalized === "weekly_(overage)"
+  ) {
     return "Fable";
   }
   if (
@@ -131,13 +134,16 @@ export function normalizeRateLimitLabel(
   if (normalized === "seven_day_opus" || normalized === "weekly_opus" || normalized === "opus") {
     return "Opus";
   }
-  if (
-    normalized === "seven_day_overage_included" ||
-    normalized === "weekly_overage_included" ||
-    normalized === "weekly_overage" ||
-    normalized === "overage"
-  ) {
-    return "Weekly (overage)";
+  if (normalized === "overage" || normalized === "usage_credits") {
+    return "Usage credits";
+  }
+  const durationLabel = windowLabelFromDuration(windowDurationMins);
+  if (durationLabel) return durationLabel;
+  if (normalized === "session" || normalized === "five_hour" || normalized === "5h") {
+    return "5h";
+  }
+  if (normalized === "weekly" || normalized === "seven_day" || normalized === "7d") {
+    return "Weekly";
   }
   return humanizeLabel(label);
 }
@@ -259,9 +265,14 @@ function extractLimitsFromClaudePayload(
   if (!info) return undefined;
 
   const rateLimitType = typeof info.rateLimitType === "string" ? info.rateLimitType : undefined;
+  const label = normalizeRateLimitLabel(rateLimitType);
   const windowDurationMins =
-    rateLimitType === "five_hour" ? 300 : rateLimitType === "seven_day" ? 10_080 : undefined;
-  const normalized = normalizeLimitWindow(rateLimitType ?? "Current", {
+    label === "5h"
+      ? 300
+      : label === "Weekly" || label === "Fable" || label === "Sonnet" || label === "Opus"
+        ? 10_080
+        : undefined;
+  const normalized = normalizeLimitWindow(label, {
     utilization: info.utilization,
     resetsAt: info.resetsAt,
     windowDurationMins,


### PR DESCRIPTION
## Summary

- Map Claude’s `seven_day_overage_included` telemetry to the Fable sublimit.
- Keep paid usage credits separate from included weekly allowances.
- Preserve model-specific weekly windows and ordering.
- Add regression coverage for normalization and usage-summary merging.

## Testing

Not run (not requested).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI labeling and rate-limit normalization only; behavior is covered by new regression tests with no auth or data-path changes.
> 
> **Overview**
> Claude rate-limit telemetry is normalized so **`seven_day_overage_included`** (and related weekly overage-included keys) display as **Fable**, not a generic “Weekly (overage)” row. **Paid `overage` / usage credits** now map to a separate **Usage credits** meter, distinct from Fable’s included weekly sublimit.
> 
> Label resolution runs **named model buckets (Fable, Sonnet, Opus) before duration-based collapsing**, so multiple 7-day windows with the same duration stay separate in the UI. Display order drops “Weekly (overage)” and adds **Usage credits**; Claude payload parsing assigns weekly durations to Fable/Sonnet/Opus when inferring `windowDurationMins`.
> 
> Tests cover Fable mapping, credits vs Fable, coexisting weekly model rows, and **provider usage summary merge** so thread `seven_day_overage_included` updates Fable without overwriting the account **Weekly** allowance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab8440a99c409a955b1b0b0ed9a4d2748ea731f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->