### PR TITLE
Refine project picker menus and composer styling

### DIFF
--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -74,15 +74,15 @@ function WorktreeGlyph({ className }: { className?: string }) {
   return <WorktreeIcon className={className} />;
 }
 
-/** Leading glyph treatment shared by every "Continue in" menu row (16px, muted). */
+/** Leading glyph treatment shared by every "Work in" menu row (16px, muted). */
 const ENV_MENU_ICON_CLASS_NAME = "size-3.5 text-muted-foreground";
 
 /**
- * One row of the "Continue in" menu: `[glyph] [label …grows] [✓ when selected]`.
+ * One row of the "Work in" menu: `[glyph] [label …grows] [✓ when selected]`.
  * Centralizes the icon/label/check treatment so the local, worktree, and handoff
  * entries stay on one grid instead of repeating the same class strings per row.
  */
-function ContinueInMenuItem({
+function WorkInMenuItem({
   icon,
   label,
   selected: selectedProp,
@@ -550,36 +550,36 @@ export default function BranchToolbar({
               className="w-60 min-w-60"
             >
               <MenuGroup>
-                <MenuGroupLabel>Continue in</MenuGroupLabel>
+                <MenuGroupLabel>Work in</MenuGroupLabel>
                 {environmentPresentation.mode === "local" ? (
-                  <ContinueInMenuItem
+                  <WorkInMenuItem
                     icon={<CentralIcon name="macbook-air" className={ENV_MENU_ICON_CLASS_NAME} />}
                     label={environmentPresentation.localOptionLabel}
                     selected
                   />
                 ) : (
-                  <ContinueInMenuItem
+                  <WorkInMenuItem
                     icon={<CentralIcon name="macbook-air" className={ENV_MENU_ICON_CLASS_NAME} />}
                     label={environmentPresentation.localOptionLabel}
                     onSelect={() => onEnvModeChange("local")}
                   />
                 )}
                 {canSwitchToWorktree ? (
-                  <ContinueInMenuItem
+                  <WorkInMenuItem
                     icon={<WorktreeGlyph className={ENV_MENU_ICON_CLASS_NAME} />}
                     label="New worktree"
                     onSelect={() => onEnvModeChange("worktree")}
                   />
                 ) : null}
                 {effectiveEnvMode === "worktree" && !canHandoffToLocal ? (
-                  <ContinueInMenuItem
+                  <WorkInMenuItem
                     icon={<WorktreeGlyph className={ENV_MENU_ICON_CLASS_NAME} />}
                     label={environmentPresentation.worktreeOptionLabel}
                     selected
                   />
                 ) : null}
                 {canHandoffToWorktree && onHandoffToWorktree ? (
-                  <ContinueInMenuItem
+                  <WorkInMenuItem
                     icon={<WorktreeGlyph className={ENV_MENU_ICON_CLASS_NAME} />}
                     label="Hand off to new worktree"
                     disabled={handoffBusy}
@@ -587,7 +587,7 @@ export default function BranchToolbar({
                   />
                 ) : null}
                 {canHandoffToLocal && onHandoffToLocal ? (
-                  <ContinueInMenuItem
+                  <WorkInMenuItem
                     icon={<HandoffIcon className={ENV_MENU_ICON_CLASS_NAME} />}
                     label="Hand off to local"
                     disabled={handoffBusy}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -577,6 +577,7 @@ import {
   COMPOSER_FOLDER_PICKER_CAPSULE_HOVER_CLASS_NAME,
   COMPOSER_FOOTER_ROW_CLASS_NAME,
   COMPOSER_TOOLBAR_CAPSULE_HOVER_CLASS_NAME,
+  COMPOSER_TOOLBAR_TRIGGER_TEXT_CLASS_NAME,
   CHAT_BACKGROUND_CLASS_NAME,
   CHAT_COLUMN_FRAME_CLASS_NAME,
   CHAT_COLUMN_GUTTER_CLASS_NAME,
@@ -11579,7 +11580,12 @@ export default function ChatView({
     !showContainerChatWorkspacePicker &&
     !showEmptyLandingProjectPicker &&
     activeProjectDisplayName ? (
-      <span className="inline-flex min-w-0 max-w-56 shrink items-center gap-2 overflow-hidden rounded-full px-2 py-1 text-[length:var(--app-font-size-ui-sm,11px)] font-normal text-[var(--color-text-foreground-secondary)] sm:max-w-64">
+      <span
+        className={cn(
+          "inline-flex min-w-0 max-w-56 shrink items-center gap-2 overflow-hidden rounded-full px-2 py-1 sm:max-w-64",
+          COMPOSER_TOOLBAR_TRIGGER_TEXT_CLASS_NAME,
+        )}
+      >
         <FolderClosed className="size-3.5 shrink-0" />
         <span className="min-w-0 truncate">{activeProjectDisplayName}</span>
       </span>
@@ -11593,11 +11599,13 @@ export default function ChatView({
   const emptyLandingControls = showEmptyLandingControls ? (
     <div
       data-empty-landing-controls="true"
-      // United-but-not-fused tray sitting in normal flow directly above the composer at a
-      // narrower width (w-14/15): tinted, rounded on top only, flush against the input
-      // shell below. No overlap/underlay tricks — in dark mode a slice tucked behind the
-      // composer's translucent corners reads as a visible cut along the seam.
-      className="chat-composer-shell mx-auto flex min-h-8 w-14/15 min-w-0 flex-nowrap items-center gap-x-1.5 overflow-hidden !rounded-b-none !rounded-t-[var(--composer-radius)] bg-[color-mix(in_srgb,var(--color-background-elevated-secondary)_76%,var(--color-background-surface)_24%)] px-2 py-1 transition-colors duration-150 ease-out motion-reduce:transition-none sm:min-h-7"
+      // Tray sitting in normal flow directly above the composer, full composer width so
+      // the project / environment / branch chips sit near the shell edges. Light mode is
+      // unfilled (chips float over the page); dark mode keeps a faint tint, rounded on
+      // top only and flush against the input shell below. No overlap/underlay tricks —
+      // in dark mode a slice tucked behind the composer's translucent corners reads as
+      // a visible cut along the seam.
+      className="chat-composer-shell mx-auto flex min-h-8 w-full min-w-0 flex-nowrap items-center gap-x-1.5 overflow-hidden !rounded-b-none !rounded-t-[var(--composer-radius)] px-1.5 py-1 transition-colors duration-150 ease-out motion-reduce:transition-none sm:min-h-7 dark:bg-[color-mix(in_srgb,var(--color-background-elevated-secondary)_76%,var(--color-background-surface)_24%)]"
     >
       {showContainerChatWorkspacePicker ? (
         <ProjectPicker
@@ -11607,6 +11615,7 @@ export default function ChatView({
           triggerClassName={cn(
             "h-8 px-2 py-1 sm:h-7 sm:px-2.5",
             COMPOSER_FOLDER_PICKER_CAPSULE_HOVER_CLASS_NAME,
+            COMPOSER_TOOLBAR_TRIGGER_TEXT_CLASS_NAME,
           )}
           showResetToHome={Boolean(
             isStudioContainer ? resolvedThreadWorkingDirectory : resolvedThreadWorktreePath,
@@ -11631,6 +11640,7 @@ export default function ChatView({
           triggerClassName={cn(
             "h-8 px-2 py-1 sm:h-7 sm:px-2.5",
             COMPOSER_FOLDER_PICKER_CAPSULE_HOVER_CLASS_NAME,
+            COMPOSER_TOOLBAR_TRIGGER_TEXT_CLASS_NAME,
           )}
           selectionMode="project"
           selectedProjectId={activeProject.id}
@@ -11675,11 +11685,11 @@ export default function ChatView({
           }
           aria-label="Temporary chat"
           className={cn(
-            "ml-auto shrink-0 gap-1.5 whitespace-nowrap px-2 text-[length:var(--app-font-size-ui-sm,11px)] font-normal sm:px-2.5",
+            "ml-auto shrink-0 gap-1.5 whitespace-nowrap px-2 sm:px-2.5",
             COMPOSER_TOOLBAR_CAPSULE_HOVER_CLASS_NAME,
-            isThreadTemporary
-              ? "text-[var(--color-text-accent)] hover:text-[var(--color-text-accent)]"
-              : "text-[var(--color-text-foreground-secondary)] hover:text-[var(--color-text-foreground)]",
+            COMPOSER_TOOLBAR_TRIGGER_TEXT_CLASS_NAME,
+            isThreadTemporary &&
+              "text-[var(--color-text-accent)] hover:text-[var(--color-text-accent)]",
           )}
         >
           <TemporaryThreadIcon className="size-3.5" />

--- a/apps/web/src/components/chat/PickerPanelShell.tsx
+++ b/apps/web/src/components/chat/PickerPanelShell.tsx
@@ -4,6 +4,7 @@
 // Depends on: shared input styling plus caller-provided content slots.
 
 import { useEffect, useRef, type ReactNode } from "react";
+import { SearchIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
 import { Input } from "../ui/input";
 import {
@@ -12,6 +13,12 @@ import {
   COMPOSER_PICKER_SEARCH_HEADER_CLASS_NAME,
   COMPOSER_PICKER_SEARCH_INPUT_CLASS_NAME,
 } from "./composerPickerStyles";
+import {
+  PICKER_PANEL_PLAIN_BODY_CLASS_NAME,
+  PICKER_PANEL_PLAIN_SEARCH_HEADER_CLASS_NAME,
+  PICKER_PANEL_PLAIN_SEARCH_ICON_CLASS_NAME,
+  PICKER_PANEL_PLAIN_SEARCH_INPUT_CLASS_NAME,
+} from "./pickerPanelStyles";
 
 const MENU_NAVIGATION_KEYS = new Set([
   "ArrowDown",
@@ -36,6 +43,13 @@ export function PickerPanelShell(props: {
   widthClassName?: string;
   bleedParentPadding?: boolean;
   listMaxHeightClassName?: string;
+  /**
+   * `"plain"` is the dense picker panel: the search area drops all field chrome (no border,
+   * fill, ring, or shadow) down to a magnifier + placeholder over a single hairline divider,
+   * and the body loses its extra padding so the list chrome owns the 4px gutter on its own.
+   * `"default"` keeps the bordered search field used by the composer submenus.
+   */
+  variant?: "default" | "plain";
 }) {
   const {
     searchPlaceholder: searchPlaceholderProp,
@@ -49,6 +63,7 @@ export function PickerPanelShell(props: {
     widthClassName: widthClassNameProp,
     bleedParentPadding: bleedParentPaddingProp,
     listMaxHeightClassName,
+    variant: variantProp,
   } = props;
   const searchPlaceholder = searchPlaceholderProp ?? "Search";
   const query = queryProp ?? "";
@@ -56,6 +71,7 @@ export function PickerPanelShell(props: {
   const autoFocusSearch = autoFocusSearchProp ?? false;
   const widthClassName = widthClassNameProp ?? "w-72";
   const bleedParentPadding = bleedParentPaddingProp ?? false;
+  const isPlain = (variantProp ?? "default") === "plain";
   const searchInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
@@ -83,21 +99,33 @@ export function PickerPanelShell(props: {
       {onQueryChange || searchInput ? (
         <div
           className={cn(
-            bleedParentPadding
-              ? cn(COMPOSER_PICKER_SEARCH_HEADER_CLASS_NAME, "-top-1 pt-2")
-              : "sticky top-0 z-20 shrink-0 border-b border-border bg-[var(--composer-surface)] p-1",
+            isPlain
+              ? PICKER_PANEL_PLAIN_SEARCH_HEADER_CLASS_NAME
+              : bleedParentPadding
+                ? cn(COMPOSER_PICKER_SEARCH_HEADER_CLASS_NAME, "-top-1 pt-2")
+                : "sticky top-0 z-20 shrink-0 border-b border-border bg-[var(--composer-surface)] p-1",
           )}
         >
+          {isPlain ? (
+            <SearchIcon aria-hidden="true" className={PICKER_PANEL_PLAIN_SEARCH_ICON_CLASS_NAME} />
+          ) : null}
           {searchInput ?? (
             <Input
-              className={cn(
-                "rounded-md border-border/60 shadow-none before:hidden has-focus-visible:border-neutral-500/15 has-focus-visible:ring-0 [&_input]:font-sans",
-                bleedParentPadding ? COMPOSER_PICKER_SEARCH_INPUT_CLASS_NAME : "bg-background",
-              )}
+              className={
+                isPlain
+                  ? PICKER_PANEL_PLAIN_SEARCH_INPUT_CLASS_NAME
+                  : cn(
+                      "rounded-md border-border/60 shadow-none before:hidden has-focus-visible:border-neutral-500/15 has-focus-visible:ring-0 [&_input]:font-sans",
+                      bleedParentPadding
+                        ? COMPOSER_PICKER_SEARCH_INPUT_CLASS_NAME
+                        : "bg-background",
+                    )
+              }
               nativeInput
               ref={searchInputRef}
               size="sm"
               type="search"
+              unstyled={isPlain}
               placeholder={searchPlaceholder}
               value={query}
               onChange={(event) => onQueryChange?.(event.target.value)}
@@ -116,7 +144,8 @@ export function PickerPanelShell(props: {
       ) : null}
       <div
         className={cn(
-          "min-h-0 flex-1 overflow-y-auto overscroll-contain py-0.5",
+          "min-h-0 flex-1 overflow-y-auto overscroll-contain",
+          isPlain ? PICKER_PANEL_PLAIN_BODY_CLASS_NAME : "py-0.5",
           bleedParentPadding ? COMPOSER_PICKER_MODEL_LIST_SCROLL_CLASS_NAME : null,
         )}
       >

--- a/apps/web/src/components/chat/ProjectPicker.tsx
+++ b/apps/web/src/components/chat/ProjectPicker.tsx
@@ -25,11 +25,18 @@ import { getLocalFoldersGroupLabel } from "~/lib/localFoldersGroupLabel";
 import { groupItemsBySpace, spaceDisplayName } from "~/lib/spaceGrouping";
 import { useVoidSpace } from "~/voidSpaceStore";
 import { cn } from "~/lib/utils";
-import { ELEVATED_HOVER_SURFACE_CLASS_NAME } from "~/surfaceStyles";
 import { FolderClosed } from "../FolderClosed";
 import { SpaceIcon } from "../SpaceIcon";
 import { PickerPanelShell } from "./PickerPanelShell";
 import { PickerTriggerButton } from "./PickerTriggerButton";
+import {
+  PICKER_PANEL_ACTION_ROW_CLASS_NAME,
+  PICKER_PANEL_GROUP_LABEL_CLASS_NAME,
+  PICKER_PANEL_PLAIN_SEARCH_INPUT_CLASS_NAME,
+  PICKER_PANEL_ROW_GEOMETRY_CLASS_NAME,
+  PICKER_PANEL_ROW_ICON_CLASS_NAME,
+  PICKER_PANEL_ROW_SELECTED_CLASS_NAME,
+} from "./pickerPanelStyles";
 import {
   Combobox,
   ComboboxEmpty,
@@ -87,13 +94,6 @@ interface ActiveFolderOption {
  * Module scope on purpose: the caller runs this inside a `try`, and React Compiler cannot lower a
  * conditional expression there — inlining it makes the whole picker skip compilation.
  */
-/** Full-width action row in the picker footer (add project, reset to home). */
-const PICKER_FOOTER_ACTION_CLASS_NAME = cn(
-  "flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-sm",
-  ELEVATED_HOVER_SURFACE_CLASS_NAME,
-  "hover:text-[var(--color-text-foreground)]",
-);
-
 function startActiveFolderSelection(
   folder: ActiveFolderOption,
   handlers: {
@@ -541,22 +541,18 @@ export const ProjectPicker = memo(function ProjectPicker({
         index={index}
         value={folder.cwd}
         className={cn(
-          selected &&
-            "bg-[var(--color-background-elevated-secondary)] text-[var(--color-text-foreground)]",
+          PICKER_PANEL_ROW_GEOMETRY_CLASS_NAME,
+          selected && PICKER_PANEL_ROW_SELECTED_CLASS_NAME,
         )}
       >
         <div className="flex min-w-0 items-center gap-2">
-          <FolderClosed className="size-3.5 shrink-0 text-muted-foreground/70" />
-          <div className="min-w-0 flex-1">
-            <div className="flex min-w-0 items-baseline gap-1.5">
-              <span className="min-w-0 truncate">{folder.primaryLabel}</span>
-              {folder.secondaryLabel ? (
-                <span className="min-w-0 truncate text-muted-foreground/60 text-xs">
-                  {folder.secondaryLabel}
-                </span>
-              ) : null}
-            </div>
-          </div>
+          <FolderClosed className={PICKER_PANEL_ROW_ICON_CLASS_NAME} />
+          <span className="min-w-0 truncate">{folder.primaryLabel}</span>
+          {folder.secondaryLabel ? (
+            <span className="min-w-0 truncate text-muted-foreground/60 text-xs">
+              {folder.secondaryLabel}
+            </span>
+          ) : null}
         </div>
       </ComboboxItem>
     );
@@ -650,13 +646,15 @@ export const ProjectPicker = memo(function ProjectPicker({
       )}
       <ComboboxPopup align={align} side={side} className="p-0">
         <PickerPanelShell
+          variant="plain"
+          widthClassName="w-60"
           searchInput={
             <ComboboxInput
-              className="rounded-md border-border/60 bg-background shadow-none before:hidden has-focus-visible:border-neutral-500/15 has-focus-visible:ring-0 [&_input]:font-sans"
-              inputClassName="ring-0"
+              inputClassName={PICKER_PANEL_PLAIN_SEARCH_INPUT_CLASS_NAME}
               placeholder={searchPlaceholder}
               showTrigger={false}
               size="sm"
+              unstyled
               value={query}
               onChange={(event) => setQuery(event.target.value)}
             />
@@ -666,13 +664,13 @@ export const ProjectPicker = memo(function ProjectPicker({
               <button
                 type="button"
                 className={cn(
-                  PICKER_FOOTER_ACTION_CLASS_NAME,
+                  PICKER_PANEL_ACTION_ROW_CLASS_NAME,
                   "disabled:cursor-not-allowed disabled:opacity-60",
                 )}
                 onClick={() => void handleAddNewProject()}
                 disabled={isPicking}
               >
-                <PlusIcon className="size-3.5 shrink-0 text-muted-foreground/70" />
+                <PlusIcon className={PICKER_PANEL_ROW_ICON_CLASS_NAME} />
                 <span className="truncate">
                   {isPicking ? loadingAddProjectLabel : addProjectLabel}
                 </span>
@@ -680,10 +678,10 @@ export const ProjectPicker = memo(function ProjectPicker({
               {shouldShowResetToHome ? (
                 <button
                   type="button"
-                  className={PICKER_FOOTER_ACTION_CLASS_NAME}
+                  className={PICKER_PANEL_ACTION_ROW_CLASS_NAME}
                   onClick={handleResetToHome}
                 >
-                  <XIcon className="size-3.5 shrink-0 text-muted-foreground/70" />
+                  <XIcon className={PICKER_PANEL_ROW_ICON_CLASS_NAME} />
                   <span className="truncate">{resetActionLabel}</span>
                 </button>
               ) : null}
@@ -709,7 +707,12 @@ export const ProjectPicker = memo(function ProjectPicker({
                 <Fragment key={group.key}>
                   {groupIndex > 0 ? <ComboboxSeparator /> : null}
                   <ComboboxGroup>
-                    <ComboboxGroupLabel className="flex items-center gap-1.5">
+                    <ComboboxGroupLabel
+                      className={cn(
+                        PICKER_PANEL_GROUP_LABEL_CLASS_NAME,
+                        "flex items-center gap-1.5",
+                      )}
+                    >
                       <SpaceIcon icon={group.icon} className="size-3 shrink-0" />
                       <span className="min-w-0 truncate">{group.label}</span>
                     </ComboboxGroupLabel>
@@ -725,7 +728,9 @@ export const ProjectPicker = memo(function ProjectPicker({
             ) : null}
             {filteredLocalFolderOptions.length > 0 ? (
               <ComboboxGroup>
-                <ComboboxGroupLabel>{localFoldersGroupLabel}</ComboboxGroupLabel>
+                <ComboboxGroupLabel className={PICKER_PANEL_GROUP_LABEL_CLASS_NAME}>
+                  {localFoldersGroupLabel}
+                </ComboboxGroupLabel>
                 {filteredLocalFolderOptions.map(({ absolutePath, entry }, index) => (
                   <ComboboxItem
                     hideIndicator={absolutePath !== selectedWorkspaceRoot}
@@ -733,12 +738,13 @@ export const ProjectPicker = memo(function ProjectPicker({
                     index={filteredActiveFolderOptions.length + index}
                     value={absolutePath}
                     className={cn(
+                      PICKER_PANEL_ROW_GEOMETRY_CLASS_NAME,
                       absolutePath === selectedWorkspaceRoot &&
-                        "bg-[var(--color-background-elevated-secondary)] text-[var(--color-text-foreground)]",
+                        PICKER_PANEL_ROW_SELECTED_CLASS_NAME,
                     )}
                   >
                     <div className="flex min-w-0 items-center gap-2">
-                      <FolderClosed className="size-3.5 shrink-0 text-muted-foreground/70" />
+                      <FolderClosed className={PICKER_PANEL_ROW_ICON_CLASS_NAME} />
                       <span className="truncate">{entry.name}</span>
                     </div>
                   </ComboboxItem>

--- a/apps/web/src/components/chat/ProjectPicker.tsx
+++ b/apps/web/src/components/chat/ProjectPicker.tsx
@@ -644,10 +644,12 @@ export const ProjectPicker = memo(function ProjectPicker({
           ) : null}
         </div>
       )}
-      <ComboboxPopup align={align} side={side} className="p-0">
+      {/* Width lives on the popup so the shell always fills it: the surface grows to a wide
+          trigger (`--anchor-width`) and never leaves an empty strip beside the rows. */}
+      <ComboboxPopup align={align} side={side} className="min-w-60 p-0">
         <PickerPanelShell
           variant="plain"
-          widthClassName="w-60"
+          widthClassName="w-full"
           searchInput={
             <ComboboxInput
               inputClassName={PICKER_PANEL_PLAIN_SEARCH_INPUT_CLASS_NAME}

--- a/apps/web/src/components/chat/composerPickerStyles.ts
+++ b/apps/web/src/components/chat/composerPickerStyles.ts
@@ -28,7 +28,13 @@ export const COMPOSER_TOOLBAR_CAPSULE_HOVER_CLASS_NAME =
 
 export const COMPOSER_FOLDER_PICKER_CAPSULE_HOVER_CLASS_NAME = `${COMPOSER_TOOLBAR_CAPSULE_HOVER_CLASS_NAME} group-hover/project-picker-trigger:bg-[var(--color-background-button-secondary-hover)]`;
 
-export const COMPOSER_TOOLBAR_PICKER_TRIGGER_CLASS_NAME = `inline-flex cursor-pointer items-center gap-1.5 px-2 py-1 ${COMPOSER_TOOLBAR_CAPSULE_HOVER_CLASS_NAME} ${COMPOSER_PICKER_TRIGGER_TEXT_CLASS_NAME}`;
+/** Primary-text variant of the picker trigger typography for the composer toolbar tray
+ *  (project chip, environment, branch, temporary): these read as the thread's headline
+ *  context, so they sit on the primary foreground rather than the secondary picker tone. */
+export const COMPOSER_TOOLBAR_TRIGGER_TEXT_CLASS_NAME =
+  "text-[length:var(--app-font-size-ui-sm,11px)] text-[var(--color-text-foreground)] sm:text-[length:var(--app-font-size-ui-sm,11px)] font-normal";
+
+export const COMPOSER_TOOLBAR_PICKER_TRIGGER_CLASS_NAME = `inline-flex cursor-pointer items-center gap-1.5 px-2 py-1 ${COMPOSER_TOOLBAR_CAPSULE_HOVER_CLASS_NAME} ${COMPOSER_TOOLBAR_TRIGGER_TEXT_CLASS_NAME}`;
 
 /** Caps model-provider submenu height; pairs with the list scroll class below. */
 export const COMPOSER_PICKER_MODEL_SUBMENU_HEIGHT_CLASS_NAME =
@@ -50,10 +56,10 @@ export const COMPOSER_PICKER_MODEL_LIST_MAX_HEIGHT_CLASS_NAME =
 export const COMPOSER_PICKER_MODEL_LIST_SCROLL_CLASS_NAME = "composer-picker-scroll";
 
 /** Corner radius for picker panel chrome and panel-level surfaces. */
-export const COMPOSER_PICKER_RADIUS_CLASS_NAME = "rounded-[0.65rem]";
+export const COMPOSER_PICKER_RADIUS_CLASS_NAME = "rounded-[0.875rem]";
 
 /** Tighter corner radius for option rows / selection pills inside picker panels. */
-export const COMPOSER_PICKER_OPTION_RADIUS_CLASS_NAME = "rounded-[0.5rem]";
+export const COMPOSER_PICKER_OPTION_RADIUS_CLASS_NAME = "rounded-[0.625rem]";
 
 /** Collapsible section headers inside model provider lists. */
 export const COMPOSER_PICKER_MODEL_GROUP_HEADER_CLASS_NAME = `grid w-full grid-cols-[0.75rem_minmax(0,1fr)_2.5rem] items-center gap-x-1.5 ${COMPOSER_PICKER_RADIUS_CLASS_NAME} px-2 py-1 text-left text-[10px] font-medium text-muted-foreground/80 outline-none transition-colors hover:bg-[color-mix(in_srgb,var(--foreground)_4%,transparent)] focus-visible:ring-0`;
@@ -230,8 +236,7 @@ export const COMPOSER_COMMAND_MENU_INLINE_WRAPPER_CLASS_NAME =
  *  Highlight tints the surface darker (button-secondary), matching every other
  *  composer picker. The `elevated-secondary-opaque` token lightens toward white,
  *  which is invisible on the near-white popover surface, so it is not used here. */
-export const COMPOSER_COMMAND_MENU_ITEM_CLASS_NAME =
-  "flex cursor-pointer select-none items-center gap-2 rounded-md px-2.5 py-1 transition-colors hover:bg-[var(--color-background-button-secondary-hover)] data-highlighted:bg-[var(--color-background-button-secondary-hover)]";
+export const COMPOSER_COMMAND_MENU_ITEM_CLASS_NAME = `flex cursor-pointer select-none items-center gap-2 ${COMPOSER_PICKER_OPTION_RADIUS_CLASS_NAME} px-2.5 py-1 transition-colors hover:bg-[var(--color-background-button-secondary-hover)] data-highlighted:bg-[var(--color-background-button-secondary-hover)]`;
 
 /** Active command menu row — keyboard-selected pill fill. */
 export const COMPOSER_COMMAND_MENU_ITEM_ACTIVE_CLASS_NAME =

--- a/apps/web/src/components/chat/pickerPanelStyles.ts
+++ b/apps/web/src/components/chat/pickerPanelStyles.ts
@@ -1,0 +1,54 @@
+// FILE: pickerPanelStyles.ts
+// Purpose: Class tokens for the dense ("plain") PickerPanelShell variant — the borderless
+//          search row, thin option rows, quiet group labels, and footer action rows.
+// Layer: Chat picker UI styling helper
+// Depends on: radius / scroll tokens from composerPickerStyles, hover token from surfaceStyles.
+//
+// Kept separate from composerPickerStyles.ts on purpose: those tokens describe the composer's
+// own popup chrome, while these describe the panel *inside* a picker popup (search + rows), so
+// any picker panel can opt into the same density without pulling in composer chrome.
+
+import { ELEVATED_HOVER_SURFACE_CLASS_NAME } from "~/surfaceStyles";
+import {
+  COMPOSER_PICKER_MODEL_LIST_SCROLL_CLASS_NAME,
+  COMPOSER_PICKER_OPTION_RADIUS_CLASS_NAME,
+} from "./composerPickerStyles";
+
+/**
+ * Search row of a plain picker panel: no field chrome at all — a leading magnifier, the
+ * transparent input, and a single hairline separating it from the list below.
+ */
+export const PICKER_PANEL_PLAIN_SEARCH_HEADER_CLASS_NAME =
+  "sticky top-0 z-20 flex shrink-0 items-center gap-2 border-b border-border bg-transparent px-2.5 py-0 *:min-w-0";
+
+/** Leading magnifier in the plain search row. */
+export const PICKER_PANEL_PLAIN_SEARCH_ICON_CLASS_NAME =
+  "size-3.5 shrink-0 text-muted-foreground/55";
+
+/**
+ * Transparent, borderless search field for the plain search row. Pair with the `unstyled`
+ * Input prop so no border/ring/fill is emitted; the child selector strips the field's own
+ * horizontal padding because the magnifier already owns the left gutter.
+ */
+export const PICKER_PANEL_PLAIN_SEARCH_INPUT_CLASS_NAME =
+  "flex min-h-8 w-full items-center bg-transparent shadow-none [&>[data-slot=input]]:px-0 [&>[data-slot=input]]:placeholder:text-muted-foreground/55";
+
+/** Row height, padding, gap, and radius shared by plain option rows and footer action rows. */
+export const PICKER_PANEL_ROW_GEOMETRY_CLASS_NAME = `min-h-7 gap-2 px-1.5 py-0.5 sm:min-h-7 ${COMPOSER_PICKER_OPTION_RADIUS_CLASS_NAME}`;
+
+/** Leading icon (folder, plus, dismiss) inside a plain picker row. */
+export const PICKER_PANEL_ROW_ICON_CLASS_NAME = "size-3.5 shrink-0 text-muted-foreground/70";
+
+/** Subtle fill marking the currently selected option row. */
+export const PICKER_PANEL_ROW_SELECTED_CLASS_NAME =
+  "bg-[var(--color-background-elevated-secondary)] text-[var(--color-text-foreground)]";
+
+/** Quiet section header above a plain picker list group. */
+export const PICKER_PANEL_GROUP_LABEL_CLASS_NAME =
+  "px-1.5 py-1 font-normal text-muted-foreground/60 text-xs";
+
+/** Full-width action row in a picker footer (add project, reset to home). */
+export const PICKER_PANEL_ACTION_ROW_CLASS_NAME = `flex w-full items-center text-left text-sm ${PICKER_PANEL_ROW_GEOMETRY_CLASS_NAME} ${ELEVATED_HOVER_SURFACE_CLASS_NAME} hover:text-[var(--color-text-foreground)]`;
+
+/** Scroll chrome for the plain panel body; list chrome supplies its own 4px padding. */
+export const PICKER_PANEL_PLAIN_BODY_CLASS_NAME = COMPOSER_PICKER_MODEL_LIST_SCROLL_CLASS_NAME;

--- a/apps/web/src/components/ui/combobox.tsx
+++ b/apps/web/src/components/ui/combobox.tsx
@@ -7,7 +7,11 @@ import * as React from "react";
 import { cn } from "~/lib/utils";
 import { Input } from "~/components/ui/input";
 import { ScrollArea } from "~/components/ui/scroll-area";
-import { APP_TRANSLUCENT_POPUP_SURFACE_BASE_CLASS_NAME } from "../chat/composerPickerStyles";
+import {
+  APP_TRANSLUCENT_POPUP_SURFACE_BASE_CLASS_NAME,
+  COMPOSER_PICKER_OPTION_RADIUS_CLASS_NAME,
+  COMPOSER_PICKER_RADIUS_CLASS_NAME,
+} from "../chat/composerPickerStyles";
 
 const ComboboxContext = React.createContext<{
   chipsRef: React.RefObject<Element | null> | null;
@@ -61,6 +65,7 @@ function ComboboxInput({
   showClear: showClearProp,
   startAddon,
   size,
+  unstyled: unstyledProp,
   ...props
 }: Omit<ComboboxPrimitive.Input.Props, "size"> & {
   inputClassName?: string;
@@ -68,10 +73,13 @@ function ComboboxInput({
   showClear?: boolean;
   startAddon?: React.ReactNode;
   size?: "sm" | "default" | "lg" | number;
+  /** Drops the field chrome (border, fill, ring) — for search rows that are only a divider. */
+  unstyled?: boolean;
   ref?: React.Ref<HTMLInputElement>;
 }) {
   const showTrigger = showTriggerProp ?? true;
   const showClear = showClearProp ?? false;
+  const unstyled = unstyledProp ?? false;
   const sizeValue = (size ?? "default") as "sm" | "default" | "lg" | number;
 
   return (
@@ -100,6 +108,7 @@ function ComboboxInput({
             className={cn("has-disabled:opacity-100", inputClassName)}
             nativeInput
             size={sizeValue}
+            unstyled={unstyled}
           />
         }
         {...props}
@@ -174,7 +183,8 @@ function ComboboxPopup({
         <span
           className={cn(
             APP_TRANSLUCENT_POPUP_SURFACE_BASE_CLASS_NAME,
-            "relative flex max-h-full min-w-(--anchor-width) max-w-(--available-width) origin-(--transform-origin) rounded-lg not-dark:bg-clip-padding shadow-lg/5 transition-[scale,opacity]",
+            "relative flex max-h-full min-w-(--anchor-width) max-w-(--available-width) origin-(--transform-origin) not-dark:bg-clip-padding shadow-lg/5 transition-[scale,opacity]",
+            COMPOSER_PICKER_RADIUS_CLASS_NAME,
             className,
           )}
         >
@@ -203,7 +213,7 @@ function ComboboxItem({
   return (
     <ComboboxPrimitive.Item
       className={cn(
-        "grid min-h-[1.625rem] in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)] cursor-default grid-cols-[1fr_auto] items-center gap-3 rounded-lg px-2.5 py-px text-base text-[var(--color-text-foreground)] outline-none data-disabled:pointer-events-none data-highlighted:bg-[var(--color-background-button-secondary-hover)] data-highlighted:text-[var(--color-text-foreground)] data-disabled:opacity-64 sm:min-h-6 sm:text-sm [&_svg:not([class*='size-'])]:size-3 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        `grid min-h-[1.625rem] in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)] cursor-default grid-cols-[1fr_auto] items-center gap-3 ${COMPOSER_PICKER_OPTION_RADIUS_CLASS_NAME} px-2.5 py-px text-base text-[var(--color-text-foreground)] outline-none data-disabled:pointer-events-none data-highlighted:bg-[var(--color-background-button-secondary-hover)] data-highlighted:text-[var(--color-text-foreground)] data-disabled:opacity-64 sm:min-h-6 sm:text-sm [&_svg:not([class*='size-'])]:size-3 [&_svg]:pointer-events-none [&_svg]:shrink-0`,
         className,
       )}
       data-slot="combobox-item"

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -13,6 +13,7 @@ import {
   COMPOSER_PICKER_MENU_POPUP_BODY_CLASS_NAME,
   COMPOSER_PICKER_MENU_POPUP_VIEWPORT_CLASS_NAME,
   COMPOSER_PICKER_MENU_SURFACE_CLASS_NAME,
+  COMPOSER_PICKER_OPTION_RADIUS_CLASS_NAME,
   COMPOSER_PICKER_SELECT_OPTION_CLASS_NAME,
   COMPOSER_SURFACE_SHADOW_CLASS_NAME,
 } from "../chat/composerPickerStyles";
@@ -25,8 +26,7 @@ const Select = SelectPrimitive.Root;
 // purpose — do not add it back.
 type SelectPopupSurface = "composer" | "settings";
 
-const settingsSelectOptionClassName =
-  "[&>svg]:-mx-0.5 flex cursor-default select-none items-center rounded-lg text-[length:var(--app-font-size-ui,12px)] text-[var(--color-text-foreground)] outline-none data-disabled:pointer-events-none data-highlighted:bg-[var(--color-background-button-secondary-hover)] data-highlighted:text-[var(--color-text-foreground)] data-disabled:opacity-64 [&>svg:not([class*='opacity-'])]:opacity-80 [&>svg]:pointer-events-none [&>svg]:shrink-0 grid in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)]";
+const settingsSelectOptionClassName = `[&>svg]:-mx-0.5 flex cursor-default select-none items-center ${COMPOSER_PICKER_OPTION_RADIUS_CLASS_NAME} text-[length:var(--app-font-size-ui,12px)] text-[var(--color-text-foreground)] outline-none data-disabled:pointer-events-none data-highlighted:bg-[var(--color-background-button-secondary-hover)] data-highlighted:text-[var(--color-text-foreground)] data-disabled:opacity-64 [&>svg:not([class*='opacity-'])]:opacity-80 [&>svg]:pointer-events-none [&>svg]:shrink-0 grid in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)]`;
 
 const SelectPopupSurfaceContext = React.createContext<SelectPopupSurface>("composer");
 


### PR DESCRIPTION
## What Changed

- Refined project picker menus with denser rows, quieter group labels, updated selection states, and shared styling tokens.
- Added a plain, borderless search variant for picker panels.
- Updated combobox and select popup radii and option styling for consistency.
- Improved composer toolbar typography and full-width empty-landing controls.
- Renamed the branch environment menu terminology from “Continue in” to “Work in”.

## Why

These changes make project and environment pickers more compact and visually consistent with the composer, while improving hierarchy, spacing, search affordances, and shared styling reuse.

## UI Changes

Updated project picker menus, composer controls, and the “Work in” environment menu. No screenshots or video are included.

## Verification

No verification results were provided.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and copy changes to picker/combobox UI and environment menu labeling; no auth, data, or API behavior changes.
> 
> **Overview**
> Renames the branch environment menu from **“Continue in”** to **“Work in”** (`WorkInMenuItem`, group label, and related comments).
> 
> Introduces a **dense “plain” picker panel** via new `pickerPanelStyles` tokens and a `variant="plain"` on `PickerPanelShell`: borderless search row (magnifier + hairline divider), tighter list body padding, and shared row/selection/group/footer styling. **Project picker** adopts this variant, centralizes row chrome on those tokens, flattens folder row layout, and sets the combobox popup to `min-w-60` with a full-width shell so the panel tracks the trigger.
> 
> **Composer picker radii** bump (`COMPOSER_PICKER_RADIUS_CLASS_NAME` / option radius) and propagate through combobox popups/items, select options, and command menu rows. **`ComboboxInput`** gains an **`unstyled`** prop (passed through to `Input`) for borderless search fields in plain panels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03368a072a20f913d120a0ab474e53af12069c51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->