### PR TITLE
Remember each project's Local or Worktree chat preference

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -7281,9 +7281,7 @@ describe("ChatView transcript geometry (full app)", () => {
         },
         { timeout: 8_000, interval: 16 },
       );
-      expect(useProjectEnvironmentStore.getState().envModeByProjectId[PROJECT_ID]).toBe(
-        "worktree",
-      );
+      expect(useProjectEnvironmentStore.getState().envModeByProjectId[PROJECT_ID]).toBe("worktree");
 
       let previousDraftId = newThreadId;
       for (const expectedMode of ["worktree", "local"] as const) {

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -39,6 +39,7 @@ import {
   getScrollContainerDistanceFromBottom,
 } from "../chat-scroll";
 import { useLatestProjectStore } from "../latestProjectStore";
+import { useProjectEnvironmentStore } from "../projectEnvironmentStore";
 import {
   INLINE_TERMINAL_CONTEXT_PLACEHOLDER,
   type TerminalContextDraft,
@@ -2126,6 +2127,7 @@ describe("ChatView transcript geometry (full app)", () => {
     attachmentUploadBarrier = null;
     attachmentCancelBarrier = null;
     localStorage.clear();
+    useProjectEnvironmentStore.setState({ envModeByProjectId: {} });
     useLatestProjectStore.setState({ latestProjectId: null });
     useWorkspacePathsStore.setState({
       homeDir: null,
@@ -7233,7 +7235,7 @@ describe("ChatView transcript geometry (full app)", () => {
     }
   });
 
-  it("offers New worktree from an empty draft thread", async () => {
+  it("remembers Local and New worktree choices for subsequent project chats", async () => {
     const mounted = await mountChatView({
       viewport: DEFAULT_VIEWPORT,
       snapshot: createSnapshotForTargetUser({
@@ -7279,6 +7281,40 @@ describe("ChatView transcript geometry (full app)", () => {
         },
         { timeout: 8_000, interval: 16 },
       );
+      expect(useProjectEnvironmentStore.getState().envModeByProjectId[PROJECT_ID]).toBe(
+        "worktree",
+      );
+
+      let previousDraftId = newThreadId;
+      for (const expectedMode of ["worktree", "local"] as const) {
+        await mounted.router.navigate({ to: "/$threadId", params: { threadId: THREAD_ID } });
+        useComposerDraftStore.getState().clearDraftThread(previousDraftId);
+        await newThreadButton.click();
+        const nextPath = await waitForURL(
+          mounted.router,
+          (path) => UUID_ROUTE_RE.test(path) && path !== `/${previousDraftId}`,
+          "The next chat should open a fresh draft.",
+        );
+        previousDraftId = nextPath.slice(1) as ThreadId;
+        await vi.waitFor(() => {
+          expect(useComposerDraftStore.getState().getDraftThread(previousDraftId)).toMatchObject({
+            projectId: PROJECT_ID,
+            envMode: expectedMode,
+            worktreePath: null,
+          });
+        });
+
+        if (expectedMode === "worktree") {
+          const picker = await waitForEnvironmentModeButton("Worktree");
+          picker.click();
+          await page.getByRole("menuitem", { name: "Local project", exact: true }).click();
+          await vi.waitFor(() => {
+            expect(useProjectEnvironmentStore.getState().envModeByProjectId[PROJECT_ID]).toBe(
+              "local",
+            );
+          });
+        }
+      }
     } finally {
       await mounted.cleanup();
     }
@@ -8319,16 +8355,20 @@ describe("ChatView transcript geometry (full app)", () => {
     });
 
     try {
+      useProjectEnvironmentStore.getState().setProjectEnvMode(PROJECT_ID, "worktree");
       await waitForNewThreadShortcutLabel();
       await waitForServerConfigToApply();
       const composerEditor = await waitForComposerEditor();
       composerEditor.focus();
       await waitForLayout();
-      await triggerChatNewShortcutUntilPath(
+      const nextPath = await triggerChatNewShortcutUntilPath(
         mounted.router,
         (path) => UUID_ROUTE_RE.test(path),
         "Route should have changed to a new draft thread UUID from the shortcut.",
       );
+      expect(
+        useComposerDraftStore.getState().getDraftThread(nextPath.slice(1) as ThreadId),
+      ).toMatchObject({ envMode: "worktree", worktreePath: null });
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -289,6 +289,7 @@ import {
 } from "../pendingUserInput";
 import { selectRightDockState, useRightDockStore } from "../rightDockStore";
 import { waitForSidechatCreator } from "../lib/sidechatCreatorRegistry";
+import { useProjectEnvironmentStore } from "../projectEnvironmentStore";
 import { useStore } from "../store";
 import { RenameThreadDialog } from "./RenameThreadDialog";
 import { getThreadFromState } from "../threadDerivation";
@@ -10217,6 +10218,9 @@ export default function ChatView({
   ]);
   const onEnvModeChange = useCallback(
     (mode: DraftThreadEnvMode) => {
+      if (activeProject) {
+        useProjectEnvironmentStore.getState().setProjectEnvMode(activeProject.id, mode);
+      }
       const nextBranch =
         mode === "worktree"
           ? (activeThread?.branch ?? draftThread?.branch ?? activeRootBranch ?? null)
@@ -10244,6 +10248,7 @@ export default function ChatView({
       scheduleComposerFocus();
     },
     [
+      activeProject,
       activeThread,
       activeRootBranch,
       draftThread?.branch,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2178,12 +2178,7 @@ export default function Sidebar() {
       setProjectExpanded(projectId, true);
       return (await handleNewThread(projectId).catch(() => null)) !== null;
     },
-    [
-      appSettings.sidebarThreadSortOrder,
-      handleNewThread,
-      navigate,
-      setProjectExpanded,
-    ],
+    [appSettings.sidebarThreadSortOrder, handleNewThread, navigate, setProjectExpanded],
   );
 
   // Poll the server read model briefly after project.create so we only recover from fresh state.
@@ -2304,12 +2299,7 @@ export default function Sidebar() {
 
       void handleNewThread(typedProjectId);
     },
-    [
-      focusMostRecentThreadForProject,
-      handleNewThread,
-      hideAutomationRunThreads,
-      sidebarThreads,
-    ],
+    [focusMostRecentThreadForProject, handleNewThread, hideAutomationRunThreads, sidebarThreads],
   );
 
   // Shared resolver behind resolveBackToStudioTarget/resolveBackToThreadsTarget (and the

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -173,6 +173,7 @@ import {
   isStudioContainerProject,
   prewarmStudioProject,
 } from "../lib/studioProjects";
+import { useProjectEnvironmentStore } from "../projectEnvironmentStore";
 import { useComposerDraftStore } from "../composerDraftStore";
 import { useLatestProjectStore } from "../latestProjectStore";
 import { resolveThreadEnvironmentPresentation } from "../lib/threadEnvironment";
@@ -2140,18 +2141,9 @@ export default function Sidebar() {
         return true;
       }
 
-      return (
-        (await handleNewThread(projectId, {
-          envMode: appSettings.defaultThreadEnvMode,
-        }).catch(() => null)) !== null
-      );
+      return (await handleNewThread(projectId).catch(() => null)) !== null;
     },
-    [
-      appSettings.defaultThreadEnvMode,
-      appSettings.sidebarThreadSortOrder,
-      handleNewThread,
-      navigate,
-    ],
+    [appSettings.sidebarThreadSortOrder, handleNewThread, navigate],
   );
 
   const openExistingProjectFromSnapshot = useCallback(
@@ -2184,14 +2176,9 @@ export default function Sidebar() {
       }
 
       setProjectExpanded(projectId, true);
-      return (
-        (await handleNewThread(projectId, {
-          envMode: appSettings.defaultThreadEnvMode,
-        }).catch(() => null)) !== null
-      );
+      return (await handleNewThread(projectId).catch(() => null)) !== null;
     },
     [
-      appSettings.defaultThreadEnvMode,
       appSettings.sidebarThreadSortOrder,
       handleNewThread,
       navigate,
@@ -2315,14 +2302,9 @@ export default function Sidebar() {
         return;
       }
 
-      void handleNewThread(typedProjectId, {
-        envMode: resolveSidebarNewThreadEnvMode({
-          defaultEnvMode: appSettings.defaultThreadEnvMode,
-        }),
-      });
+      void handleNewThread(typedProjectId);
     },
     [
-      appSettings.defaultThreadEnvMode,
       focusMostRecentThreadForProject,
       handleNewThread,
       hideAutomationRunThreads,
@@ -2628,9 +2610,7 @@ export default function Sidebar() {
         // snapshot is just slow to catch up, continue with the local new-thread flow
         // instead of surfacing a false-negative sidebar sync error.
         setProjectExpanded(creationResult.projectId, true);
-        const threadId = await handleNewThread(creationResult.projectId, {
-          envMode: appSettings.defaultThreadEnvMode,
-        }).catch(() => null);
+        const threadId = await handleNewThread(creationResult.projectId).catch(() => null);
         if (!threadId) {
           throw new Error("Project creation was superseded before its chat opened.");
         }
@@ -2640,7 +2620,6 @@ export default function Sidebar() {
     },
     [
       appSettings.defaultProvider,
-      appSettings.defaultThreadEnvMode,
       handleNewThread,
       projects,
       recoverExistingProjectFromServer,
@@ -2706,12 +2685,12 @@ export default function Sidebar() {
         projectCwd: project.cwd,
         draftWorktreePath: draftThread?.worktreePath ?? null,
         serverCwd,
-        // Hover-time warm must resolve the same envMode the click will pass so the
-        // warmed cwd keys match the thread ChatView actually mounts (local mode
-        // clears the draft worktree; worktree mode keeps it).
-        envMode: resolveSidebarNewThreadEnvMode({
-          defaultEnvMode: appSettings.defaultThreadEnvMode,
-        }),
+        // Match new-thread bootstrap: preserve existing drafts and apply project
+        // preferences only when creating a fresh one.
+        envMode:
+          draftThread?.envMode ??
+          useProjectEnvironmentStore.getState().envModeByProjectId[projectId] ??
+          appSettings.defaultThreadEnvMode,
         providerStatuses,
         statusesReconciled: hasReconciledServerProviderStatuses(queryClient),
         providerOrder: appSettings.providerOrder,
@@ -2740,11 +2719,7 @@ export default function Sidebar() {
   const handlePrimaryNewThread = useCallback(() => {
     if (primaryNewThreadTarget) {
       prefetchModelsForProjectNewThread(primaryNewThreadTarget.projectId, { includeDroid: true });
-      void handleNewThread(primaryNewThreadTarget.projectId, {
-        envMode: resolveSidebarNewThreadEnvMode({
-          defaultEnvMode: appSettings.defaultThreadEnvMode,
-        }),
-      });
+      void handleNewThread(primaryNewThreadTarget.projectId);
       return;
     }
 
@@ -2755,7 +2730,6 @@ export default function Sidebar() {
     }
     handleStartAddProject();
   }, [
-    appSettings.defaultThreadEnvMode,
     handleNewThread,
     handleStartAddProject,
     prefetchModelsForProjectNewThread,
@@ -5048,12 +5022,7 @@ export default function Sidebar() {
                 onClick={(event) => {
                   event.preventDefault();
                   event.stopPropagation();
-                  void handleNewThread(project.id, {
-                    envMode: resolveSidebarNewThreadEnvMode({
-                      defaultEnvMode: appSettings.defaultThreadEnvMode,
-                    }),
-                    entryPoint: "terminal",
-                  });
+                  void handleNewThread(project.id, { entryPoint: "terminal" });
                 }}
               />
               <SidebarIconButton
@@ -5074,11 +5043,7 @@ export default function Sidebar() {
                   event.preventDefault();
                   event.stopPropagation();
                   prefetchModelsForProjectNewThread(project.id, { includeDroid: true });
-                  void handleNewThread(project.id, {
-                    envMode: resolveSidebarNewThreadEnvMode({
-                      defaultEnvMode: appSettings.defaultThreadEnvMode,
-                    }),
-                  });
+                  void handleNewThread(project.id);
                 }}
               />
             </SidebarSectionToolbar>

--- a/apps/web/src/components/chat/SingleChatSurface.tsx
+++ b/apps/web/src/components/chat/SingleChatSurface.tsx
@@ -828,9 +828,7 @@ export function SingleChatSurface(props: {
 
     await handleNewThread(
       projectId,
-      {
-        envMode: appSettings.defaultThreadEnvMode,
-      },
+      undefined,
       {
         search: (previous) => ({
           ...stripEditorViewSearchParams(stripDiffSearchParams(previous)),

--- a/apps/web/src/components/chat/SingleChatSurface.tsx
+++ b/apps/web/src/components/chat/SingleChatSurface.tsx
@@ -826,16 +826,12 @@ export function SingleChatSurface(props: {
       return;
     }
 
-    await handleNewThread(
-      projectId,
-      undefined,
-      {
-        search: (previous) => ({
-          ...stripEditorViewSearchParams(stripDiffSearchParams(previous)),
-          view: "editor",
-        }),
-      },
-    );
+    await handleNewThread(projectId, undefined, {
+      search: (previous) => ({
+        ...stripEditorViewSearchParams(stripDiffSearchParams(previous)),
+        view: "editor",
+      }),
+    });
   };
   const handleSelectEditorProject = (projectId: ProjectId) => {
     void openEditorProject(projectId).catch((error: unknown) => {

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -40,6 +40,7 @@ import { newCommandId, newThreadId } from "../lib/utils";
 import { readNativeApi } from "../nativeApi";
 import { useFocusedChatContext } from "../focusedChatContext";
 import { useStore } from "../store";
+import { useProjectEnvironmentStore } from "../projectEnvironmentStore";
 import { useTemporaryThreadStore } from "../temporaryThreadStore";
 import { useTerminalStateStore } from "../terminalStateStore";
 
@@ -82,6 +83,10 @@ export function useHandleNewThread() {
     }
 
     const entryPoint = options?.entryPoint ?? "chat";
+    const defaultEnvMode =
+      (entryPoint === "chat"
+        ? useProjectEnvironmentStore.getState().envModeByProjectId[projectId]
+        : undefined) ?? settings.defaultThreadEnvMode;
     if (entryPoint === "chat") {
       const draftStore = useComposerDraftStore.getState();
       const draftThread = draftStore.getDraftThreadByProjectId(projectId, "chat");
@@ -103,7 +108,7 @@ export function useHandleNewThread() {
         worktreePath: options?.worktreePath ?? null,
         hasExplicitWorktreePath: options?.worktreePath !== undefined,
         fresh: options?.fresh === true,
-        envMode: options?.envMode ?? null,
+        envMode: options?.envMode ?? draftThread?.envMode ?? defaultEnvMode,
         serverCwd,
         providerStatuses,
         statusesReconciled: providerStatusesReconciled,
@@ -366,7 +371,12 @@ export function useHandleNewThread() {
         markTemporaryThread(threadId);
       }
       const createdAt = new Date().toISOString();
-      const draftSeed = createFreshDraftThreadSeed({ createdAt, entryPoint, options });
+      const draftSeed = createFreshDraftThreadSeed({
+        createdAt,
+        entryPoint,
+        options,
+        defaultEnvMode,
+      });
       const committed = await stageDraftNavigation({
         // Keep the previous routed draft alive while the destination loads. Replacing the
         // project's primary slot earlier makes the route guard redirect the old URL to Home.

--- a/apps/web/src/lib/threadBootstrap.test.ts
+++ b/apps/web/src/lib/threadBootstrap.test.ts
@@ -259,6 +259,38 @@ describe("threadBootstrap", () => {
     });
   });
 
+  it.each(["local", "worktree"] as const)(
+    "starts fresh chats in the preferred %s mode without inheriting a worktree",
+    (defaultEnvMode) => {
+      expect(
+        createFreshDraftThreadSeed({
+          createdAt: "2026-04-05T10:00:00.000Z",
+          entryPoint: "chat",
+          options: undefined,
+          defaultEnvMode,
+        }),
+      ).toMatchObject({ envMode: defaultEnvMode, branch: null, worktreePath: null });
+    },
+  );
+
+  it("keeps explicit workspace targets ahead of the preferred mode", () => {
+    const input = {
+      createdAt: "2026-04-05T10:00:00.000Z",
+      entryPoint: "chat" as const,
+      defaultEnvMode: "worktree" as const,
+    };
+    expect(createFreshDraftThreadSeed({ ...input, options: { envMode: "local" } }).envMode).toBe(
+      "local",
+    );
+    expect(
+      createFreshDraftThreadSeed({
+        ...input,
+        defaultEnvMode: "local",
+        options: { worktreePath: "/repo/.worktrees/explicit" },
+      }),
+    ).toMatchObject({ envMode: "worktree", worktreePath: "/repo/.worktrees/explicit" });
+  });
+
   it("marks fresh draft seeds as temporary when requested", () => {
     expect(
       createFreshDraftThreadSeed({

--- a/apps/web/src/lib/threadBootstrap.ts
+++ b/apps/web/src/lib/threadBootstrap.ts
@@ -211,13 +211,16 @@ export function createFreshDraftThreadSeed(input: {
   createdAt: string;
   entryPoint: ThreadPrimarySurface;
   options: NewThreadOptions | undefined;
+  defaultEnvMode?: DraftThreadEnvMode;
 }): Omit<DraftThreadState, "projectId" | "interactionMode"> {
   return {
     createdAt: input.createdAt,
     branch: input.options?.branch ?? null,
     worktreePath: input.options?.worktreePath ?? null,
     workingDirectory: input.options?.workingDirectory ?? null,
-    envMode: input.options?.envMode ?? "local",
+    envMode:
+      input.options?.envMode ??
+      (input.options?.worktreePath ? "worktree" : (input.defaultEnvMode ?? "local")),
     runtimeMode: DEFAULT_RUNTIME_MODE,
     entryPoint: input.entryPoint,
     ...(input.options?.temporary ? { isTemporary: true } : {}),

--- a/apps/web/src/projectEnvironmentStore.test.ts
+++ b/apps/web/src/projectEnvironmentStore.test.ts
@@ -1,0 +1,53 @@
+import { ProjectId } from "@synara/contracts";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useProjectEnvironmentStore } from "./projectEnvironmentStore";
+
+const PROJECT_A = ProjectId.makeUnsafe("project-a");
+const PROJECT_B = ProjectId.makeUnsafe("project-b");
+
+describe("project environment preferences", () => {
+  beforeEach(() => {
+    useProjectEnvironmentStore.setState({ envModeByProjectId: {} });
+  });
+
+  it("remembers each project's latest choice independently", () => {
+    const { setProjectEnvMode } = useProjectEnvironmentStore.getState();
+    setProjectEnvMode(PROJECT_A, "worktree");
+    expect(useProjectEnvironmentStore.getState().envModeByProjectId[PROJECT_B]).toBeUndefined();
+
+    setProjectEnvMode(PROJECT_B, "worktree");
+    setProjectEnvMode(PROJECT_A, "local");
+    expect(useProjectEnvironmentStore.getState().envModeByProjectId).toEqual({
+      [PROJECT_A]: "local",
+      [PROJECT_B]: "worktree",
+    });
+  });
+
+  it("restores both choices from persisted storage", async () => {
+    const { setProjectEnvMode } = useProjectEnvironmentStore.getState();
+    setProjectEnvMode(PROJECT_A, "local");
+    setProjectEnvMode(PROJECT_B, "worktree");
+    const { name, storage } = useProjectEnvironmentStore.persist.getOptions();
+    const saved = await storage!.getItem(name);
+
+    useProjectEnvironmentStore.setState({ envModeByProjectId: {} });
+    await storage!.setItem(name, saved!);
+    await useProjectEnvironmentStore.persist.rehydrate();
+
+    expect(useProjectEnvironmentStore.getState().envModeByProjectId).toEqual({
+      [PROJECT_A]: "local",
+      [PROJECT_B]: "worktree",
+    });
+  });
+
+  it("ignores invalid stored choices while preserving valid preferences", () => {
+    const { merge } = useProjectEnvironmentStore.persist.getOptions();
+    expect(
+      merge!(
+        { envModeByProjectId: { [PROJECT_A]: "worktree", [PROJECT_B]: "invalid" } },
+        useProjectEnvironmentStore.getState(),
+      ).envModeByProjectId,
+    ).toEqual({ [PROJECT_A]: "worktree" });
+  });
+});

--- a/apps/web/src/projectEnvironmentStore.test.ts
+++ b/apps/web/src/projectEnvironmentStore.test.ts
@@ -1,5 +1,5 @@
 import { ProjectId } from "@synara/contracts";
-import { beforeEach, describe, expect, it } from "vitest";
+import { assert, beforeEach, describe, expect, it } from "vitest";
 
 import { useProjectEnvironmentStore } from "./projectEnvironmentStore";
 
@@ -29,10 +29,13 @@ describe("project environment preferences", () => {
     setProjectEnvMode(PROJECT_A, "local");
     setProjectEnvMode(PROJECT_B, "worktree");
     const { name, storage } = useProjectEnvironmentStore.persist.getOptions();
-    const saved = await storage!.getItem(name);
+    assert(name);
+    assert(storage);
+    const saved = await storage.getItem(name);
+    assert(saved);
 
     useProjectEnvironmentStore.setState({ envModeByProjectId: {} });
-    await storage!.setItem(name, saved!);
+    await storage.setItem(name, saved);
     await useProjectEnvironmentStore.persist.rehydrate();
 
     expect(useProjectEnvironmentStore.getState().envModeByProjectId).toEqual({

--- a/apps/web/src/projectEnvironmentStore.ts
+++ b/apps/web/src/projectEnvironmentStore.ts
@@ -1,0 +1,39 @@
+import type { ProjectId, ThreadEnvironmentMode } from "@synara/contracts";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+import { createMemoryStorage } from "./lib/storage";
+import { isPlainObject, sanitizeStringKeyedRecord } from "./persistedRecord";
+
+interface ProjectEnvironmentStoreState {
+  envModeByProjectId: Partial<Record<ProjectId, ThreadEnvironmentMode>>;
+  setProjectEnvMode: (projectId: ProjectId, envMode: ThreadEnvironmentMode) => void;
+}
+
+const storage = typeof localStorage !== "undefined" ? localStorage : createMemoryStorage();
+
+export const useProjectEnvironmentStore = create<ProjectEnvironmentStoreState>()(
+  persist(
+    (set) => ({
+      envModeByProjectId: {},
+      setProjectEnvMode: (projectId, envMode) =>
+        set((state) =>
+          state.envModeByProjectId[projectId] === envMode
+            ? state
+            : { envModeByProjectId: { ...state.envModeByProjectId, [projectId]: envMode } },
+        ),
+    }),
+    {
+      name: "synara:project-environment:v1",
+      storage: createJSONStorage(() => storage),
+      partialize: (state) => ({ envModeByProjectId: state.envModeByProjectId }),
+      merge: (persisted, current) => ({
+        ...current,
+        envModeByProjectId: sanitizeStringKeyedRecord(
+          isPlainObject(persisted) ? persisted.envModeByProjectId : undefined,
+          (value) => (value === "local" || value === "worktree" ? value : null),
+        ),
+      }),
+    },
+  ),
+);

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -453,31 +453,19 @@ function ChatRouteGlobalShortcuts() {
             });
             return;
           }
-          await handleNewThread(target.projectId, {
-            provider,
-            ...(target.inheritContext
-              ? resolveInheritedThreadContext({ activeThread, activeDraftThread })
-              : {}),
-          });
+          await handleNewThread(target.projectId, { provider });
         })();
         return;
       }
 
       if (command !== "chat.new") return;
-      // Falls back to the most recent project when none is focused (e.g. the landing
-      // view) so the primary "new thread" chord always creates a thread; on that
-      // fallback the active branch/worktree context belongs to the absent project, so
-      // `resolveNewThreadTarget` omits it and we defer to the target's defaults.
+      // Fall back to the most recent project when none is focused and let the
+      // shared bootstrap apply that project's preferred environment.
       const target = resolveNewThreadTarget({ currentProjectId, latestUsableProjectId });
       if (!target) return;
       event.preventDefault();
       event.stopPropagation();
-      void handleNewThread(
-        target.projectId,
-        target.inheritContext
-          ? resolveInheritedThreadContext({ activeThread, activeDraftThread })
-          : undefined,
-      );
+      void handleNewThread(target.projectId);
     };
 
     window.addEventListener("keydown", onWindowKeyDown, { capture: true });


### PR DESCRIPTION
## Summary

- Persist each project's latest Local or Worktree environment choice.
- Apply the project preference when creating new chats while preserving explicit workspace targets.
- Route sidebar actions, shortcuts, and chat flows through the shared environment bootstrap logic.
- Add unit and browser coverage for preference persistence and subsequent chat creation.

## Testing

- Unit tests for project preference storage and fresh draft environment selection.
- Browser tests for switching modes and creating subsequent project chats, including the new-chat shortcut.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many new-thread entry points and persisted client state, so regressions could affect which workspace (local vs worktree) new chats start in.
> 
> **Overview**
> Adds a **persisted per-project environment preference** (`local` vs `worktree`) so new chats in a project reopen with the last mode the user picked, instead of always using the global default.
> 
> When the user changes environment mode in the composer, **ChatView** writes that choice to the new store. **New-thread bootstrap** (`useHandleNewThread`, `createFreshDraftThreadSeed`) resolves `envMode` as: explicit options → existing draft → project preference → app default; explicit `worktreePath` / `envMode` still win. Sidebar, editor surface, and **chat.new** shortcuts stop threading `defaultThreadEnvMode` (and shortcut flows no longer inherit the active thread’s branch/worktree context), relying on this shared logic instead. Model prefetch for sidebar “new thread” hover now uses the same resolution so warmed CWD keys match the opened draft.
> 
> Coverage includes unit tests for the store and seed logic, plus expanded browser tests for remembering choices across successive project chats and the new-chat shortcut.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96de0df4d46f5f5838ba12cf468b5cebbd99eb97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->