### PR TITLE
Add asynchronous Codex user-input round trips

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -2156,6 +2156,35 @@ describe("sendTurn", () => {
 });
 
 describe("steerTurn", () => {
+  it("starts a turn when a late answer arrives after the originating turn ended", async () => {
+    const { manager, sendRequest } = createSendTurnHarness();
+    sendRequest.mockResolvedValueOnce({ turn: { id: "answer-turn" } });
+    await manager.steerTurn({ threadId: asThreadId("thread_1"), input: "My answer" });
+    expect(sendRequest).toHaveBeenCalledWith(expect.anything(), "turn/start", expect.objectContaining({
+      input: [{ type: "text", text: "My answer", text_elements: [] }],
+    }));
+  });
+
+  it("safely starts a turn if Codex explicitly rejects a steer after turn completion", async () => {
+    const { manager, context, sendRequest } = createSendTurnHarness();
+    context.session.status = "running";
+    context.session.activeTurnId = "turn_active";
+    sendRequest.mockRejectedValueOnce(new Error("turn/steer failed: no active turn to steer"));
+    sendRequest.mockResolvedValueOnce({ turn: { id: "answer-turn" } });
+    const result = await manager.steerTurn({ threadId: asThreadId("thread_1"), input: "My answer" });
+    expect(result.turnId).toBe("answer-turn");
+    expect(sendRequest.mock.calls.map((call) => call[1])).toEqual(["turn/steer", "turn/start"]);
+  });
+
+  it("does not resend an answer after ambiguous delivery failure", async () => {
+    const { manager, context, sendRequest } = createSendTurnHarness();
+    context.session.status = "running";
+    context.session.activeTurnId = "turn_active";
+    sendRequest.mockRejectedValueOnce(new Error("Timed out waiting for turn/steer."));
+    await expect(manager.steerTurn({ threadId: asThreadId("thread_1"), input: "My answer" })).rejects.toThrow("Timed out");
+    expect(sendRequest).toHaveBeenCalledTimes(1);
+  });
+
   it("steers the active Codex turn when the session is already running", async () => {
     const { manager, context, sendRequest } = createSendTurnHarness();
     context.session.status = "running";

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -2156,6 +2156,17 @@ describe("sendTurn", () => {
 });
 
 describe("steerTurn", () => {
+  it.each(["review", "compact"])("returns a definitive rejection for a %s turn", async (kind) => {
+    const { manager, context, sendRequest } = createSendTurnHarness();
+    context.session.status = "running";
+    context.session.activeTurnId = "turn_active";
+    sendRequest.mockRejectedValueOnce(new Error(`turn/steer failed: cannot steer a ${kind} turn`));
+    await expect(
+      manager.steerTurn({ threadId: asThreadId("thread_1"), input: "My answer" }),
+    ).rejects.toMatchObject({ name: "CodexTurnNotSteerableError" });
+    expect(sendRequest.mock.calls.map((call) => call[1])).toEqual(["turn/steer"]);
+  });
+
   it("returns control to the reactor when the originating turn already ended", async () => {
     const { manager, sendRequest } = createSendTurnHarness();
     await expect(

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -2156,24 +2156,23 @@ describe("sendTurn", () => {
 });
 
 describe("steerTurn", () => {
-  it("starts a turn when a late answer arrives after the originating turn ended", async () => {
+  it("returns control to the reactor when the originating turn already ended", async () => {
     const { manager, sendRequest } = createSendTurnHarness();
-    sendRequest.mockResolvedValueOnce({ turn: { id: "answer-turn" } });
-    await manager.steerTurn({ threadId: asThreadId("thread_1"), input: "My answer" });
-    expect(sendRequest).toHaveBeenCalledWith(expect.anything(), "turn/start", expect.objectContaining({
-      input: [{ type: "text", text: "My answer", text_elements: [] }],
-    }));
+    await expect(
+      manager.steerTurn({ threadId: asThreadId("thread_1"), input: "My answer" }),
+    ).rejects.toMatchObject({ name: "CodexTurnNotActiveError" });
+    expect(sendRequest).not.toHaveBeenCalled();
   });
 
-  it("safely starts a turn if Codex explicitly rejects a steer after turn completion", async () => {
+  it("returns an explicit steer rejection without starting an unprepared turn", async () => {
     const { manager, context, sendRequest } = createSendTurnHarness();
     context.session.status = "running";
     context.session.activeTurnId = "turn_active";
     sendRequest.mockRejectedValueOnce(new Error("turn/steer failed: no active turn to steer"));
-    sendRequest.mockResolvedValueOnce({ turn: { id: "answer-turn" } });
-    const result = await manager.steerTurn({ threadId: asThreadId("thread_1"), input: "My answer" });
-    expect(result.turnId).toBe("answer-turn");
-    expect(sendRequest.mock.calls.map((call) => call[1])).toEqual(["turn/steer", "turn/start"]);
+    await expect(
+      manager.steerTurn({ threadId: asThreadId("thread_1"), input: "My answer" }),
+    ).rejects.toMatchObject({ name: "CodexTurnNotActiveError" });
+    expect(sendRequest.mock.calls.map((call) => call[1])).toEqual(["turn/steer"]);
   });
 
   it("does not resend an answer after ambiguous delivery failure", async () => {
@@ -2181,7 +2180,9 @@ describe("steerTurn", () => {
     context.session.status = "running";
     context.session.activeTurnId = "turn_active";
     sendRequest.mockRejectedValueOnce(new Error("Timed out waiting for turn/steer."));
-    await expect(manager.steerTurn({ threadId: asThreadId("thread_1"), input: "My answer" })).rejects.toThrow("Timed out");
+    await expect(
+      manager.steerTurn({ threadId: asThreadId("thread_1"), input: "My answer" }),
+    ).rejects.toThrow("Timed out");
     expect(sendRequest).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -569,6 +569,8 @@ Your active mode changes only when new developer instructions with a different \
 The \`request_user_input\` tool is unavailable in Default mode. If you call it while in Default mode, it will return an error.
 
 In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, ask the user directly with a concise plain-text question. Never write a multiple choice question as a textual assistant message.
+
+When \`request_user_input_async\` is available, use it to ask for missing context or preferences while continuing independent work. The user can answer the inline question later, including after this turn ends. A pending question is not an answer or approval. If the tool is unavailable, ask in ordinary text.
 </collaboration_mode>${CODEX_BROWSER_TOOL_ROUTING_INSTRUCTIONS}\n\n${SYNARA_GATEWAY_HARNESS_POLICY}`;
 
 // Maps Synara's simple runtime toggle to Codex thread-level permission overrides.
@@ -1435,11 +1437,22 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       throw new Error("Session is missing provider resume thread id.");
     }
 
-    const response = await this.sendRequest(context, "turn/steer", {
-      threadId: providerThreadId,
-      input: turnInput,
-      expectedTurnId: activeTurnId,
-    });
+    let response: unknown;
+    try {
+      response = await this.sendRequest(context, "turn/steer", {
+        threadId: providerThreadId,
+        input: turnInput,
+        expectedTurnId: activeTurnId,
+      });
+    } catch (error) {
+      // The turn may finish between our live-state check and Codex accepting the
+      // steer. Only this explicit rejection proves the input was not submitted;
+      // a timeout or transport failure must never trigger a duplicate send.
+      if (error instanceof Error && error.message === "turn/steer failed: no active turn to steer") {
+        return this.sendTurn(input);
+      }
+      throw error;
+    }
 
     const turnIdRaw = this.readString(this.readObject(response), "turnId");
     if (!turnIdRaw) {

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -59,6 +59,7 @@ import {
 import {
   CodexSessionStartError,
   CodexTurnNotActiveError,
+  CodexTurnNotSteerableError,
   isNonFatalCodexErrorMessage,
 } from "./codexErrorClassification.ts";
 import { buildCodexProcessEnv } from "./codexProcessEnv.ts";
@@ -1458,6 +1459,13 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         error.message === "turn/steer failed: no active turn to steer"
       ) {
         throw new CodexTurnNotActiveError(error.message, { cause: error });
+      }
+      if (
+        error instanceof Error &&
+        (error.message === "turn/steer failed: cannot steer a review turn" ||
+          error.message === "turn/steer failed: cannot steer a compact turn")
+      ) {
+        throw new CodexTurnNotSteerableError(error.message, { cause: error });
       }
       throw error;
     }

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -56,7 +56,11 @@ import {
   AGENT_GATEWAY_TURN_AUTHORITY_RETIRED,
   type AgentGatewaySessionLease,
 } from "./agentGateway/sessionLease.ts";
-import { CodexSessionStartError, isNonFatalCodexErrorMessage } from "./codexErrorClassification.ts";
+import {
+  CodexSessionStartError,
+  CodexTurnNotActiveError,
+  isNonFatalCodexErrorMessage,
+} from "./codexErrorClassification.ts";
 import { buildCodexProcessEnv } from "./codexProcessEnv.ts";
 import { assertCodexWorkingDirectoryExists } from "./codexWorkingDirectory.ts";
 import { executableIdentity, resolveExecutable } from "./executableLookup.ts";
@@ -1420,7 +1424,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
 
     const activeTurnId = context.session.activeTurnId;
     if (context.session.status !== "running" || activeTurnId === undefined) {
-      return this.sendTurn(input);
+      throw new CodexTurnNotActiveError("No active Codex turn to steer.");
     }
 
     const turnInput = buildCodexTurnInput(input);
@@ -1448,8 +1452,12 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       // The turn may finish between our live-state check and Codex accepting the
       // steer. Only this explicit rejection proves the input was not submitted;
       // a timeout or transport failure must never trigger a duplicate send.
-      if (error instanceof Error && error.message === "turn/steer failed: no active turn to steer") {
-        return this.sendTurn(input);
+      // The reactor owns replacement turns so their baselines precede execution.
+      if (
+        error instanceof Error &&
+        error.message === "turn/steer failed: no active turn to steer"
+      ) {
+        throw new CodexTurnNotActiveError(error.message, { cause: error });
       }
       throw error;
     }

--- a/apps/server/src/codexErrorClassification.ts
+++ b/apps/server/src/codexErrorClassification.ts
@@ -7,6 +7,11 @@ export class CodexSessionStartError extends Error {
   override readonly name = "CodexSessionStartError";
 }
 
+/** No input was submitted: the caller may prepare and start a replacement turn. */
+export class CodexTurnNotActiveError extends Error {
+  override readonly name = "CodexTurnNotActiveError";
+}
+
 const NON_FATAL_CODEX_ERROR_SNIPPETS = [
   "write_stdin failed: stdin is closed for this session",
 ] as const;

--- a/apps/server/src/codexErrorClassification.ts
+++ b/apps/server/src/codexErrorClassification.ts
@@ -12,6 +12,11 @@ export class CodexTurnNotActiveError extends Error {
   override readonly name = "CodexTurnNotActiveError";
 }
 
+/** Review and compaction reject input without submitting it to the model. */
+export class CodexTurnNotSteerableError extends Error {
+  override readonly name = "CodexTurnNotSteerableError";
+}
+
 const NON_FATAL_CODEX_ERROR_SNIPPETS = [
   "write_stdin failed: stdin is closed for this session",
 ] as const;

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
@@ -504,22 +504,31 @@ const makeOrchestrationEngine = Effect.gen(function* () {
     model: OrchestrationReadModel,
     threadId: ThreadId,
   ): Effect.Effect<OrchestrationReadModel, OrchestrationDispatchError> =>
-    projectionSnapshotQuery.getThreadDetailById(threadId).pipe(
-      Effect.map((threadOption) =>
-        Option.match(threadOption, {
-          onNone: () => model,
-          onSome: (thread) => overlayThread(model, thread),
-        }),
-      ),
-      Effect.mapError(
-        (error) =>
-          new OrchestrationCommandInternalError({
-            commandId: command.commandId,
-            commandType: command.type,
-            detail: `Failed to load thread detail for command validation: ${error.message}`,
+    projectionSnapshotQuery
+      .getThreadDetailById(threadId, {
+        ...(command.type === "thread.activity.append" &&
+        command.activity.kind === "user-input.async"
+          ? { includeActivityId: command.activity.id }
+          : command.type === "thread.turn.start" && command.asyncUserInputResponse
+            ? { includeActivityId: command.asyncUserInputResponse.activityId }
+            : {}),
+      })
+      .pipe(
+        Effect.map((threadOption) =>
+          Option.match(threadOption, {
+            onNone: () => model,
+            onSome: (thread) => overlayThread(model, thread),
           }),
-      ),
-    );
+        ),
+        Effect.mapError(
+          (error) =>
+            new OrchestrationCommandInternalError({
+              commandId: command.commandId,
+              commandType: command.type,
+              detail: `Failed to load thread detail for command validation: ${error.message}`,
+            }),
+        ),
+      );
 
   const buildDeciderReadModel = (
     command: OrchestrationCommand,

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
@@ -529,12 +529,19 @@ const makeOrchestrationEngine = Effect.gen(function* () {
       case "thread.fork.create":
         return loadThreadDetailForDecider(command, commandReadModel, command.sourceThreadId);
       case "thread.turn.start":
+        if (command.asyncUserInputResponse) {
+          return loadThreadDetailForDecider(command, commandReadModel, command.threadId);
+        }
         return command.sourceProposedPlan
           ? loadThreadDetailForDecider(
               command,
               commandReadModel,
               command.sourceProposedPlan.threadId,
             )
+          : Effect.succeed(commandReadModel);
+      case "thread.activity.append":
+        return command.activity.kind === "user-input.async"
+          ? loadThreadDetailForDecider(command, commandReadModel, command.threadId)
           : Effect.succeed(commandReadModel);
       case "thread.conversation.rollback":
       case "thread.message.edit-and-resend":

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1,4 +1,5 @@
 import { ApprovalRequestId, CommandId, type OrchestrationEvent } from "@synara/contracts";
+import { reopenAsyncUserInputAfterMessageRemoval } from "@synara/shared/asyncUserInput";
 import {
   addPinnedMessage,
   removePinnedMessage,
@@ -1416,6 +1417,9 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
 
         case "thread.reverted":
         case "thread.conversation-rolled-back": {
+          if (event.type === "thread.conversation-rolled-back" && event.payload.numTurns === 0) {
+            return;
+          }
           const existingRows = yield* projectionThreadActivityRepository.listByThreadId({
             threadId: event.payload.threadId,
           });
@@ -1435,13 +1439,39 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
                   existingRows,
                   new Set(event.payload.removedTurnIds ?? []),
                 );
+          // Message projection runs first. Read only response IDs here rather than
+          // loading the full transcript again to find replies removed by rollback.
+          const removedResponses = keptRows.some((row) => row.kind === "user-input.async")
+            ? yield* sql<{ readonly messageId: string }>`
+                SELECT json_extract(activity.payload_json, '$.response.messageId') AS "messageId"
+                FROM projection_thread_activities AS activity
+                WHERE activity.thread_id = ${event.payload.threadId}
+                  AND activity.kind = 'user-input.async'
+                  AND json_type(activity.payload_json, '$.response.messageId') = 'text'
+                  AND NOT EXISTS (
+                    SELECT 1 FROM projection_thread_messages AS message
+                    WHERE message.thread_id = activity.thread_id
+                      AND message.message_id = json_extract(activity.payload_json, '$.response.messageId')
+                  )
+              `.pipe(
+                Effect.mapError(toPersistenceSqlError("ProjectionPipeline.removedAsyncResponses:query")),
+              )
+            : [];
+          const reconciledRows = reopenAsyncUserInputAfterMessageRemoval(
+            keptRows,
+            new Set(removedResponses.map((row) => row.messageId)),
+          );
           if (keptRows.length === existingRows.length) {
+            yield* Effect.forEach(
+              reconciledRows.filter((row, index) => row !== keptRows[index]),
+              projectionThreadActivityRepository.upsert,
+            );
             return;
           }
           yield* projectionThreadActivityRepository.deleteByThreadId({
             threadId: event.payload.threadId,
           });
-          yield* Effect.forEach(keptRows, projectionThreadActivityRepository.upsert);
+          yield* Effect.forEach(reconciledRows, projectionThreadActivityRepository.upsert);
           return;
         }
 

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1454,7 +1454,9 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
                       AND message.message_id = json_extract(activity.payload_json, '$.response.messageId')
                   )
               `.pipe(
-                Effect.mapError(toPersistenceSqlError("ProjectionPipeline.removedAsyncResponses:query")),
+                Effect.mapError(
+                  toPersistenceSqlError("ProjectionPipeline.removedAsyncResponses:query"),
+                ),
               )
             : [];
           const reconciledRows = reopenAsyncUserInputAfterMessageRemoval(

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -1190,6 +1190,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           WHERE ${liveThreadScope}
         ) AS ranked
         WHERE activity_rank <= ${MAX_SNAPSHOT_THREAD_ACTIVITIES}
+          OR kind = 'user-input.async'
           OR (
             kind IN ('approval.requested', 'user-input.requested')
             AND json_extract(payload_json, '$.requestId') IS NOT NULL
@@ -1807,6 +1808,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                 AND (SELECT has_newer_turn FROM cutoff_turn_state)
               )
             )
+            OR kind = 'user-input.async'
             OR (
               kind IN ('approval.requested', 'user-input.requested')
               AND json_extract(payload_json, '$.requestId') IS NOT NULL

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -1,5 +1,6 @@
 import {
   CheckpointRef,
+  EventId,
   IsoDateTime,
   MessageId,
   NonNegativeInt,
@@ -1190,7 +1191,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           WHERE ${liveThreadScope}
         ) AS ranked
         WHERE activity_rank <= ${MAX_SNAPSHOT_THREAD_ACTIVITIES}
-          OR kind = 'user-input.async'
+          OR (kind = 'user-input.async' AND json_type(payload_json, '$.response') IS NULL)
           OR (
             kind IN ('approval.requested', 'user-input.requested')
             AND json_extract(payload_json, '$.requestId') IS NOT NULL
@@ -1719,9 +1720,9 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
   });
 
   const listThreadActivityRowsByThread = SqlSchema.findAll({
-    Request: ThreadIdLookupInput,
+    Request: Schema.Struct({ threadId: ThreadId, includeActivityId: Schema.optional(EventId) }),
     Result: ProjectionThreadActivityDbRowSchema,
-    execute: ({ threadId }) =>
+    execute: ({ threadId, includeActivityId }) =>
       sql`
         WITH ranked AS (
           SELECT
@@ -1808,7 +1809,8 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                 AND (SELECT has_newer_turn FROM cutoff_turn_state)
               )
             )
-            OR kind = 'user-input.async'
+            OR activity_id = ${includeActivityId ?? null}
+            OR (kind = 'user-input.async' AND json_type(payload_json, '$.response') IS NULL)
             OR (
               kind IN ('approval.requested', 'user-input.requested')
               AND json_extract(payload_json, '$.requestId') IS NOT NULL
@@ -2911,7 +2913,11 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
   // transaction (the single shared connection stays blocked for its duration).
   const loadThreadDetailRaw = (
     threadId: ThreadId,
-    options: { readonly messageLimit: number | null; readonly tracePrefix: string } = {
+    options: {
+      readonly messageLimit: number | null;
+      readonly tracePrefix: string;
+      readonly includeActivityId?: EventId;
+    } = {
       messageLimit: MAX_THREAD_MESSAGES,
       tracePrefix: "ProjectionSnapshotQuery.getThreadDetailById",
     },
@@ -2969,7 +2975,10 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             ),
           ),
         ),
-        listThreadActivityRowsByThread({ threadId }).pipe(
+        listThreadActivityRowsByThread({
+          threadId,
+          ...(options.includeActivityId ? { includeActivityId: options.includeActivityId } : {}),
+        }).pipe(
           Effect.mapError(
             toPersistenceSqlOrDecodeError(
               `${options.tracePrefix}:listActivities:query`,
@@ -3035,7 +3044,11 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
 
   const loadThreadDetail = (
     threadId: ThreadId,
-    options: { readonly messageLimit: number | null; readonly tracePrefix: string } = {
+    options: {
+      readonly messageLimit: number | null;
+      readonly tracePrefix: string;
+      readonly includeActivityId?: EventId;
+    } = {
       messageLimit: MAX_THREAD_MESSAGES,
       tracePrefix: "ProjectionSnapshotQuery.getThreadDetailById",
     },
@@ -3053,15 +3066,26 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
       ),
     );
 
-  const getThreadDetailById: ProjectionSnapshotQueryShape["getThreadDetailById"] = (threadId) =>
-    sql.withTransaction(loadThreadDetail(threadId)).pipe(
-      Effect.mapError((error) => {
-        if (isPersistenceError(error)) {
-          return error;
-        }
-        return toPersistenceSqlError("ProjectionSnapshotQuery.getThreadDetailById:query")(error);
-      }),
-    );
+  const getThreadDetailById: ProjectionSnapshotQueryShape["getThreadDetailById"] = (
+    threadId,
+    options,
+  ) =>
+    sql
+      .withTransaction(
+        loadThreadDetail(threadId, {
+          messageLimit: MAX_THREAD_MESSAGES,
+          tracePrefix: "ProjectionSnapshotQuery.getThreadDetailById",
+          ...options,
+        }),
+      )
+      .pipe(
+        Effect.mapError((error) => {
+          if (isPersistenceError(error)) {
+            return error;
+          }
+          return toPersistenceSqlError("ProjectionSnapshotQuery.getThreadDetailById:query")(error);
+        }),
+      );
 
   const getThreadDetailForExportById: ProjectionSnapshotQueryShape["getThreadDetailForExportById"] =
     (threadId) =>

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -8681,6 +8681,64 @@ describe("ProviderCommandReactor", () => {
     },
   );
 
+  it("queues a definitively rejected Codex steer until the blocking turn settles", async () => {
+    const harness = await createHarness();
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const turnId = asTurnId("review-turn");
+    harness.setRuntimeSessionTurnState({ threadId, status: "running", activeTurnId: turnId });
+    harness.steerTurn.mockImplementationOnce(() =>
+      Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: "codex",
+          method: "turn/steer",
+          detail: "cannot steer a review turn",
+          reason: "turn-not-steerable",
+        }),
+      ),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("answer-during-review"),
+        threadId,
+        message: {
+          messageId: asMessageId("async-answer"),
+          role: "user",
+          text: "My answer",
+          attachments: [],
+        },
+        dispatchMode: "steer",
+        runtimeMode: "approval-required",
+        interactionMode: "default",
+        createdAt: new Date().toISOString(),
+      }),
+    );
+    await waitFor(() => harness.steerTurn.mock.calls.length === 1);
+    await harness.drain();
+    expect(harness.sendTurn).not.toHaveBeenCalled();
+    expect(harness.interruptTurn).not.toHaveBeenCalled();
+    const model = await Effect.runPromise(harness.engine.getReadModel());
+    expect(
+      model.threads[0]?.activities.some(
+        (activity) => activity.kind === "provider.turn.start.failed",
+      ),
+    ).toBe(false);
+    harness.setRuntimeSessionTurnState({ threadId, status: "ready" });
+    await harness.emitRuntimeEvent({
+      type: "turn.completed",
+      eventId: asEventId("review-finished"),
+      provider: "codex",
+      threadId,
+      turnId,
+      createdAt: new Date().toISOString(),
+      payload: { state: "completed" },
+      providerRefs: {},
+    });
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({ threadId, input: "My answer" });
+    expect(harness.steerTurn).toHaveBeenCalledTimes(1);
+  });
+
   it("steers a running claude turn natively without interrupting it", async () => {
     const harness = await createHarness({
       threadModelSelection: {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -405,7 +405,7 @@ describe("ProviderCommandReactor", () => {
         runtimeSessions.push(next);
       }
     };
-    const steerTurn = vi.fn((_: unknown) =>
+    const steerTurn = vi.fn<ProviderServiceShape["steerTurn"]>((_: unknown) =>
       Effect.succeed({
         threadId: ThreadId.makeUnsafe("thread-1"),
         turnId: asTurnId("turn-steer-1"),
@@ -8581,6 +8581,105 @@ describe("ProviderCommandReactor", () => {
       input: "steer but nothing is running",
     });
   });
+
+  it.each(["turn-not-active", "timeout"] as const)(
+    "handles a Codex steer %s without bypassing turn baselines",
+    async (failure) => {
+      let releaseGit: () => void = () => {};
+      let releaseStudio: () => void = () => {};
+      const gitGate = new Promise<void>((resolve) => {
+        releaseGit = resolve;
+      });
+      const studioGate = new Promise<void>((resolve) => {
+        releaseStudio = resolve;
+      });
+      const captureCheckpoint = vi.fn<CheckpointStoreShape["captureCheckpoint"]>(() =>
+        Effect.promise(() => gitGate),
+      );
+      const startStudioBaseline = vi.fn(() => studioGate);
+      const harness = await createHarness({
+        checkpointStore: {
+          isGitRepository: () => Effect.succeed(true),
+          captureCheckpoint,
+        },
+        studioOutputReactor: {
+          captureBaselineBeforeTurn: () => Effect.promise(startStudioBaseline),
+        },
+      });
+      const threadId = ThreadId.makeUnsafe("thread-1");
+      const now = new Date().toISOString();
+      harness.setRuntimeSessionTurnState({
+        threadId,
+        status: "running",
+        activeTurnId: asTurnId("turn-ending"),
+      });
+      harness.steerTurn.mockImplementationOnce(() =>
+        Effect.fail(
+          new ProviderAdapterRequestError({
+            provider: "codex",
+            method: "turn/steer",
+            detail: failure,
+            ...(failure === "turn-not-active" ? { reason: failure } : {}),
+          }),
+        ),
+      );
+      try {
+        await Effect.runPromise(
+          harness.engine.dispatch({
+            type: "thread.turn.start",
+            commandId: CommandId.makeUnsafe(`steer-${failure}`),
+            threadId,
+            message: {
+              messageId: asMessageId(`answer-${failure}`),
+              role: "user",
+              text: "My answer",
+              attachments: [],
+            },
+            dispatchMode: "steer",
+            runtimeMode: "approval-required",
+            interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+            createdAt: now,
+          }),
+        );
+        if (failure === "timeout") {
+          await waitFor(async () => {
+            const model = await Effect.runPromise(harness.engine.getReadModel());
+            return (
+              model.threads[0]?.activities.some(
+                (activity) => activity.kind === "provider.turn.start.failed",
+              ) ?? false
+            );
+          });
+          expect(harness.sendTurn).not.toHaveBeenCalled();
+          expect(captureCheckpoint).not.toHaveBeenCalled();
+          expect(startStudioBaseline).not.toHaveBeenCalled();
+          return;
+        }
+        await waitFor(
+          () =>
+            captureCheckpoint.mock.calls.length === 1 &&
+            startStudioBaseline.mock.calls.length === 1,
+        );
+        expect(harness.sendTurn).not.toHaveBeenCalled();
+        releaseGit();
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        expect(harness.sendTurn).not.toHaveBeenCalled();
+        releaseStudio();
+        await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+        expect(captureCheckpoint.mock.calls[0]?.[0]).toMatchObject({
+          checkpointRef: expect.stringContaining(
+            `/message-start/${Buffer.from(`answer-${failure}`).toString("base64url")}`,
+          ),
+          skipIfExists: true,
+        });
+        expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({ threadId, input: "My answer" });
+        expect(harness.interruptTurn).not.toHaveBeenCalled();
+      } finally {
+        releaseGit();
+        releaseStudio();
+      }
+    },
+  );
 
   it("steers a running claude turn natively without interrupting it", async () => {
     const harness = await createHarness({

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -51,6 +51,7 @@ import {
   isUsableGeneratedThreadTitle,
 } from "@synara/shared/chatThreads";
 import {
+  isNativeConversationMessageSource,
   collectTailTurnIds,
   resolveTailUserMessageEditTarget,
 } from "@synara/shared/conversationEdit";
@@ -2767,7 +2768,7 @@ const make = Effect.gen(function* () {
     const thread = yield* resolveThread(threadId);
     if (!thread) return null;
     const userMessages = thread.messages.filter(
-      (message) => message.role === "user" && message.source === "native",
+      (message) => message.role === "user" && isNativeConversationMessageSource(message.source),
     );
     return userMessages.length === 1 && userMessages[0]?.id === messageId ? thread : null;
   });
@@ -3154,6 +3155,23 @@ const make = Effect.gen(function* () {
         dispatchMode: immediateDispatchMode,
         createdAt: event.payload.createdAt,
       }).pipe(
+        Effect.catchTag("ProviderAdapterRequestError", (error) =>
+          error.provider === "codex" &&
+          error.method === "turn/steer" &&
+          error.reason === "turn-not-steerable"
+            ? Effect.gen(function* () {
+                // Codex accepted no input. Wait for review/compaction to settle;
+                // do not interrupt it or mark an already accepted answer failed.
+                yield* enqueueQueuedTurnStart({
+                  ...event,
+                  payload: { ...event.payload, dispatchMode: "queue" },
+                });
+                if (liveTurnId !== undefined) {
+                  yield* bindPendingQueuedDispatchToTurn(liveTurnId);
+                }
+              })
+            : Effect.fail(error),
+        ),
         Effect.catchCause((cause) =>
           Cause.hasInterruptsOnly(cause)
             ? Effect.failCause(cause)
@@ -3280,7 +3298,7 @@ const make = Effect.gen(function* () {
           ...(nextQueuedTurn.assistantDeliveryMode !== undefined
             ? { assistantDeliveryMode: nextQueuedTurn.assistantDeliveryMode }
             : {}),
-          dispatchMode: nextQueuedTurn.dispatchMode,
+          dispatchMode: promotion.dispatchMode,
           ...(nextQueuedTurn.dispatchOrigin !== undefined
             ? { dispatchOrigin: nextQueuedTurn.dispatchOrigin }
             : {}),

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -2370,10 +2370,6 @@ const make = Effect.gen(function* () {
       });
 
     const captureMessageStartCheckpoint = Effect.gen(function* () {
-      if ((input.dispatchMode ?? "queue") === "steer") {
-        return;
-      }
-
       const currentThread = yield* resolveThread(input.threadId);
       if (!currentThread) {
         return;
@@ -2426,6 +2422,23 @@ const make = Effect.gen(function* () {
     let pendingContextBootstrapAttempt: PendingContextBootstrapAttempt | undefined;
     let startedTurn: ProviderTurnStartResult | undefined;
 
+    if (input.reviewTarget === undefined && input.dispatchMode === "steer") {
+      startedTurn = yield* providerService
+        .steerTurn({
+          ...providerTurnInput,
+          ...(normalizedInput ? { input: normalizedInput } : {}),
+        })
+        .pipe(
+          Effect.catchTag("ProviderAdapterRequestError", (error) =>
+            error.provider === "codex" &&
+            error.method === "turn/steer" &&
+            error.reason === "turn-not-active"
+              ? Effect.succeed(undefined)
+              : Effect.fail(error),
+          ),
+        );
+    }
+
     if (input.reviewTarget !== undefined) {
       yield* capturePreTurnBaselines;
       startedTurn = yield* providerService
@@ -2434,12 +2447,9 @@ const make = Effect.gen(function* () {
           target: input.reviewTarget,
         })
         .pipe(Effect.onError(() => cancelPendingStudioBaseline));
-    } else if (input.dispatchMode === "steer") {
-      startedTurn = yield* providerService.steerTurn({
-        ...providerTurnInput,
-        ...(normalizedInput ? { input: normalizedInput } : {}),
-      });
-    } else {
+    } else if (startedTurn === undefined) {
+      // A rejected Codex steer follows the normal start path, including both
+      // pre-turn baselines and delivery/bootstrap bookkeeping.
       yield* capturePreTurnBaselines;
       const tracksDroidContextAcceptance =
         activeSession?.provider === "droid" &&

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2287,37 +2287,66 @@ describe("ProviderRuntimeIngestion", () => {
     const threadId = asThreadId("thread-1");
     const turnId = asTurnId("async-turn");
     harness.emit({
-      type: "turn.started", eventId: asEventId("async-turn-start"),
-      provider: "codex", threadId, turnId, createdAt, payload: {},
+      type: "turn.started",
+      eventId: asEventId("async-turn-start"),
+      provider: "codex",
+      threadId,
+      turnId,
+      createdAt,
+      payload: {},
     });
     harness.emit({
-      type: "content.delta", eventId: asEventId("before-question"),
-      provider: "codex", threadId, turnId, createdAt, itemId: asItemId("working-message"),
+      type: "content.delta",
+      eventId: asEventId("before-question"),
+      provider: "codex",
+      threadId,
+      turnId,
+      createdAt,
+      itemId: asItemId("working-message"),
       payload: { streamKind: "assistant_text", delta: "Investigating. " },
     });
     harness.emit({
-      type: "item.completed", eventId: asEventId("async-question"),
-      provider: "codex", threadId, turnId, createdAt, itemId: asItemId("question-item"),
+      type: "item.completed",
+      eventId: asEventId("async-question"),
+      provider: "codex",
+      threadId,
+      turnId,
+      createdAt,
+      itemId: asItemId("question-item"),
       payload: {
-        itemType: "assistant_message", status: "completed", detail: "Which interaction?",
+        itemType: "assistant_message",
+        status: "completed",
+        detail: "Which interaction?",
         asyncQuestions: [{ title: "Which interaction?", options: null }],
       },
     });
     harness.emit({
-      type: "content.delta", eventId: asEventId("after-question"),
-      provider: "codex", threadId, turnId, createdAt, itemId: asItemId("working-message"),
+      type: "content.delta",
+      eventId: asEventId("after-question"),
+      provider: "codex",
+      threadId,
+      turnId,
+      createdAt,
+      itemId: asItemId("working-message"),
       payload: { streamKind: "assistant_text", delta: "Continuing with independent code." },
     });
-    const thread = await waitForThread(harness.engine, (entry) =>
-      entry.activities.some((activity) => activity.kind === "user-input.async") &&
-      entry.messages.some((message) => message.text.includes("Continuing with independent code.")),
+    const thread = await waitForThread(
+      harness.engine,
+      (entry) =>
+        entry.activities.some((activity) => activity.kind === "user-input.async") &&
+        entry.messages.some((message) =>
+          message.text.includes("Continuing with independent code."),
+        ),
     );
     expect(thread.messages).toHaveLength(1);
     expect(thread.messages[0]).toMatchObject({
-      text: "Investigating. Continuing with independent code.", streaming: true,
+      text: "Investigating. Continuing with independent code.",
+      streaming: true,
     });
     expect(thread.session).toMatchObject({ status: "running", activeTurnId: turnId });
-    expect(thread.activities.some((activity) => activity.kind === "user-input.requested")).toBe(false);
+    expect(thread.activities.some((activity) => activity.kind === "user-input.requested")).toBe(
+      false,
+    );
   });
 
   it("does not project reasoning content deltas into transcript work rows", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2281,6 +2281,45 @@ describe("ProviderRuntimeIngestion", () => {
     expect(message?.streaming).toBe(false);
   });
 
+  it("keeps streaming while an async question is pending without completing the assistant message", async () => {
+    const harness = await createHarness();
+    const createdAt = new Date().toISOString();
+    const threadId = asThreadId("thread-1");
+    const turnId = asTurnId("async-turn");
+    harness.emit({
+      type: "turn.started", eventId: asEventId("async-turn-start"),
+      provider: "codex", threadId, turnId, createdAt, payload: {},
+    });
+    harness.emit({
+      type: "content.delta", eventId: asEventId("before-question"),
+      provider: "codex", threadId, turnId, createdAt, itemId: asItemId("working-message"),
+      payload: { streamKind: "assistant_text", delta: "Investigating. " },
+    });
+    harness.emit({
+      type: "item.completed", eventId: asEventId("async-question"),
+      provider: "codex", threadId, turnId, createdAt, itemId: asItemId("question-item"),
+      payload: {
+        itemType: "assistant_message", status: "completed", detail: "Which interaction?",
+        asyncQuestions: [{ title: "Which interaction?", options: null }],
+      },
+    });
+    harness.emit({
+      type: "content.delta", eventId: asEventId("after-question"),
+      provider: "codex", threadId, turnId, createdAt, itemId: asItemId("working-message"),
+      payload: { streamKind: "assistant_text", delta: "Continuing with independent code." },
+    });
+    const thread = await waitForThread(harness.engine, (entry) =>
+      entry.activities.some((activity) => activity.kind === "user-input.async") &&
+      entry.messages.some((message) => message.text.includes("Continuing with independent code.")),
+    );
+    expect(thread.messages).toHaveLength(1);
+    expect(thread.messages[0]).toMatchObject({
+      text: "Investigating. Continuing with independent code.", streaming: true,
+    });
+    expect(thread.session).toMatchObject({ status: "running", activeTurnId: turnId });
+    expect(thread.activities.some((activity) => activity.kind === "user-input.requested")).toBe(false);
+  });
+
   it("does not project reasoning content deltas into transcript work rows", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -233,7 +233,7 @@ function eventNeedsHeavyThreadDetail(event: ProviderRuntimeEvent): boolean {
     // apply fallback completion text; image_generation completion scans
     // thread.messages to attach the generated-image reference.
     return (
-      event.payload.itemType === "assistant_message" ||
+      (event.payload.itemType === "assistant_message" && !event.payload.asyncQuestions) ||
       generatedImagePathFromRuntimeEvent(event) !== undefined
     );
   }
@@ -323,7 +323,8 @@ function isRowMakingProviderRuntimeEvent(event: ProviderRuntimeEvent): boolean {
     case "item.updated":
     case "item.completed": {
       const itemType = event.payload.itemType;
-      return itemType !== undefined && itemType !== "assistant_message" && itemType !== "reasoning";
+      return event.payload.asyncQuestions !== undefined ||
+        (itemType !== undefined && itemType !== "assistant_message" && itemType !== "reasoning");
     }
     case "runtime.warning":
     case "user-input.requested":
@@ -2478,7 +2479,8 @@ const make = Effect.gen(function* () {
       }
 
       const assistantCompletion =
-        event.type === "item.completed" && event.payload.itemType === "assistant_message"
+        event.type === "item.completed" && event.payload.itemType === "assistant_message" &&
+          !event.payload.asyncQuestions
           ? {
               fallbackText: event.payload.detail,
             }

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -323,8 +323,10 @@ function isRowMakingProviderRuntimeEvent(event: ProviderRuntimeEvent): boolean {
     case "item.updated":
     case "item.completed": {
       const itemType = event.payload.itemType;
-      return event.payload.asyncQuestions !== undefined ||
-        (itemType !== undefined && itemType !== "assistant_message" && itemType !== "reasoning");
+      return (
+        event.payload.asyncQuestions !== undefined ||
+        (itemType !== undefined && itemType !== "assistant_message" && itemType !== "reasoning")
+      );
     }
     case "runtime.warning":
     case "user-input.requested":
@@ -2479,8 +2481,9 @@ const make = Effect.gen(function* () {
       }
 
       const assistantCompletion =
-        event.type === "item.completed" && event.payload.itemType === "assistant_message" &&
-          !event.payload.asyncQuestions
+        event.type === "item.completed" &&
+        event.payload.itemType === "assistant_message" &&
+        !event.payload.asyncQuestions
           ? {
               fallbackText: event.payload.detail,
             }

--- a/apps/server/src/orchestration/Layers/asyncUserInputRoundTrip.test.ts
+++ b/apps/server/src/orchestration/Layers/asyncUserInputRoundTrip.test.ts
@@ -1,0 +1,196 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  CommandId,
+  CheckpointRef,
+  MessageId,
+  ProjectId,
+  ThreadId,
+  EventId,
+  RuntimeItemId,
+  TurnId,
+  type OrchestrationCommand,
+} from "@synara/contracts";
+import { Effect, Layer, ManagedRuntime, Option, Stream } from "effect";
+import { expect, it } from "vitest";
+import { SqlClient } from "effect/unstable/sql";
+import { projectProviderRuntimeActivities } from "../providerRuntimeActivityProjection.ts";
+import { createEmptyReadModel, projectEvent } from "../projector.ts";
+
+import { OrchestrationCommandReceiptRepositoryLive } from "../../persistence/Layers/OrchestrationCommandReceipts.ts";
+import { OrchestrationEventStoreLive } from "../../persistence/Layers/OrchestrationEventStore.ts";
+import { makeSqlitePersistenceLive } from "../../persistence/Layers/Sqlite.ts";
+import { ServerConfig } from "../../config.ts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
+import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
+import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQuery.ts";
+import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
+import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
+
+async function createSystem(dbPath: string) {
+  const ServerConfigLayer = ServerConfig.layerTest(process.cwd(), {
+    prefix: "synara-async-questions-test-",
+  });
+  const layer = OrchestrationEngineLive.pipe(
+    Layer.provideMerge(OrchestrationProjectionPipelineLive),
+    Layer.provideMerge(OrchestrationProjectionSnapshotQueryLive),
+    Layer.provideMerge(OrchestrationEventStoreLive),
+    Layer.provideMerge(OrchestrationCommandReceiptRepositoryLive),
+    Layer.provideMerge(makeSqlitePersistenceLive(dbPath)),
+    Layer.provideMerge(ServerConfigLayer),
+    Layer.provideMerge(NodeServices.layer),
+  );
+  const runtime = ManagedRuntime.make(layer);
+  const engine = await runtime.runPromise(Effect.service(OrchestrationEngineService));
+  const sql = await runtime.runPromise(Effect.service(SqlClient.SqlClient));
+  const query = await runtime.runPromise(Effect.service(ProjectionSnapshotQuery));
+  return {
+    engine,
+    query,
+    sql,
+    run: <A, E>(effect: Effect.Effect<A, E>) => runtime.runPromise(effect),
+    dispose: () => runtime.dispose(),
+  };
+}
+
+it.each(["ready", "running"] as const)("persists async questions and admits one answer on a %s thread across restarts", async (status) => {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "synara-async-questions-"));
+  const dbPath = path.join(stateDir, "state.sqlite");
+  let system = await createSystem(dbPath);
+  const createdAt = "2026-09-10T12:00:00.000Z";
+  const threadId = ThreadId.makeUnsafe("async-thread");
+  const projectId = ProjectId.makeUnsafe("async-project");
+  const turnId = TurnId.makeUnsafe("original-turn");
+  const [question] = projectProviderRuntimeActivities({
+    type: "item.completed", provider: "codex", threadId, turnId,
+    eventId: EventId.makeUnsafe("async-event"), itemId: RuntimeItemId.makeUnsafe("question-1"),
+    createdAt,
+    payload: {
+      itemType: "assistant_message",
+      asyncQuestions: [{ title: "What triggers it?", options: ["Scrolling", "Tabs"] }],
+    },
+  });
+  expect(question).toBeDefined();
+  const appendQuestion = (commandId: string): OrchestrationCommand => ({
+    type: "thread.activity.append", commandId: CommandId.makeUnsafe(commandId),
+    threadId, activity: question!, createdAt,
+  });
+  const respond = (commandId: string): OrchestrationCommand => ({
+    type: "thread.turn.start", commandId: CommandId.makeUnsafe(commandId), threadId,
+    asyncUserInputResponse: { activityId: question!.id, answers: ["Switching tabs quickly"] },
+    message: { messageId: MessageId.makeUnsafe(commandId), role: "user", text: "client placeholder", attachments: [] },
+    runtimeMode: "approval-required", interactionMode: "default", dispatchMode: "queue", createdAt,
+  });
+  try {
+    await system.run(system.engine.dispatch({
+      type: "project.create", commandId: CommandId.makeUnsafe("create-project"), projectId,
+      title: "Async questions", workspaceRoot: "/tmp/async-project", defaultModelSelection: null, createdAt,
+    }));
+    await system.run(system.engine.dispatch({
+      type: "thread.create", commandId: CommandId.makeUnsafe("create-thread"), threadId, projectId,
+      title: "Async questions", modelSelection: { provider: "codex", model: "gpt-5-codex" },
+      runtimeMode: "approval-required", interactionMode: "default", branch: null, worktreePath: null, createdAt,
+    }));
+    await system.run(system.engine.dispatch({
+      type: "thread.messages.import", commandId: CommandId.makeUnsafe("original-message"),
+      threadId, createdAt,
+      messages: [{ messageId: MessageId.makeUnsafe("original-message"), role: "user",
+        text: "Investigate this issue", createdAt, updatedAt: createdAt }],
+    }));
+    await system.run(system.engine.dispatch({
+      type: "thread.turn.diff.complete", commandId: CommandId.makeUnsafe("original-checkpoint"),
+      threadId, turnId, checkpointTurnCount: 1, checkpointRef: CheckpointRef.makeUnsafe("original-checkpoint"),
+      status: "ready", files: [], completedAt: createdAt, createdAt,
+    }));
+    await system.run(system.engine.dispatch(appendQuestion("question-arrived")));
+    // A long-running agent must not evict the card from the bounded activity window.
+    await system.run(system.sql`
+      WITH RECURSIVE numbers(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM numbers WHERE n < 2200)
+      INSERT INTO projection_thread_activities
+        (activity_id, thread_id, turn_id, tone, kind, summary, payload_json, sequence, created_at)
+      SELECT 'work-' || n, ${threadId}, ${turnId}, 'tool', 'tool.completed', 'Done', '{}', n + 100,
+        '2026-09-10T12:01:00.000Z' FROM numbers
+    `);
+    const pending = Option.getOrThrow(await system.run(system.query.getThreadDetailById(threadId)));
+    expect(pending.activities.find((activity) => activity.id === question!.id)?.payload).toEqual(question!.payload);
+    expect(pending.hasPendingUserInput).toBe(false);
+    expect(pending.pendingInteractions).toEqual([]);
+    const snapshot = await system.run(system.query.getSnapshot());
+    expect(snapshot.threads[0]?.activities.some((activity) => activity.id === question!.id)).toBe(true);
+
+    await system.dispose();
+    system = await createSystem(dbPath);
+    await system.run(system.engine.dispatch({
+      type: "thread.session.set",
+      commandId: CommandId.makeUnsafe("set-session"),
+      threadId,
+      session: {
+        threadId,
+        status,
+        providerName: "codex",
+        runtimeMode: "approval-required",
+        activeTurnId: status === "running" ? turnId : null,
+        lastError: null,
+        updatedAt: createdAt,
+      },
+      createdAt,
+    }));
+    const submissions = await Promise.allSettled([
+      system.run(system.engine.dispatch(respond("answer-tab-a"))),
+      system.run(system.engine.dispatch(respond("answer-tab-b"))),
+    ]);
+    expect(submissions.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(submissions.filter((result) => result.status === "rejected")).toHaveLength(1);
+    const answered = Option.getOrThrow(await system.run(system.query.getThreadDetailById(threadId)));
+    expect(answered.messages).toHaveLength(2);
+    const answerMessageId = answered.messages.at(-1)!.id;
+    expect(answered.messages.at(-1)?.text).toBe("What triggers it?\nSwitching tabs quickly");
+    expect(answered.activities.find((activity) => activity.id === question!.id)?.payload).toMatchObject({
+      response: { answers: ["Switching tabs quickly"], messageId: answerMessageId },
+    });
+    const events = Array.from(await system.run(Stream.runCollect(system.engine.readEvents(0))));
+    expect(events.filter((event) => event.type === "thread.turn-start-requested")).toHaveLength(1);
+    expect(events.find((event) => event.type === "thread.turn-start-requested")?.payload).toMatchObject({ dispatchMode: "steer" });
+    expect(events.some((event) => event.type === "thread.turn-interrupt-requested")).toBe(false);
+
+    await system.dispose();
+    system = await createSystem(dbPath);
+    await system.run(system.engine.dispatch(appendQuestion("replayed-item")));
+    await expect(system.run(system.engine.dispatch(respond("answer-after-restart")))).rejects.toThrow("already answered");
+    const restarted = Option.getOrThrow(await system.run(system.query.getThreadDetailById(threadId)));
+    expect(restarted.activities.find((activity) => activity.id === question!.id)?.payload).toMatchObject({ response: { answers: ["Switching tabs quickly"] } });
+
+    await system.run(system.engine.dispatch(status === "ready" ? {
+      type: "thread.conversation.rollback.complete", commandId: CommandId.makeUnsafe("remove-answer"),
+      threadId, messageId: answerMessageId, numTurns: 1, removedTurnIds: [TurnId.makeUnsafe("answer-turn")], createdAt,
+    } : {
+      type: "thread.revert.complete", commandId: CommandId.makeUnsafe("remove-answer"),
+      threadId, turnCount: 1, createdAt,
+    }));
+    const reopened = Option.getOrThrow(await system.run(system.query.getThreadDetailById(threadId)));
+    expect(reopened.messages.map((message) => message.id)).toEqual(["original-message"]);
+    expect(reopened.activities.find((activity) => activity.id === question!.id)?.payload).toEqual(question!.payload);
+
+    // The in-memory projector must agree with SQLite when replaying the same history.
+    let replayed = createEmptyReadModel(createdAt);
+    const history = await system.run(Stream.runCollect(system.engine.readEvents(0)));
+    for (const event of history) {
+      replayed = await Effect.runPromise(projectEvent(replayed, event));
+    }
+    expect(replayed.threads[0]?.activities.find((activity) => activity.id === question!.id)?.payload).toEqual(question!.payload);
+
+    await system.dispose();
+    system = await createSystem(dbPath);
+    await system.run(system.engine.dispatch(respond("replacement-answer")));
+    const replaced = Option.getOrThrow(await system.run(system.query.getThreadDetailById(threadId)));
+    expect(replaced.activities.find((activity) => activity.id === question!.id)?.payload).toMatchObject({
+      response: { messageId: "replacement-answer" },
+    });
+  } finally {
+    await system.dispose();
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});

--- a/apps/server/src/orchestration/Layers/asyncUserInputRoundTrip.test.ts
+++ b/apps/server/src/orchestration/Layers/asyncUserInputRoundTrip.test.ts
@@ -87,7 +87,9 @@ it.each(["ready", "running"] as const)(
       activity: question!,
       createdAt,
     });
-    const respond = (commandId: string): OrchestrationCommand => ({
+    const respond = (
+      commandId: string,
+    ): Extract<OrchestrationCommand, { type: "thread.turn.start" }> => ({
       type: "thread.turn.start",
       commandId: CommandId.makeUnsafe(commandId),
       threadId,
@@ -162,6 +164,48 @@ it.each(["ready", "running"] as const)(
         }),
       );
       await system.run(system.engine.dispatch(appendQuestion("question-arrived")));
+      const childThreadId = ThreadId.makeUnsafe("subagent:async-thread:child");
+      const childQuestionId = EventId.makeUnsafe("child-question");
+      await system.run(
+        system.engine.dispatch({
+          type: "thread.create",
+          commandId: CommandId.makeUnsafe("create-child"),
+          threadId: childThreadId,
+          parentThreadId: threadId,
+          projectId,
+          title: "Child",
+          modelSelection: { provider: "codex", model: "gpt-5-codex" },
+          runtimeMode: "approval-required",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt,
+        }),
+      );
+      await system.run(
+        system.engine.dispatch({
+          type: "thread.activity.append",
+          commandId: CommandId.makeUnsafe("child-question"),
+          threadId: childThreadId,
+          activity: { ...question!, id: childQuestionId },
+          createdAt,
+        }),
+      );
+      await expect(
+        system.run(
+          system.engine.dispatch({
+            ...respond("child-answer"),
+            threadId: childThreadId,
+            asyncUserInputResponse: { activityId: childQuestionId, answers: ["Tabs"] },
+          }),
+        ),
+      ).rejects.toThrow("unavailable");
+      const child = Option.getOrThrow(
+        await system.run(system.query.getThreadDetailById(childThreadId)),
+      );
+      expect(child.messages).toHaveLength(0);
+      expect(child.activities[0]?.payload).toEqual(question!.payload);
+
       // A long-running agent must not evict the card from the bounded activity window.
       await system.run(system.sql`
       WITH RECURSIVE numbers(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM numbers WHERE n < 2200)
@@ -171,7 +215,9 @@ it.each(["ready", "running"] as const)(
         '2026-09-10T12:01:00.000Z' FROM numbers
     `);
       const pending = Option.getOrThrow(
-        await system.run(system.query.getThreadDetailById(threadId)),
+        await system.run(
+          system.query.getThreadDetailById(threadId, { includeActivityId: question!.id }),
+        ),
       );
       expect(pending.activities.find((activity) => activity.id === question!.id)?.payload).toEqual(
         question!.payload,
@@ -179,9 +225,11 @@ it.each(["ready", "running"] as const)(
       expect(pending.hasPendingUserInput).toBe(false);
       expect(pending.pendingInteractions).toEqual([]);
       const snapshot = await system.run(system.query.getSnapshot());
-      expect(snapshot.threads[0]?.activities.some((activity) => activity.id === question!.id)).toBe(
-        true,
-      );
+      expect(
+        snapshot.threads
+          .find((thread) => thread.id === threadId)
+          ?.activities.some((activity) => activity.id === question!.id),
+      ).toBe(true);
 
       await system.dispose();
       system = await createSystem(dbPath);
@@ -209,7 +257,9 @@ it.each(["ready", "running"] as const)(
       expect(submissions.filter((result) => result.status === "fulfilled")).toHaveLength(1);
       expect(submissions.filter((result) => result.status === "rejected")).toHaveLength(1);
       const answered = Option.getOrThrow(
-        await system.run(system.query.getThreadDetailById(threadId)),
+        await system.run(
+          system.query.getThreadDetailById(threadId, { includeActivityId: question!.id }),
+        ),
       );
       expect(answered.messages).toHaveLength(2);
       const answerMessageId = answered.messages.at(-1)!.id;
@@ -219,6 +269,31 @@ it.each(["ready", "running"] as const)(
       ).toMatchObject({
         response: { answers: ["Switching tabs quickly"], messageId: answerMessageId },
       });
+      const publicDetail = Option.getOrThrow(
+        await system.run(system.query.getThreadDetailById(threadId)),
+      );
+      expect(publicDetail.activities.some((activity) => activity.id === question!.id)).toBe(false);
+      expect(publicDetail.activities.length).toBeLessThanOrEqual(2000);
+      expect(
+        (await system.run(system.query.getSnapshot())).threads.find(
+          (thread) => thread.id === threadId,
+        )!.activities.length,
+      ).toBeLessThanOrEqual(500);
+      expect(answered.messages.at(-1)?.source).toBe("async-user-input");
+      await expect(
+        system.run(
+          system.engine.dispatch({
+            type: "thread.message.edit-and-resend",
+            commandId: CommandId.makeUnsafe("edit-answer"),
+            threadId,
+            messageId: answerMessageId,
+            text: "Corrected answer",
+            runtimeMode: "approval-required",
+            interactionMode: "default",
+            createdAt,
+          }),
+        ),
+      ).rejects.toThrow("non-native-message");
       const events = Array.from(await system.run(Stream.runCollect(system.engine.readEvents(0))));
       expect(events.filter((event) => event.type === "thread.turn-start-requested")).toHaveLength(
         1,
@@ -235,7 +310,9 @@ it.each(["ready", "running"] as const)(
         system.run(system.engine.dispatch(respond("answer-after-restart"))),
       ).rejects.toThrow("already answered");
       const restarted = Option.getOrThrow(
-        await system.run(system.query.getThreadDetailById(threadId)),
+        await system.run(
+          system.query.getThreadDetailById(threadId, { includeActivityId: question!.id }),
+        ),
       );
       expect(
         restarted.activities.find((activity) => activity.id === question!.id)?.payload,
@@ -263,7 +340,9 @@ it.each(["ready", "running"] as const)(
         ),
       );
       const reopened = Option.getOrThrow(
-        await system.run(system.query.getThreadDetailById(threadId)),
+        await system.run(
+          system.query.getThreadDetailById(threadId, { includeActivityId: question!.id }),
+        ),
       );
       expect(reopened.messages.map((message) => message.id)).toEqual(["original-message"]);
       expect(reopened.activities.find((activity) => activity.id === question!.id)?.payload).toEqual(
@@ -284,13 +363,35 @@ it.each(["ready", "running"] as const)(
       system = await createSystem(dbPath);
       await system.run(system.engine.dispatch(respond("replacement-answer")));
       const replaced = Option.getOrThrow(
-        await system.run(system.query.getThreadDetailById(threadId)),
+        await system.run(
+          system.query.getThreadDetailById(threadId, { includeActivityId: question!.id }),
+        ),
       );
       expect(
         replaced.activities.find((activity) => activity.id === question!.id)?.payload,
       ).toMatchObject({
         response: { messageId: "replacement-answer" },
       });
+      await system.run(system.sql`
+        WITH RECURSIVE numbers(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM numbers WHERE n < 2200)
+        INSERT INTO projection_thread_activities
+          (activity_id, thread_id, turn_id, tone, kind, summary, payload_json, sequence, created_at)
+        SELECT 'settled-' || n, ${threadId}, NULL, 'info', 'user-input.async', 'Answered',
+          ${JSON.stringify({ questions: [{ title: "Which?", options: null }], response: { answers: ["A"], messageId: "replacement-answer" } })},
+          n + 3000, '2026-09-10T12:02:00.000Z' FROM numbers
+      `);
+      const boundedDetail = Option.getOrThrow(
+        await system.run(system.query.getThreadDetailById(threadId)),
+      );
+      expect(boundedDetail.activities).toHaveLength(2000);
+      const boundedSnapshot = await system.run(system.query.getSnapshot());
+      expect(
+        boundedSnapshot.threads.find((thread) => thread.id === threadId)!.activities,
+      ).toHaveLength(500);
+      await system.run(system.engine.dispatch(appendQuestion("replayed-archived-item")));
+      await expect(
+        system.run(system.engine.dispatch(respond("duplicate-archived-answer"))),
+      ).rejects.toThrow("already answered");
     } finally {
       await system.dispose();
       fs.rmSync(stateDir, { recursive: true, force: true });

--- a/apps/server/src/orchestration/Layers/asyncUserInputRoundTrip.test.ts
+++ b/apps/server/src/orchestration/Layers/asyncUserInputRoundTrip.test.ts
@@ -56,141 +56,244 @@ async function createSystem(dbPath: string) {
   };
 }
 
-it.each(["ready", "running"] as const)("persists async questions and admits one answer on a %s thread across restarts", async (status) => {
-  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "synara-async-questions-"));
-  const dbPath = path.join(stateDir, "state.sqlite");
-  let system = await createSystem(dbPath);
-  const createdAt = "2026-09-10T12:00:00.000Z";
-  const threadId = ThreadId.makeUnsafe("async-thread");
-  const projectId = ProjectId.makeUnsafe("async-project");
-  const turnId = TurnId.makeUnsafe("original-turn");
-  const [question] = projectProviderRuntimeActivities({
-    type: "item.completed", provider: "codex", threadId, turnId,
-    eventId: EventId.makeUnsafe("async-event"), itemId: RuntimeItemId.makeUnsafe("question-1"),
-    createdAt,
-    payload: {
-      itemType: "assistant_message",
-      asyncQuestions: [{ title: "What triggers it?", options: ["Scrolling", "Tabs"] }],
-    },
-  });
-  expect(question).toBeDefined();
-  const appendQuestion = (commandId: string): OrchestrationCommand => ({
-    type: "thread.activity.append", commandId: CommandId.makeUnsafe(commandId),
-    threadId, activity: question!, createdAt,
-  });
-  const respond = (commandId: string): OrchestrationCommand => ({
-    type: "thread.turn.start", commandId: CommandId.makeUnsafe(commandId), threadId,
-    asyncUserInputResponse: { activityId: question!.id, answers: ["Switching tabs quickly"] },
-    message: { messageId: MessageId.makeUnsafe(commandId), role: "user", text: "client placeholder", attachments: [] },
-    runtimeMode: "approval-required", interactionMode: "default", dispatchMode: "queue", createdAt,
-  });
-  try {
-    await system.run(system.engine.dispatch({
-      type: "project.create", commandId: CommandId.makeUnsafe("create-project"), projectId,
-      title: "Async questions", workspaceRoot: "/tmp/async-project", defaultModelSelection: null, createdAt,
-    }));
-    await system.run(system.engine.dispatch({
-      type: "thread.create", commandId: CommandId.makeUnsafe("create-thread"), threadId, projectId,
-      title: "Async questions", modelSelection: { provider: "codex", model: "gpt-5-codex" },
-      runtimeMode: "approval-required", interactionMode: "default", branch: null, worktreePath: null, createdAt,
-    }));
-    await system.run(system.engine.dispatch({
-      type: "thread.messages.import", commandId: CommandId.makeUnsafe("original-message"),
-      threadId, createdAt,
-      messages: [{ messageId: MessageId.makeUnsafe("original-message"), role: "user",
-        text: "Investigate this issue", createdAt, updatedAt: createdAt }],
-    }));
-    await system.run(system.engine.dispatch({
-      type: "thread.turn.diff.complete", commandId: CommandId.makeUnsafe("original-checkpoint"),
-      threadId, turnId, checkpointTurnCount: 1, checkpointRef: CheckpointRef.makeUnsafe("original-checkpoint"),
-      status: "ready", files: [], completedAt: createdAt, createdAt,
-    }));
-    await system.run(system.engine.dispatch(appendQuestion("question-arrived")));
-    // A long-running agent must not evict the card from the bounded activity window.
-    await system.run(system.sql`
+it.each(["ready", "running"] as const)(
+  "persists async questions and admits one answer on a %s thread across restarts",
+  async (status) => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "synara-async-questions-"));
+    const dbPath = path.join(stateDir, "state.sqlite");
+    let system = await createSystem(dbPath);
+    const createdAt = "2026-09-10T12:00:00.000Z";
+    const threadId = ThreadId.makeUnsafe("async-thread");
+    const projectId = ProjectId.makeUnsafe("async-project");
+    const turnId = TurnId.makeUnsafe("original-turn");
+    const [question] = projectProviderRuntimeActivities({
+      type: "item.completed",
+      provider: "codex",
+      threadId,
+      turnId,
+      eventId: EventId.makeUnsafe("async-event"),
+      itemId: RuntimeItemId.makeUnsafe("question-1"),
+      createdAt,
+      payload: {
+        itemType: "assistant_message",
+        asyncQuestions: [{ title: "What triggers it?", options: ["Scrolling", "Tabs"] }],
+      },
+    });
+    expect(question).toBeDefined();
+    const appendQuestion = (commandId: string): OrchestrationCommand => ({
+      type: "thread.activity.append",
+      commandId: CommandId.makeUnsafe(commandId),
+      threadId,
+      activity: question!,
+      createdAt,
+    });
+    const respond = (commandId: string): OrchestrationCommand => ({
+      type: "thread.turn.start",
+      commandId: CommandId.makeUnsafe(commandId),
+      threadId,
+      asyncUserInputResponse: { activityId: question!.id, answers: ["Switching tabs quickly"] },
+      message: {
+        messageId: MessageId.makeUnsafe(commandId),
+        role: "user",
+        text: "client placeholder",
+        attachments: [],
+      },
+      runtimeMode: "approval-required",
+      interactionMode: "default",
+      dispatchMode: "queue",
+      createdAt,
+    });
+    try {
+      await system.run(
+        system.engine.dispatch({
+          type: "project.create",
+          commandId: CommandId.makeUnsafe("create-project"),
+          projectId,
+          title: "Async questions",
+          workspaceRoot: "/tmp/async-project",
+          defaultModelSelection: null,
+          createdAt,
+        }),
+      );
+      await system.run(
+        system.engine.dispatch({
+          type: "thread.create",
+          commandId: CommandId.makeUnsafe("create-thread"),
+          threadId,
+          projectId,
+          title: "Async questions",
+          modelSelection: { provider: "codex", model: "gpt-5-codex" },
+          runtimeMode: "approval-required",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          createdAt,
+        }),
+      );
+      await system.run(
+        system.engine.dispatch({
+          type: "thread.messages.import",
+          commandId: CommandId.makeUnsafe("original-message"),
+          threadId,
+          createdAt,
+          messages: [
+            {
+              messageId: MessageId.makeUnsafe("original-message"),
+              role: "user",
+              text: "Investigate this issue",
+              createdAt,
+              updatedAt: createdAt,
+            },
+          ],
+        }),
+      );
+      await system.run(
+        system.engine.dispatch({
+          type: "thread.turn.diff.complete",
+          commandId: CommandId.makeUnsafe("original-checkpoint"),
+          threadId,
+          turnId,
+          checkpointTurnCount: 1,
+          checkpointRef: CheckpointRef.makeUnsafe("original-checkpoint"),
+          status: "ready",
+          files: [],
+          completedAt: createdAt,
+          createdAt,
+        }),
+      );
+      await system.run(system.engine.dispatch(appendQuestion("question-arrived")));
+      // A long-running agent must not evict the card from the bounded activity window.
+      await system.run(system.sql`
       WITH RECURSIVE numbers(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM numbers WHERE n < 2200)
       INSERT INTO projection_thread_activities
         (activity_id, thread_id, turn_id, tone, kind, summary, payload_json, sequence, created_at)
       SELECT 'work-' || n, ${threadId}, ${turnId}, 'tool', 'tool.completed', 'Done', '{}', n + 100,
         '2026-09-10T12:01:00.000Z' FROM numbers
     `);
-    const pending = Option.getOrThrow(await system.run(system.query.getThreadDetailById(threadId)));
-    expect(pending.activities.find((activity) => activity.id === question!.id)?.payload).toEqual(question!.payload);
-    expect(pending.hasPendingUserInput).toBe(false);
-    expect(pending.pendingInteractions).toEqual([]);
-    const snapshot = await system.run(system.query.getSnapshot());
-    expect(snapshot.threads[0]?.activities.some((activity) => activity.id === question!.id)).toBe(true);
+      const pending = Option.getOrThrow(
+        await system.run(system.query.getThreadDetailById(threadId)),
+      );
+      expect(pending.activities.find((activity) => activity.id === question!.id)?.payload).toEqual(
+        question!.payload,
+      );
+      expect(pending.hasPendingUserInput).toBe(false);
+      expect(pending.pendingInteractions).toEqual([]);
+      const snapshot = await system.run(system.query.getSnapshot());
+      expect(snapshot.threads[0]?.activities.some((activity) => activity.id === question!.id)).toBe(
+        true,
+      );
 
-    await system.dispose();
-    system = await createSystem(dbPath);
-    await system.run(system.engine.dispatch({
-      type: "thread.session.set",
-      commandId: CommandId.makeUnsafe("set-session"),
-      threadId,
-      session: {
-        threadId,
-        status,
-        providerName: "codex",
-        runtimeMode: "approval-required",
-        activeTurnId: status === "running" ? turnId : null,
-        lastError: null,
-        updatedAt: createdAt,
-      },
-      createdAt,
-    }));
-    const submissions = await Promise.allSettled([
-      system.run(system.engine.dispatch(respond("answer-tab-a"))),
-      system.run(system.engine.dispatch(respond("answer-tab-b"))),
-    ]);
-    expect(submissions.filter((result) => result.status === "fulfilled")).toHaveLength(1);
-    expect(submissions.filter((result) => result.status === "rejected")).toHaveLength(1);
-    const answered = Option.getOrThrow(await system.run(system.query.getThreadDetailById(threadId)));
-    expect(answered.messages).toHaveLength(2);
-    const answerMessageId = answered.messages.at(-1)!.id;
-    expect(answered.messages.at(-1)?.text).toBe("What triggers it?\nSwitching tabs quickly");
-    expect(answered.activities.find((activity) => activity.id === question!.id)?.payload).toMatchObject({
-      response: { answers: ["Switching tabs quickly"], messageId: answerMessageId },
-    });
-    const events = Array.from(await system.run(Stream.runCollect(system.engine.readEvents(0))));
-    expect(events.filter((event) => event.type === "thread.turn-start-requested")).toHaveLength(1);
-    expect(events.find((event) => event.type === "thread.turn-start-requested")?.payload).toMatchObject({ dispatchMode: "steer" });
-    expect(events.some((event) => event.type === "thread.turn-interrupt-requested")).toBe(false);
+      await system.dispose();
+      system = await createSystem(dbPath);
+      await system.run(
+        system.engine.dispatch({
+          type: "thread.session.set",
+          commandId: CommandId.makeUnsafe("set-session"),
+          threadId,
+          session: {
+            threadId,
+            status,
+            providerName: "codex",
+            runtimeMode: "approval-required",
+            activeTurnId: status === "running" ? turnId : null,
+            lastError: null,
+            updatedAt: createdAt,
+          },
+          createdAt,
+        }),
+      );
+      const submissions = await Promise.allSettled([
+        system.run(system.engine.dispatch(respond("answer-tab-a"))),
+        system.run(system.engine.dispatch(respond("answer-tab-b"))),
+      ]);
+      expect(submissions.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+      expect(submissions.filter((result) => result.status === "rejected")).toHaveLength(1);
+      const answered = Option.getOrThrow(
+        await system.run(system.query.getThreadDetailById(threadId)),
+      );
+      expect(answered.messages).toHaveLength(2);
+      const answerMessageId = answered.messages.at(-1)!.id;
+      expect(answered.messages.at(-1)?.text).toBe("What triggers it?\nSwitching tabs quickly");
+      expect(
+        answered.activities.find((activity) => activity.id === question!.id)?.payload,
+      ).toMatchObject({
+        response: { answers: ["Switching tabs quickly"], messageId: answerMessageId },
+      });
+      const events = Array.from(await system.run(Stream.runCollect(system.engine.readEvents(0))));
+      expect(events.filter((event) => event.type === "thread.turn-start-requested")).toHaveLength(
+        1,
+      );
+      expect(
+        events.find((event) => event.type === "thread.turn-start-requested")?.payload,
+      ).toMatchObject({ dispatchMode: "steer" });
+      expect(events.some((event) => event.type === "thread.turn-interrupt-requested")).toBe(false);
 
-    await system.dispose();
-    system = await createSystem(dbPath);
-    await system.run(system.engine.dispatch(appendQuestion("replayed-item")));
-    await expect(system.run(system.engine.dispatch(respond("answer-after-restart")))).rejects.toThrow("already answered");
-    const restarted = Option.getOrThrow(await system.run(system.query.getThreadDetailById(threadId)));
-    expect(restarted.activities.find((activity) => activity.id === question!.id)?.payload).toMatchObject({ response: { answers: ["Switching tabs quickly"] } });
+      await system.dispose();
+      system = await createSystem(dbPath);
+      await system.run(system.engine.dispatch(appendQuestion("replayed-item")));
+      await expect(
+        system.run(system.engine.dispatch(respond("answer-after-restart"))),
+      ).rejects.toThrow("already answered");
+      const restarted = Option.getOrThrow(
+        await system.run(system.query.getThreadDetailById(threadId)),
+      );
+      expect(
+        restarted.activities.find((activity) => activity.id === question!.id)?.payload,
+      ).toMatchObject({ response: { answers: ["Switching tabs quickly"] } });
 
-    await system.run(system.engine.dispatch(status === "ready" ? {
-      type: "thread.conversation.rollback.complete", commandId: CommandId.makeUnsafe("remove-answer"),
-      threadId, messageId: answerMessageId, numTurns: 1, removedTurnIds: [TurnId.makeUnsafe("answer-turn")], createdAt,
-    } : {
-      type: "thread.revert.complete", commandId: CommandId.makeUnsafe("remove-answer"),
-      threadId, turnCount: 1, createdAt,
-    }));
-    const reopened = Option.getOrThrow(await system.run(system.query.getThreadDetailById(threadId)));
-    expect(reopened.messages.map((message) => message.id)).toEqual(["original-message"]);
-    expect(reopened.activities.find((activity) => activity.id === question!.id)?.payload).toEqual(question!.payload);
+      await system.run(
+        system.engine.dispatch(
+          status === "ready"
+            ? {
+                type: "thread.conversation.rollback.complete",
+                commandId: CommandId.makeUnsafe("remove-answer"),
+                threadId,
+                messageId: answerMessageId,
+                numTurns: 1,
+                removedTurnIds: [TurnId.makeUnsafe("answer-turn")],
+                createdAt,
+              }
+            : {
+                type: "thread.revert.complete",
+                commandId: CommandId.makeUnsafe("remove-answer"),
+                threadId,
+                turnCount: 1,
+                createdAt,
+              },
+        ),
+      );
+      const reopened = Option.getOrThrow(
+        await system.run(system.query.getThreadDetailById(threadId)),
+      );
+      expect(reopened.messages.map((message) => message.id)).toEqual(["original-message"]);
+      expect(reopened.activities.find((activity) => activity.id === question!.id)?.payload).toEqual(
+        question!.payload,
+      );
 
-    // The in-memory projector must agree with SQLite when replaying the same history.
-    let replayed = createEmptyReadModel(createdAt);
-    const history = await system.run(Stream.runCollect(system.engine.readEvents(0)));
-    for (const event of history) {
-      replayed = await Effect.runPromise(projectEvent(replayed, event));
+      // The in-memory projector must agree with SQLite when replaying the same history.
+      let replayed = createEmptyReadModel(createdAt);
+      const history = await system.run(Stream.runCollect(system.engine.readEvents(0)));
+      for (const event of history) {
+        replayed = await Effect.runPromise(projectEvent(replayed, event));
+      }
+      expect(
+        replayed.threads[0]?.activities.find((activity) => activity.id === question!.id)?.payload,
+      ).toEqual(question!.payload);
+
+      await system.dispose();
+      system = await createSystem(dbPath);
+      await system.run(system.engine.dispatch(respond("replacement-answer")));
+      const replaced = Option.getOrThrow(
+        await system.run(system.query.getThreadDetailById(threadId)),
+      );
+      expect(
+        replaced.activities.find((activity) => activity.id === question!.id)?.payload,
+      ).toMatchObject({
+        response: { messageId: "replacement-answer" },
+      });
+    } finally {
+      await system.dispose();
+      fs.rmSync(stateDir, { recursive: true, force: true });
     }
-    expect(replayed.threads[0]?.activities.find((activity) => activity.id === question!.id)?.payload).toEqual(question!.payload);
-
-    await system.dispose();
-    system = await createSystem(dbPath);
-    await system.run(system.engine.dispatch(respond("replacement-answer")));
-    const replaced = Option.getOrThrow(await system.run(system.query.getThreadDetailById(threadId)));
-    expect(replaced.activities.find((activity) => activity.id === question!.id)?.payload).toMatchObject({
-      response: { messageId: "replacement-answer" },
-    });
-  } finally {
-    await system.dispose();
-    fs.rmSync(stateDir, { recursive: true, force: true });
-  }
-});
+  },
+);

--- a/apps/server/src/orchestration/Services/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Services/ProjectionSnapshotQuery.ts
@@ -7,6 +7,7 @@
  * @module ProjectionSnapshotQuery
  */
 import type {
+  EventId,
   OrchestrationCheckpointSummary,
   OrchestrationProject,
   OrchestrationProjectShell,
@@ -240,6 +241,8 @@ export interface ProjectionSnapshotQueryShape {
    */
   readonly getThreadDetailById: (
     threadId: ThreadId,
+    // Command validation may include one archived activity without unbounding public snapshots.
+    options?: { readonly includeActivityId?: EventId },
   ) => Effect.Effect<Option.Option<OrchestrationThread>, ProjectionRepositoryError>;
 
   /**

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -33,6 +33,7 @@ import {
 } from "@synara/shared/conversationEdit";
 import { Effect } from "effect";
 import {
+  canRespondToAsyncUserInput,
   formatAsyncUserInputResponse,
   isAsyncUserInputActivity,
 } from "@synara/shared/asyncUserInput";
@@ -1781,6 +1782,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         : undefined;
       if (asyncResponse) {
         if (
+          !canRespondToAsyncUserInput(targetThread) ||
           (targetThread.session?.providerName ?? targetThread.modelSelection.provider) !==
             "codex" ||
           (command.modelSelection ?? targetThread.modelSelection).provider !== "codex" ||
@@ -1895,7 +1897,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           dispatchOrigin: command.dispatchOrigin ?? "user",
           turnId: null,
           streaming: false,
-          source: "native",
+          source: asyncResponse ? "async-user-input" : "native",
           createdAt: command.createdAt,
           updatedAt: command.createdAt,
         },

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -11,6 +11,7 @@ import {
   EventId,
   MAX_PINNED_PROJECTS,
   PINNED_MESSAGES_MAX_COUNT,
+  PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
   RESERVED_VOID_SPACE_ID,
   SPACES_MAX_COUNT,
   THREAD_GOAL_ACHIEVEMENTS_MAX_COUNT,
@@ -31,6 +32,10 @@ import {
   resolveTailUserMessageEditTarget,
 } from "@synara/shared/conversationEdit";
 import { Effect } from "effect";
+import {
+  formatAsyncUserInputResponse,
+  isAsyncUserInputActivity,
+} from "@synara/shared/asyncUserInput";
 
 import { OrchestrationCommandInvariantError } from "./Errors.ts";
 import { buildForkThreadTitle } from "./forkThreadTitle.ts";
@@ -1770,6 +1775,26 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         threadId: command.threadId,
       });
       yield* validateSidechatExecutionAvailable(command, targetThread);
+      const asyncResponse = command.asyncUserInputResponse;
+      const asyncQuestion = asyncResponse
+        ? targetThread.activities.find((activity) => activity.id === asyncResponse.activityId)
+        : undefined;
+      if (asyncResponse) {
+        if (
+          (targetThread.session?.providerName ?? targetThread.modelSelection.provider) !== "codex" ||
+          (command.modelSelection ?? targetThread.modelSelection).provider !== "codex" ||
+          !asyncQuestion || !isAsyncUserInputActivity(asyncQuestion) ||
+          asyncQuestion.payload.response ||
+          asyncResponse.answers.length !== asyncQuestion.payload.questions.length ||
+          command.sourceProposedPlan || command.reviewTarget ||
+          command.message.attachments.length > 0
+        ) {
+          return yield* new OrchestrationCommandInvariantError({
+            commandType: command.type,
+            detail: "This Codex question is unavailable, already answered, or has incomplete answers.",
+          });
+        }
+      }
       if (command.resumePrecondition !== undefined) {
         // Quit-resume continuations are only valid while the thread is exactly as
         // it was recorded; checked here so it holds inside the serialized dispatch.
@@ -1795,9 +1820,11 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       // Respect settings changed before its serialized dispatch instead of
       // replaying the planner's stale permission or interaction mode.
       const runtimeMode =
-        command.resumePrecondition === undefined ? command.runtimeMode : targetThread.runtimeMode;
+        command.resumePrecondition === undefined && !asyncResponse
+          ? command.runtimeMode
+          : targetThread.runtimeMode;
       const interactionMode =
-        command.resumePrecondition === undefined
+        command.resumePrecondition === undefined && !asyncResponse
           ? command.interactionMode
           : targetThread.interactionMode;
       yield* validateAutoRuntimeMode(
@@ -1816,7 +1843,16 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         sourceProposedPlan && sourceThread
           ? sourceThread.proposedPlans.find((entry) => entry.id === sourceProposedPlan.planId)
           : null;
-      const dispatchMode = command.dispatchMode ?? "queue";
+      const dispatchMode = asyncResponse ? "steer" : (command.dispatchMode ?? "queue");
+      const messageText = asyncResponse && asyncQuestion && isAsyncUserInputActivity(asyncQuestion)
+        ? formatAsyncUserInputResponse(asyncQuestion.payload.questions, asyncResponse.answers)
+        : command.message.text;
+      if (messageText.length > PROVIDER_SEND_TURN_MAX_INPUT_CHARS) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: "The question and answer exceed the maximum message length.",
+        });
+      }
       if (sourceProposedPlan && !sourcePlan) {
         return yield* new OrchestrationCommandInvariantError({
           commandType: command.type,
@@ -1841,7 +1877,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           threadId: command.threadId,
           messageId: command.message.messageId,
           role: "user",
-          text: command.message.text,
+          text: messageText,
           attachments: command.message.attachments,
           ...(command.message.skills !== undefined ? { skills: command.message.skills } : {}),
           ...(command.message.mentions !== undefined ? { mentions: command.message.mentions } : {}),
@@ -1918,6 +1954,31 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
               createdAt: command.createdAt,
             },
           },
+        ];
+      }
+      if (asyncResponse && asyncQuestion && isAsyncUserInputActivity(asyncQuestion)) {
+        return [
+          userMessageEvent,
+          {
+            ...withEventBase({
+              aggregateKind: "thread",
+              aggregateId: command.threadId,
+              occurredAt: command.createdAt,
+              commandId: command.commandId,
+            }),
+            type: "thread.activity-appended",
+            payload: {
+              threadId: command.threadId,
+              activity: {
+                ...asyncQuestion,
+                payload: {
+                  questions: asyncQuestion.payload.questions,
+                  response: { answers: asyncResponse.answers, messageId: command.message.messageId },
+                },
+              },
+            },
+          },
+          queuedEvent,
         ];
       }
       return [userMessageEvent, queuedEvent];
@@ -2619,11 +2680,15 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
     }
 
     case "thread.activity.append": {
-      yield* requireThread({
+      const thread = yield* requireThread({
         readModel,
         command,
         threadId: command.threadId,
       });
+      // Replayed item completions must never reopen an already-submitted question.
+      const activity = isAsyncUserInputActivity(command.activity)
+        ? thread.activities.find((entry) => entry.id === command.activity.id) ?? command.activity
+        : command.activity;
       const requestId =
         typeof command.activity.payload === "object" &&
         command.activity.payload !== null &&
@@ -2643,7 +2708,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         type: "thread.activity-appended",
         payload: {
           threadId: command.threadId,
-          activity: command.activity,
+          activity,
         },
       };
     }

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1781,17 +1781,21 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         : undefined;
       if (asyncResponse) {
         if (
-          (targetThread.session?.providerName ?? targetThread.modelSelection.provider) !== "codex" ||
+          (targetThread.session?.providerName ?? targetThread.modelSelection.provider) !==
+            "codex" ||
           (command.modelSelection ?? targetThread.modelSelection).provider !== "codex" ||
-          !asyncQuestion || !isAsyncUserInputActivity(asyncQuestion) ||
+          !asyncQuestion ||
+          !isAsyncUserInputActivity(asyncQuestion) ||
           asyncQuestion.payload.response ||
           asyncResponse.answers.length !== asyncQuestion.payload.questions.length ||
-          command.sourceProposedPlan || command.reviewTarget ||
+          command.sourceProposedPlan ||
+          command.reviewTarget ||
           command.message.attachments.length > 0
         ) {
           return yield* new OrchestrationCommandInvariantError({
             commandType: command.type,
-            detail: "This Codex question is unavailable, already answered, or has incomplete answers.",
+            detail:
+              "This Codex question is unavailable, already answered, or has incomplete answers.",
           });
         }
       }
@@ -1844,9 +1848,10 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           ? sourceThread.proposedPlans.find((entry) => entry.id === sourceProposedPlan.planId)
           : null;
       const dispatchMode = asyncResponse ? "steer" : (command.dispatchMode ?? "queue");
-      const messageText = asyncResponse && asyncQuestion && isAsyncUserInputActivity(asyncQuestion)
-        ? formatAsyncUserInputResponse(asyncQuestion.payload.questions, asyncResponse.answers)
-        : command.message.text;
+      const messageText =
+        asyncResponse && asyncQuestion && isAsyncUserInputActivity(asyncQuestion)
+          ? formatAsyncUserInputResponse(asyncQuestion.payload.questions, asyncResponse.answers)
+          : command.message.text;
       if (messageText.length > PROVIDER_SEND_TURN_MAX_INPUT_CHARS) {
         return yield* new OrchestrationCommandInvariantError({
           commandType: command.type,
@@ -1973,7 +1978,10 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
                 ...asyncQuestion,
                 payload: {
                   questions: asyncQuestion.payload.questions,
-                  response: { answers: asyncResponse.answers, messageId: command.message.messageId },
+                  response: {
+                    answers: asyncResponse.answers,
+                    messageId: command.message.messageId,
+                  },
                 },
               },
             },
@@ -2687,7 +2695,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       });
       // Replayed item completions must never reopen an already-submitted question.
       const activity = isAsyncUserInputActivity(command.activity)
-        ? thread.activities.find((entry) => entry.id === command.activity.id) ?? command.activity
+        ? (thread.activities.find((entry) => entry.id === command.activity.id) ?? command.activity)
         : command.activity;
       const requestId =
         typeof command.activity.payload === "object" &&

--- a/apps/server/src/orchestration/handoff.ts
+++ b/apps/server/src/orchestration/handoff.ts
@@ -1,3 +1,4 @@
+import { isNativeConversationMessageSource } from "@synara/shared/conversationEdit";
 import type { OrchestrationMessage, OrchestrationThread } from "@synara/contracts";
 import { unicodeSafeEndOffset } from "@synara/shared/text";
 
@@ -62,7 +63,7 @@ export function hasNativeHandoffMessages(thread: Pick<OrchestrationThread, "mess
   return thread.messages.some(
     (message) =>
       (message.role === "user" || message.role === "assistant") &&
-      message.source === "native" &&
+      isNativeConversationMessageSource(message.source) &&
       message.streaming === false,
   );
 }
@@ -80,7 +81,9 @@ export function hasNativeAssistantMessagesBefore(
   }
   return thread.messages.slice(0, currentIndex).some((message) => {
     return (
-      message.role === "assistant" && message.source === "native" && message.streaming === false
+      message.role === "assistant" &&
+      isNativeConversationMessageSource(message.source) &&
+      message.streaming === false
     );
   });
 }

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -1714,7 +1714,7 @@ describe("orchestration projector", () => {
     expect(afterReplacement.threads[0]?.activities[1]?.summary).toBe("late updated");
   });
 
-  it("retains and updates async questions outside the normal activity window", async () => {
+  it("retains only unresolved async questions outside the normal activity window", async () => {
     const createdAt = "2026-09-10T00:00:00.000Z";
     let model = await projectThreadWithRunningTurn({ createdAt, startedAt: createdAt });
     let eventSequence = 2;
@@ -1754,28 +1754,20 @@ describe("orchestration projector", () => {
       await appendActivity(`tool-${index}`, index + 10, "tool.updated", {});
     }
     const activities = () => model.threads[0]!.activities;
-    expect(
-      activities()
-        .slice(0, 2)
-        .map((activity) => activity.id),
-    ).toEqual(["pending", "answered"]);
+    expect(activities()[0]?.id).toBe("pending");
+    expect(activities().some((activity) => activity.id === "answered")).toBe(false);
     expect(activities().filter((activity) => activity.kind === "tool.updated")).toHaveLength(500);
-    expect(activities()[2]?.id).toBe("tool-5");
+    expect(activities()[1]?.id).toBe("tool-5");
 
-    // Replacing an old card must preserve both its position and its submitted answer.
+    // Answering an old card releases its exception from the history cap.
     await appendActivity("pending", 3, "user-input.async", { questions, response: answer });
-    expect(activities()[0]?.payload).toEqual({ questions, response: answer });
-    expect(activities()[1]?.payload).toEqual({ questions, response: answer });
-    expect(activities().filter((activity) => activity.id === "pending")).toHaveLength(1);
+    expect(activities().some((activity) => activity.id === "pending")).toBe(false);
+    expect(activities()).toHaveLength(500);
 
-    // Replay can also insert older activities into an already capped snapshot.
+    // Replay can also insert older pending questions into an already capped snapshot.
     await appendActivity("older", 2, "user-input.async", { questions });
-    expect(
-      activities()
-        .slice(0, 3)
-        .map((activity) => activity.id),
-    ).toEqual(["older", "pending", "answered"]);
-    expect(activities()).toHaveLength(503);
+    expect(activities()[0]?.id).toBe("older");
+    expect(activities()).toHaveLength(501);
   });
 
   it("caps message and checkpoint retention for long-lived threads", async () => {

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -1714,6 +1714,70 @@ describe("orchestration projector", () => {
     expect(afterReplacement.threads[0]?.activities[1]?.summary).toBe("late updated");
   });
 
+  it("retains and updates async questions outside the normal activity window", async () => {
+    const createdAt = "2026-09-10T00:00:00.000Z";
+    let model = await projectThreadWithRunningTurn({ createdAt, startedAt: createdAt });
+    let eventSequence = 2;
+    const questions = [{ title: "Which approach?", options: ["A", "B"] }];
+    const answer = { answers: ["A"], messageId: "answer-1" };
+    const appendActivity = async (id: string, sequence: number, kind: string, payload: unknown) => {
+      model = await Effect.runPromise(
+        projectEvent(
+          model,
+          makeEvent({
+            sequence: ++eventSequence,
+            type: "thread.activity-appended",
+            aggregateKind: "thread",
+            aggregateId: "thread-1",
+            occurredAt: createdAt,
+            commandId: null,
+            payload: {
+              threadId: "thread-1",
+              activity: {
+                id,
+                sequence,
+                kind,
+                payload,
+                tone: "info",
+                summary: id,
+                turnId: null,
+                createdAt,
+              },
+            },
+          }),
+        ),
+      );
+    };
+    await appendActivity("pending", 3, "user-input.async", { questions });
+    await appendActivity("answered", 4, "user-input.async", { questions, response: answer });
+    for (let index = 0; index < 505; index += 1) {
+      await appendActivity(`tool-${index}`, index + 10, "tool.updated", {});
+    }
+    const activities = () => model.threads[0]!.activities;
+    expect(
+      activities()
+        .slice(0, 2)
+        .map((activity) => activity.id),
+    ).toEqual(["pending", "answered"]);
+    expect(activities().filter((activity) => activity.kind === "tool.updated")).toHaveLength(500);
+    expect(activities()[2]?.id).toBe("tool-5");
+
+    // Replacing an old card must preserve both its position and its submitted answer.
+    await appendActivity("pending", 3, "user-input.async", { questions, response: answer });
+    expect(activities()[0]?.payload).toEqual({ questions, response: answer });
+    expect(activities()[1]?.payload).toEqual({ questions, response: answer });
+    expect(activities().filter((activity) => activity.id === "pending")).toHaveLength(1);
+
+    // Replay can also insert older activities into an already capped snapshot.
+    await appendActivity("older", 2, "user-input.async", { questions });
+    expect(
+      activities()
+        .slice(0, 3)
+        .map((activity) => activity.id),
+    ).toEqual(["older", "pending", "answered"]);
+    expect(activities()).toHaveLength(503);
+  });
+
   it("caps message and checkpoint retention for long-lived threads", async () => {
     const createdAt = "2026-03-01T10:00:00.000Z";
     const model = createEmptyReadModel(createdAt);

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -1,10 +1,12 @@
 import {
-  CODEX_ASYNC_USER_INPUT_ACTIVITY_KIND,
   type OrchestrationEvent,
   type OrchestrationReadModel,
   type ThreadId,
 } from "@synara/contracts";
-import { reopenAsyncUserInputAfterMessageRemoval } from "@synara/shared/asyncUserInput";
+import {
+  isPendingAsyncUserInputActivity,
+  reopenAsyncUserInputAfterMessageRemoval,
+} from "@synara/shared/asyncUserInput";
 import {
   OrchestrationCheckpointSummary,
   OrchestrationMessage,
@@ -277,8 +279,7 @@ function capThreadActivities(
   return tailStart <= 0
     ? activities
     : activities.filter(
-        (activity, index) =>
-          index >= tailStart || activity.kind === CODEX_ASYNC_USER_INPUT_ACTIVITY_KIND,
+        (activity, index) => index >= tailStart || isPendingAsyncUserInputActivity(activity),
       );
 }
 

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -1,4 +1,5 @@
 import type { OrchestrationEvent, OrchestrationReadModel, ThreadId } from "@synara/contracts";
+import { reopenAsyncUserInputAfterMessageRemoval } from "@synara/shared/asyncUserInput";
 import {
   OrchestrationCheckpointSummary,
   OrchestrationMessage,
@@ -1329,7 +1330,15 @@ export function projectEvent(
             thread.proposedPlans,
             retainedTurnIds,
           ).slice(-200);
-          const activities = retainThreadActivitiesAfterRevert(thread.activities, retainedTurnIds);
+          const retainedMessageIds = new Set(messages.map((message) => message.id));
+          const activities = reopenAsyncUserInputAfterMessageRemoval(
+            retainThreadActivitiesAfterRevert(thread.activities, retainedTurnIds),
+            new Set(
+              thread.messages
+                .filter((message) => !retainedMessageIds.has(message.id))
+                .map((message) => message.id),
+            ),
+          );
 
           const latestCheckpoint = checkpoints.at(-1) ?? null;
           const latestTurn =
@@ -1386,8 +1395,16 @@ export function projectEvent(
           const proposedPlans = thread.proposedPlans
             .filter((plan) => plan.turnId === null || !rollback.removedTurnIds.has(plan.turnId))
             .slice(-200);
-          const activities = thread.activities.filter(
-            (activity) => activity.turnId === null || !rollback.removedTurnIds.has(activity.turnId),
+          const retainedMessageIds = new Set(rollback.messages.map((message) => message.id));
+          const activities = reopenAsyncUserInputAfterMessageRemoval(
+            thread.activities.filter(
+              (activity) => activity.turnId === null || !rollback.removedTurnIds.has(activity.turnId),
+            ),
+            new Set(
+              thread.messages
+                .filter((message) => !retainedMessageIds.has(message.id))
+                .map((message) => message.id),
+            ),
           );
           const latestCheckpoint = checkpoints.at(-1) ?? null;
 

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -1,4 +1,9 @@
-import type { OrchestrationEvent, OrchestrationReadModel, ThreadId } from "@synara/contracts";
+import {
+  CODEX_ASYNC_USER_INPUT_ACTIVITY_KIND,
+  type OrchestrationEvent,
+  type OrchestrationReadModel,
+  type ThreadId,
+} from "@synara/contracts";
 import { reopenAsyncUserInputAfterMessageRemoval } from "@synara/shared/asyncUserInput";
 import {
   OrchestrationCheckpointSummary,
@@ -265,6 +270,18 @@ function compareThreadActivities(
   return left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id);
 }
 
+function capThreadActivities(
+  activities: ReadonlyArray<OrchestrationThread["activities"][number]>,
+): ReadonlyArray<OrchestrationThread["activities"][number]> {
+  const tailStart = activities.length - MAX_THREAD_ACTIVITIES;
+  return tailStart <= 0
+    ? activities
+    : activities.filter(
+        (activity, index) =>
+          index >= tailStart || activity.kind === CODEX_ASYNC_USER_INPUT_ACTIVITY_KIND,
+      );
+}
+
 function upsertThreadActivity(
   activities: ReadonlyArray<OrchestrationThread["activities"][number]>,
   activity: OrchestrationThread["activities"][number],
@@ -273,7 +290,7 @@ function upsertThreadActivity(
   if (existingIndex >= 0 && compareThreadActivities(activities[existingIndex]!, activity) === 0) {
     const next = [...activities];
     next[existingIndex] = activity;
-    return next.slice(-MAX_THREAD_ACTIVITIES);
+    return capThreadActivities(next);
   }
 
   const withoutExisting =
@@ -282,7 +299,7 @@ function upsertThreadActivity(
       : [...activities.slice(0, existingIndex), ...activities.slice(existingIndex + 1)];
   const last = withoutExisting.at(-1);
   if (!last || compareThreadActivities(last, activity) <= 0) {
-    return [...withoutExisting, activity].slice(-MAX_THREAD_ACTIVITIES);
+    return capThreadActivities([...withoutExisting, activity]);
   }
 
   let low = 0;
@@ -295,9 +312,11 @@ function upsertThreadActivity(
       high = middle;
     }
   }
-  return [...withoutExisting.slice(0, low), activity, ...withoutExisting.slice(low)].slice(
-    -MAX_THREAD_ACTIVITIES,
-  );
+  return capThreadActivities([
+    ...withoutExisting.slice(0, low),
+    activity,
+    ...withoutExisting.slice(low),
+  ]);
 }
 
 export function createEmptyReadModel(nowIso: string): OrchestrationReadModel {
@@ -1398,7 +1417,8 @@ export function projectEvent(
           const retainedMessageIds = new Set(rollback.messages.map((message) => message.id));
           const activities = reopenAsyncUserInputAfterMessageRemoval(
             thread.activities.filter(
-              (activity) => activity.turnId === null || !rollback.removedTurnIds.has(activity.turnId),
+              (activity) =>
+                activity.turnId === null || !rollback.removedTurnIds.has(activity.turnId),
             ),
             new Set(
               thread.messages

--- a/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
+++ b/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
@@ -1,4 +1,5 @@
 import {
+  CODEX_ASYNC_USER_INPUT_ACTIVITY_KIND,
   ApprovalRequestId,
   EventId,
   isToolLifecycleItemType,
@@ -550,6 +551,23 @@ export function projectProviderRuntimeActivities(
     typeof sessionSequence === "number" && Number.isInteger(sessionSequence) && sessionSequence >= 0
       ? { sequence: sessionSequence }
       : {};
+  if (
+    event.provider === "codex" &&
+    event.type === "item.completed" &&
+    event.payload.asyncQuestions &&
+    event.itemId
+  ) {
+    return [{
+      id: EventId.makeUnsafe(`codex-async-question:${event.threadId}:${event.itemId}`),
+      createdAt: event.createdAt,
+      tone: "info",
+      kind: CODEX_ASYNC_USER_INPUT_ACTIVITY_KIND,
+      summary: "Question from Codex",
+      payload: toActivityPayload({ questions: event.payload.asyncQuestions }),
+      turnId: toTurnId(event.turnId) ?? null,
+      ...maybeSequence,
+    }];
+  }
   // Codex and Antigravity only render completed reasoning items with a readable summary.
   // Empty starts/completions are private/encrypted reasoning boundaries, not
   // transcript rows. Waiting for the authoritative completion also avoids

--- a/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
+++ b/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
@@ -557,16 +557,18 @@ export function projectProviderRuntimeActivities(
     event.payload.asyncQuestions &&
     event.itemId
   ) {
-    return [{
-      id: EventId.makeUnsafe(`codex-async-question:${event.threadId}:${event.itemId}`),
-      createdAt: event.createdAt,
-      tone: "info",
-      kind: CODEX_ASYNC_USER_INPUT_ACTIVITY_KIND,
-      summary: "Question from Codex",
-      payload: toActivityPayload({ questions: event.payload.asyncQuestions }),
-      turnId: toTurnId(event.turnId) ?? null,
-      ...maybeSequence,
-    }];
+    return [
+      {
+        id: EventId.makeUnsafe(`codex-async-question:${event.threadId}:${event.itemId}`),
+        createdAt: event.createdAt,
+        tone: "info",
+        kind: CODEX_ASYNC_USER_INPUT_ACTIVITY_KIND,
+        summary: "Question from Codex",
+        payload: toActivityPayload({ questions: event.payload.asyncQuestions }),
+        turnId: toTurnId(event.turnId) ?? null,
+        ...maybeSequence,
+      },
+    ];
   }
   // Codex and Antigravity only render completed reasoning items with a readable summary.
   // Empty starts/completions are private/encrypted reasoning boundaries, not

--- a/apps/server/src/profileStats.ts
+++ b/apps/server/src/profileStats.ts
@@ -680,7 +680,7 @@ const makeProfileStatsQuery = Effect.gen(function* () {
           FROM projection_thread_messages m
           JOIN projection_threads t ON t.thread_id = m.thread_id
           WHERE m.role = 'user'
-            AND m.source = 'native'
+            AND m.source IN ('native', 'async-user-input')
             AND (m.dispatch_origin IS NULL OR m.dispatch_origin = 'user')
           UNION ALL
           SELECT d.created_at AS created_at
@@ -983,7 +983,7 @@ const makeProfileStatsQuery = Effect.gen(function* () {
       FROM projection_thread_messages m
       JOIN projection_threads t ON t.thread_id = m.thread_id
       WHERE m.role = 'user'
-        AND m.source = 'native'
+        AND m.source IN ('native', 'async-user-input')
         AND (m.dispatch_origin IS NULL OR m.dispatch_origin = 'user')
         AND (
           (m.skills_json IS NOT NULL AND TRIM(m.skills_json) NOT IN ('', '[]'))
@@ -1040,7 +1040,7 @@ const makeProfileStatsQuery = Effect.gen(function* () {
           FROM projection_thread_messages m
           JOIN projection_threads t ON t.thread_id = m.thread_id
           WHERE m.role = 'user'
-            AND m.source = 'native'
+            AND m.source IN ('native', 'async-user-input')
             AND (m.dispatch_origin IS NULL OR m.dispatch_origin = 'user')
           UNION ALL
           SELECT

--- a/apps/server/src/profileStatsArchive.ts
+++ b/apps/server/src/profileStatsArchive.ts
@@ -652,7 +652,7 @@ const makeProfileStatsArchive = Effect.gen(function* () {
         FROM projection_thread_messages
         WHERE thread_id = ${threadId}
           AND role = 'user'
-          AND source = 'native'
+          AND source IN ('native', 'async-user-input')
           AND (dispatch_origin IS NULL OR dispatch_origin = 'user')
         ORDER BY created_at ASC, message_id ASC
       `;
@@ -690,7 +690,7 @@ const makeProfileStatsArchive = Effect.gen(function* () {
           FROM projection_thread_messages
           WHERE thread_id = ${threadId}
             AND role = 'user'
-            AND source = 'native'
+            AND source IN ('native', 'async-user-input')
             AND (dispatch_origin IS NULL OR dispatch_origin = 'user')
         `;
         yield* Effect.forEach(

--- a/apps/server/src/provider/Errors.ts
+++ b/apps/server/src/provider/Errors.ts
@@ -60,8 +60,8 @@ export class ProviderAdapterRequestError extends Schema.TaggedErrorClass<Provide
     provider: Schema.String,
     method: Schema.String,
     detail: Schema.String,
-    // Explicit proof that a steer submitted no input and needs a normal turn start.
-    reason: Schema.optional(Schema.Literal("turn-not-active")),
+    // Explicit proof that a steer submitted no input and can safely be retried.
+    reason: Schema.optional(Schema.Literals(["turn-not-active", "turn-not-steerable"])),
     cause: Schema.optional(Schema.Defect),
   },
 ) {

--- a/apps/server/src/provider/Errors.ts
+++ b/apps/server/src/provider/Errors.ts
@@ -60,6 +60,8 @@ export class ProviderAdapterRequestError extends Schema.TaggedErrorClass<Provide
     provider: Schema.String,
     method: Schema.String,
     detail: Schema.String,
+    // Explicit proof that a steer submitted no input and needs a normal turn start.
+    reason: Schema.optional(Schema.Literal("turn-not-active")),
     cause: Schema.optional(Schema.Defect),
   },
 ) {

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -771,6 +771,33 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
     }),
   );
 
+  it.effect("emits async questions only on completion, without a blocking request", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+      const questions = [
+        { title: "Which interaction triggers it?", options: ["Scrolling", "Switching tabs"] },
+        { title: "Anything else?", options: null },
+      ];
+      const event: ProviderEvent = {
+        id: asEventId("evt-async-start"), kind: "notification", provider: "codex",
+        createdAt: new Date().toISOString(), method: "item/started",
+        threadId: asThreadId("thread-1"), turnId: asTurnId("turn-1"),
+        itemId: asItemId("question-1"),
+        payload: { item: { type: "agentMessage", id: "question-1", delivery: "async", questions } },
+      };
+      lifecycleManager.emit("event", event);
+      lifecycleManager.emit("event", { ...event, id: asEventId("evt-async-complete"), method: "item/completed" });
+      const result = yield* Fiber.join(firstEventFiber);
+      assert.equal(result._tag, "Some");
+      if (result._tag !== "Some") return;
+      assert.equal(result.value.type, "item.completed");
+      if (result.value.type !== "item.completed") return;
+      assert.deepEqual(result.value.payload.asyncQuestions, questions);
+      assert.equal(result.value.requestId, undefined);
+    }),
+  );
+
   it.effect("keeps inspected images out of generated output artifacts", () =>
     Effect.gen(function* () {
       const adapter = yield* CodexAdapter;

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -23,7 +23,11 @@ import {
   type CodexAppServerSendTurnInput,
 } from "../../codexAppServerManager.ts";
 import { ServerConfig } from "../../config.ts";
-import { CodexSessionStartError, CodexTurnNotActiveError } from "../../codexErrorClassification.ts";
+import {
+  CodexSessionStartError,
+  CodexTurnNotActiveError,
+  CodexTurnNotSteerableError,
+} from "../../codexErrorClassification.ts";
 import { ProviderAdapterValidationError } from "../Errors.ts";
 import { CodexAdapter } from "../Services/CodexAdapter.ts";
 import { ProviderSessionDirectory } from "../Services/ProviderSessionDirectory.ts";
@@ -181,6 +185,7 @@ validationLayer("CodexAdapterLive validation", (it) => {
       const adapter = yield* CodexAdapter;
       for (const cause of [
         new CodexTurnNotActiveError("No active turn"),
+        new CodexTurnNotSteerableError("cannot steer a compact turn"),
         new Error("Timed out waiting for turn/steer."),
       ]) {
         validationManager.steerTurnImpl.mockRejectedValueOnce(cause);
@@ -194,7 +199,11 @@ validationLayer("CodexAdapterLive validation", (it) => {
         }
         assert.equal(
           result.failure.reason,
-          cause instanceof CodexTurnNotActiveError ? "turn-not-active" : undefined,
+          cause instanceof CodexTurnNotActiveError
+            ? "turn-not-active"
+            : cause instanceof CodexTurnNotSteerableError
+              ? "turn-not-steerable"
+              : undefined,
         );
       }
     }),

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -23,7 +23,7 @@ import {
   type CodexAppServerSendTurnInput,
 } from "../../codexAppServerManager.ts";
 import { ServerConfig } from "../../config.ts";
-import { CodexSessionStartError } from "../../codexErrorClassification.ts";
+import { CodexSessionStartError, CodexTurnNotActiveError } from "../../codexErrorClassification.ts";
 import { ProviderAdapterValidationError } from "../Errors.ts";
 import { CodexAdapter } from "../Services/CodexAdapter.ts";
 import { ProviderSessionDirectory } from "../Services/ProviderSessionDirectory.ts";
@@ -176,6 +176,30 @@ const validationLayer = it.layer(
 );
 
 validationLayer("CodexAdapterLive validation", (it) => {
+  it.effect("preserves only explicit evidence that a steer submitted no input", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      for (const cause of [
+        new CodexTurnNotActiveError("No active turn"),
+        new Error("Timed out waiting for turn/steer."),
+      ]) {
+        validationManager.steerTurnImpl.mockRejectedValueOnce(cause);
+        const result = yield* adapter.steerTurn!({
+          threadId: asThreadId("thread-1"),
+          input: "My answer",
+        }).pipe(Effect.result);
+        assert.equal(result._tag, "Failure");
+        if (result._tag !== "Failure" || result.failure._tag !== "ProviderAdapterRequestError") {
+          throw new Error("Expected request error");
+        }
+        assert.equal(
+          result.failure.reason,
+          cause instanceof CodexTurnNotActiveError ? "turn-not-active" : undefined,
+        );
+      }
+    }),
+  );
+
   it.effect(
     "preserves startup cleanup evidence without reclassifying unknown process failures",
     () =>
@@ -780,14 +804,22 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
         { title: "Anything else?", options: null },
       ];
       const event: ProviderEvent = {
-        id: asEventId("evt-async-start"), kind: "notification", provider: "codex",
-        createdAt: new Date().toISOString(), method: "item/started",
-        threadId: asThreadId("thread-1"), turnId: asTurnId("turn-1"),
+        id: asEventId("evt-async-start"),
+        kind: "notification",
+        provider: "codex",
+        createdAt: new Date().toISOString(),
+        method: "item/started",
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-1"),
         itemId: asItemId("question-1"),
         payload: { item: { type: "agentMessage", id: "question-1", delivery: "async", questions } },
       };
       lifecycleManager.emit("event", event);
-      lifecycleManager.emit("event", { ...event, id: asEventId("evt-async-complete"), method: "item/completed" });
+      lifecycleManager.emit("event", {
+        ...event,
+        id: asEventId("evt-async-complete"),
+        method: "item/completed",
+      });
       const result = yield* Fiber.join(firstEventFiber);
       assert.equal(result._tag, "Some");
       if (result._tag !== "Some") return;

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -67,6 +67,7 @@ import {
 } from "../../codexGeneratedImages.ts";
 import {
   CodexSessionStartError,
+  CodexTurnNotActiveError,
   isNonFatalCodexErrorMessage,
 } from "../../codexErrorClassification.ts";
 import { ServerConfig } from "../../config.ts";
@@ -235,6 +236,7 @@ function toRequestError(threadId: ThreadId, method: string, cause: unknown): Pro
     provider: PROVIDER,
     method,
     detail: toMessage(cause, `${method} failed`),
+    ...(cause instanceof CodexTurnNotActiveError ? { reason: "turn-not-active" as const } : {}),
     cause,
   });
 }

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -68,6 +68,7 @@ import {
 import {
   CodexSessionStartError,
   CodexTurnNotActiveError,
+  CodexTurnNotSteerableError,
   isNonFatalCodexErrorMessage,
 } from "../../codexErrorClassification.ts";
 import { ServerConfig } from "../../config.ts";
@@ -237,6 +238,9 @@ function toRequestError(threadId: ThreadId, method: string, cause: unknown): Pro
     method,
     detail: toMessage(cause, `${method} failed`),
     ...(cause instanceof CodexTurnNotActiveError ? { reason: "turn-not-active" as const } : {}),
+    ...(cause instanceof CodexTurnNotSteerableError
+      ? { reason: "turn-not-steerable" as const }
+      : {}),
     cause,
   });
 }

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -7,6 +7,7 @@
  * @module CodexAdapterLive
  */
 import {
+  AsyncUserInputQuestions,
   type ChatAttachment,
   type CanonicalItemType,
   type CanonicalRequestType,
@@ -862,6 +863,8 @@ function withMinimalRawPayload(
   };
 }
 
+const isAsyncUserInputQuestions = Schema.is(AsyncUserInputQuestions);
+
 function mapItemLifecycle(
   event: ProviderEvent,
   canonicalThreadId: ThreadId,
@@ -875,6 +878,14 @@ function mapItemLifecycle(
   }
 
   const itemType = toCanonicalItemType(source.type ?? source.kind);
+  const asyncQuestions =
+    itemType === "assistant_message" && isAsyncUserInputQuestions(source.questions)
+      ? source.questions
+      : undefined;
+  // Async questions arrive as complete agent messages, with no pending RPC to answer.
+  if (asyncQuestions && lifecycle !== "item.completed") {
+    return undefined;
+  }
   if (itemType === "unknown" && lifecycle !== "item.updated") {
     return undefined;
   }
@@ -913,6 +924,7 @@ function mapItemLifecycle(
     type: lifecycle,
     payload: {
       itemType: canonicalItemType,
+      ...(asyncQuestions ? { asyncQuestions } : {}),
       ...(status ? { status } : {}),
       ...(itemTitle(canonicalItemType) ? { title: itemTitle(canonicalItemType) } : {}),
       ...(generatedImageReference

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -510,6 +510,8 @@ import {
 } from "./chat/threadFind.logic";
 import { ThreadDetailHydrationState } from "./chat/ThreadDetailHydrationState";
 import type { MessagesTimelineController } from "./chat/MessagesTimeline";
+import { isAsyncUserInputActivity } from "@synara/shared/asyncUserInput";
+import type { RespondToAsyncUserInput } from "./chat/AsyncUserInputCard";
 import { buildTurnDiffSummaryByAssistantMessageId } from "./chat/MessagesTimeline.logic";
 import { deriveAgentActivityTimelineState } from "./chat/agentActivity.logic";
 import { ExpandedImagePreview } from "./chat/ExpandedImagePreview";
@@ -3481,14 +3483,44 @@ export default function ChatView({
     );
     return derivePromptHistoryFromMessages([...activeMessages, ...pendingOptimisticMessages]);
   }, [activeThread?.messages, optimisticUserMessages]);
+  const asyncQuestions = useMemo(
+    () => (activeThread?.activities ?? []).filter(isAsyncUserInputActivity),
+    [activeThread?.activities],
+  );
+  const asyncResponseThreadId = activeThread?.id;
+  const asyncResponseRuntimeMode = activeThread?.runtimeMode;
+  const asyncResponseInteractionMode = activeThread?.interactionMode;
+  const onRespondToAsyncUserInput = useCallback<RespondToAsyncUserInput>(async (response) => {
+    const api = readNativeApi();
+    if (!api || !asyncResponseThreadId || !asyncResponseRuntimeMode || !asyncResponseInteractionMode || isSidechatExpired) {
+      throw new Error("This conversation is unavailable. Reconnect and try again.");
+    }
+    await api.orchestration.dispatchCommand({
+      type: "thread.turn.start",
+      commandId: CommandId.makeUnsafe(crypto.randomUUID()),
+      threadId: asyncResponseThreadId,
+      asyncUserInputResponse: response,
+      message: {
+        messageId: MessageId.makeUnsafe(crypto.randomUUID()),
+        role: "user",
+        text: response.answers.join("\n\n"),
+        attachments: [],
+      },
+      dispatchMode: "steer",
+      runtimeMode: asyncResponseRuntimeMode,
+      interactionMode: asyncResponseInteractionMode,
+      createdAt: new Date().toISOString(),
+    });
+  }, [asyncResponseThreadId, asyncResponseRuntimeMode, asyncResponseInteractionMode, isSidechatExpired]);
   const timelineEntries = useMemo(
     () =>
       deriveTimelineEntries(
         timelineMessages,
         activeThread?.proposedPlans ?? [],
         agentActivityTimelineState.timelineWorkEntries,
+        asyncQuestions,
       ),
-    [activeThread?.proposedPlans, agentActivityTimelineState.timelineWorkEntries, timelineMessages],
+    [activeThread?.proposedPlans, agentActivityTimelineState.timelineWorkEntries, timelineMessages, asyncQuestions],
   );
   const enteringUserMessageIds = useMemo<ReadonlySet<MessageId>>(
     () => new Set(optimisticUserMessages.map((message) => message.id)),
@@ -12683,6 +12715,7 @@ export default function ChatView({
               <div className="flex min-h-0 flex-1 flex-col">
                 <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
                   <ChatTranscriptPane
+                    onRespondToAsyncUserInput={onRespondToAsyncUserInput}
                     activeThreadId={activeThread.id}
                     activeTurnId={activeTurnIdForTranscript}
                     agentActivityDetail={openAgentActivityDetail}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2,6 +2,7 @@ import {
   type AutomationDefinition,
   type AutomationSchedule,
   type ApprovalRequestId,
+  CommandId,
   DEFAULT_MODEL_BY_PROVIDER,
   EventId,
   MessageId,
@@ -45,6 +46,7 @@ import { respondingInteractionReclaimAt } from "@synara/shared/pendingInteractio
 import { providerSupportsNativeTurnSteering } from "@synara/shared/providerMetadata";
 import { getDefaultModel, getModelCapabilities, normalizeModelSlug } from "@synara/shared/model";
 import {
+  isNativeConversationMessageSource,
   resolveLatestTailUserMessageEditTarget,
   resolveTailUserMessageEditTarget,
 } from "@synara/shared/conversationEdit";
@@ -510,7 +512,10 @@ import {
 } from "./chat/threadFind.logic";
 import { ThreadDetailHydrationState } from "./chat/ThreadDetailHydrationState";
 import type { MessagesTimelineController } from "./chat/MessagesTimeline";
-import { isAsyncUserInputActivity } from "@synara/shared/asyncUserInput";
+import {
+  canRespondToAsyncUserInput,
+  isAsyncUserInputActivity,
+} from "@synara/shared/asyncUserInput";
 import type { RespondToAsyncUserInput } from "./chat/AsyncUserInputCard";
 import { buildTurnDiffSummaryByAssistantMessageId } from "./chat/MessagesTimeline.logic";
 import { deriveAgentActivityTimelineState } from "./chat/agentActivity.logic";
@@ -3488,6 +3493,7 @@ export default function ChatView({
     [activeThread?.activities],
   );
   const asyncResponseThreadId = activeThread?.id;
+  const asyncResponseAllowed = activeThread ? canRespondToAsyncUserInput(activeThread) : false;
   const asyncResponseRuntimeMode = activeThread?.runtimeMode;
   const asyncResponseInteractionMode = activeThread?.interactionMode;
   const onRespondToAsyncUserInput = useCallback<RespondToAsyncUserInput>(
@@ -3495,6 +3501,7 @@ export default function ChatView({
       const api = readNativeApi();
       if (
         !api ||
+        !asyncResponseAllowed ||
         !asyncResponseThreadId ||
         !asyncResponseRuntimeMode ||
         !asyncResponseInteractionMode ||
@@ -3521,6 +3528,7 @@ export default function ChatView({
     },
     [
       asyncResponseThreadId,
+      asyncResponseAllowed,
       asyncResponseRuntimeMode,
       asyncResponseInteractionMode,
       isSidechatExpired,
@@ -4259,7 +4267,7 @@ export default function ChatView({
   const hasNativeUserMessages = useMemo(
     () =>
       activeThread?.messages.some(
-        (message) => message.role === "user" && message.source === "native",
+        (message) => message.role === "user" && isNativeConversationMessageSource(message.source),
       ) ?? false,
     [activeThread?.messages],
   );
@@ -12734,7 +12742,7 @@ export default function ChatView({
               <div className="flex min-h-0 flex-1 flex-col">
                 <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
                   <ChatTranscriptPane
-                    onRespondToAsyncUserInput={onRespondToAsyncUserInput}
+                    {...(asyncResponseAllowed ? { onRespondToAsyncUserInput } : {})}
                     activeThreadId={activeThread.id}
                     activeTurnId={activeTurnIdForTranscript}
                     agentActivityDetail={openAgentActivityDetail}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3490,28 +3490,42 @@ export default function ChatView({
   const asyncResponseThreadId = activeThread?.id;
   const asyncResponseRuntimeMode = activeThread?.runtimeMode;
   const asyncResponseInteractionMode = activeThread?.interactionMode;
-  const onRespondToAsyncUserInput = useCallback<RespondToAsyncUserInput>(async (response) => {
-    const api = readNativeApi();
-    if (!api || !asyncResponseThreadId || !asyncResponseRuntimeMode || !asyncResponseInteractionMode || isSidechatExpired) {
-      throw new Error("This conversation is unavailable. Reconnect and try again.");
-    }
-    await api.orchestration.dispatchCommand({
-      type: "thread.turn.start",
-      commandId: CommandId.makeUnsafe(crypto.randomUUID()),
-      threadId: asyncResponseThreadId,
-      asyncUserInputResponse: response,
-      message: {
-        messageId: MessageId.makeUnsafe(crypto.randomUUID()),
-        role: "user",
-        text: response.answers.join("\n\n"),
-        attachments: [],
-      },
-      dispatchMode: "steer",
-      runtimeMode: asyncResponseRuntimeMode,
-      interactionMode: asyncResponseInteractionMode,
-      createdAt: new Date().toISOString(),
-    });
-  }, [asyncResponseThreadId, asyncResponseRuntimeMode, asyncResponseInteractionMode, isSidechatExpired]);
+  const onRespondToAsyncUserInput = useCallback<RespondToAsyncUserInput>(
+    async (response) => {
+      const api = readNativeApi();
+      if (
+        !api ||
+        !asyncResponseThreadId ||
+        !asyncResponseRuntimeMode ||
+        !asyncResponseInteractionMode ||
+        isSidechatExpired
+      ) {
+        throw new Error("This conversation is unavailable. Reconnect and try again.");
+      }
+      await api.orchestration.dispatchCommand({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe(crypto.randomUUID()),
+        threadId: asyncResponseThreadId,
+        asyncUserInputResponse: response,
+        message: {
+          messageId: MessageId.makeUnsafe(crypto.randomUUID()),
+          role: "user",
+          text: response.answers.join("\n\n"),
+          attachments: [],
+        },
+        dispatchMode: "steer",
+        runtimeMode: asyncResponseRuntimeMode,
+        interactionMode: asyncResponseInteractionMode,
+        createdAt: new Date().toISOString(),
+      });
+    },
+    [
+      asyncResponseThreadId,
+      asyncResponseRuntimeMode,
+      asyncResponseInteractionMode,
+      isSidechatExpired,
+    ],
+  );
   const timelineEntries = useMemo(
     () =>
       deriveTimelineEntries(
@@ -3520,7 +3534,12 @@ export default function ChatView({
         agentActivityTimelineState.timelineWorkEntries,
         asyncQuestions,
       ),
-    [activeThread?.proposedPlans, agentActivityTimelineState.timelineWorkEntries, timelineMessages, asyncQuestions],
+    [
+      activeThread?.proposedPlans,
+      agentActivityTimelineState.timelineWorkEntries,
+      timelineMessages,
+      asyncQuestions,
+    ],
   );
   const enteringUserMessageIds = useMemo<ReadonlySet<MessageId>>(
     () => new Set(optimisticUserMessages.map((message) => message.id)),

--- a/apps/web/src/components/chat/AsyncUserInputCard.browser.tsx
+++ b/apps/web/src/components/chat/AsyncUserInputCard.browser.tsx
@@ -7,25 +7,46 @@ import { render } from "vitest-browser-react";
 import { AsyncUserInputCard } from "./AsyncUserInputCard";
 
 const question: AsyncUserInputActivity = {
-  id: EventId.makeUnsafe("question-1"), kind: "user-input.async", tone: "info",
-  summary: "Question from Codex", createdAt: "2026-09-10T12:00:00.000Z", turnId: null,
-  payload: { questions: [
-    { title: "Which interaction triggers the problem?", options: ["Switching tabs", "Scrolling"] },
-    { title: "What else should I know?", options: null },
-  ] },
+  id: EventId.makeUnsafe("question-1"),
+  kind: "user-input.async",
+  tone: "info",
+  summary: "Question from Codex",
+  createdAt: "2026-09-10T12:00:00.000Z",
+  turnId: null,
+  payload: {
+    questions: [
+      {
+        title: "Which interaction triggers the problem?",
+        options: ["Switching tabs", "Scrolling"],
+      },
+      { title: "What else should I know?", options: null },
+    ],
+  },
 };
 
 it("keeps suggested choices unsubmitted and accepts free text while work continues", async () => {
   let finish: () => void = () => {};
-  const onRespond = vi.fn(() => new Promise<void>((resolve) => { finish = resolve; }));
-  await render(<div style={{ width: 560, padding: 16 }}><AsyncUserInputCard activity={question} onRespond={onRespond} /></div>);
-  await expect.element(page.getByRole("button", { name: "Switching tabs" })).toHaveAttribute("aria-pressed", "true");
+  const onRespond = vi.fn(
+    () =>
+      new Promise<void>((resolve) => {
+        finish = resolve;
+      }),
+  );
+  await render(
+    <div style={{ width: 560, padding: 16 }}>
+      <AsyncUserInputCard activity={question} onRespond={onRespond} />
+    </div>,
+  );
+  await expect
+    .element(page.getByRole("button", { name: "Switching tabs" }))
+    .toHaveAttribute("aria-pressed", "true");
   expect(onRespond).not.toHaveBeenCalled();
   await page.getByLabelText("Or write your own answer").fill("Resizing the window");
   await page.getByLabelText("Your answer", { exact: true }).fill("Only with a long transcript");
   await page.getByRole("button", { name: "Submit answer" }).click();
   expect(onRespond).toHaveBeenCalledExactlyOnceWith({
-    activityId: question.id, answers: ["Resizing the window", "Only with a long transcript"],
+    activityId: question.id,
+    answers: ["Resizing the window", "Only with a long transcript"],
   });
   await expect.element(page.getByRole("button", { name: "Submitting…" })).toBeDisabled();
   finish();
@@ -35,9 +56,21 @@ it("keeps suggested choices unsubmitted and accepts free text while work continu
 
 it("restores submitted answers and never offers another submission after refresh", async () => {
   const onRespond = vi.fn();
-  await render(<AsyncUserInputCard activity={{ ...question, payload: {
-    ...question.payload, response: { answers: ["Scrolling", "After a reconnect"], messageId: MessageId.makeUnsafe("answer-1") },
-  } }} onRespond={onRespond} />);
+  await render(
+    <AsyncUserInputCard
+      activity={{
+        ...question,
+        payload: {
+          ...question.payload,
+          response: {
+            answers: ["Scrolling", "After a reconnect"],
+            messageId: MessageId.makeUnsafe("answer-1"),
+          },
+        },
+      }}
+      onRespond={onRespond}
+    />,
+  );
   await expect.element(page.getByText("Answer submitted")).toBeVisible();
   await expect.element(page.getByText("After a reconnect")).toBeVisible();
   await expect.element(page.getByRole("button", { name: "Submit answer" })).not.toBeInTheDocument();
@@ -45,31 +78,59 @@ it("restores submitted answers and never offers another submission after refresh
 });
 
 it("keeps the draft available when submission fails", async () => {
-  const onRespond = vi.fn().mockRejectedValueOnce(new Error("Connection lost")).mockResolvedValue(undefined);
+  const onRespond = vi
+    .fn()
+    .mockRejectedValueOnce(new Error("Connection lost"))
+    .mockResolvedValue(undefined);
   await render(<AsyncUserInputCard activity={question} onRespond={onRespond} />);
   await page.getByLabelText("Your answer", { exact: true }).fill("After a reconnect");
   await page.getByRole("button", { name: "Submit answer" }).click();
   await expect.element(page.getByRole("alert")).toHaveTextContent("Connection lost");
-  await expect.element(page.getByLabelText("Your answer", { exact: true })).toHaveValue("After a reconnect");
+  await expect
+    .element(page.getByLabelText("Your answer", { exact: true }))
+    .toHaveValue("After a reconnect");
   await page.getByRole("button", { name: "Submit answer" }).click();
   await expect.element(page.getByText("Answer submitted")).toBeVisible();
 });
 
-it.each([true, false])("reopens a rolled-back reply (rendered saved answer: %s)", async (renderSavedAnswer) => {
-  const onRespond = vi.fn().mockResolvedValue(undefined);
-  const screen = await render(<AsyncUserInputCard activity={question} onRespond={onRespond} />);
-  await page.getByLabelText("Your answer", { exact: true }).fill("Original answer");
-  await page.getByRole("button", { name: "Submit answer" }).click();
-  await expect.element(page.getByText("Answer submitted")).toBeVisible();
-  if (renderSavedAnswer) {
-    await screen.rerender(<AsyncUserInputCard activity={{ ...question, payload: {
-      ...question.payload, response: { answers: ["Switching tabs", "Original answer"], messageId: MessageId.makeUnsafe("answer-1") },
-    } }} onRespond={onRespond} />);
-  }
-  await screen.rerender(<AsyncUserInputCard activity={{ ...question, payload: { ...question.payload } }} onRespond={onRespond} />);
-  await expect.element(page.getByRole("button", { name: "Submit answer" })).toBeVisible();
-  await page.getByLabelText("Your answer", { exact: true }).fill("Corrected answer");
-  await page.getByRole("button", { name: "Submit answer" }).click();
-  expect(onRespond).toHaveBeenLastCalledWith({ activityId: question.id, answers: ["Switching tabs", "Corrected answer"] });
-  expect(onRespond).toHaveBeenCalledTimes(2);
-});
+it.each([true, false])(
+  "reopens a rolled-back reply (rendered saved answer: %s)",
+  async (renderSavedAnswer) => {
+    const onRespond = vi.fn().mockResolvedValue(undefined);
+    const screen = await render(<AsyncUserInputCard activity={question} onRespond={onRespond} />);
+    await page.getByLabelText("Your answer", { exact: true }).fill("Original answer");
+    await page.getByRole("button", { name: "Submit answer" }).click();
+    await expect.element(page.getByText("Answer submitted")).toBeVisible();
+    if (renderSavedAnswer) {
+      await screen.rerender(
+        <AsyncUserInputCard
+          activity={{
+            ...question,
+            payload: {
+              ...question.payload,
+              response: {
+                answers: ["Switching tabs", "Original answer"],
+                messageId: MessageId.makeUnsafe("answer-1"),
+              },
+            },
+          }}
+          onRespond={onRespond}
+        />,
+      );
+    }
+    await screen.rerender(
+      <AsyncUserInputCard
+        activity={{ ...question, payload: { ...question.payload } }}
+        onRespond={onRespond}
+      />,
+    );
+    await expect.element(page.getByRole("button", { name: "Submit answer" })).toBeVisible();
+    await page.getByLabelText("Your answer", { exact: true }).fill("Corrected answer");
+    await page.getByRole("button", { name: "Submit answer" }).click();
+    expect(onRespond).toHaveBeenLastCalledWith({
+      activityId: question.id,
+      answers: ["Switching tabs", "Corrected answer"],
+    });
+    expect(onRespond).toHaveBeenCalledTimes(2);
+  },
+);

--- a/apps/web/src/components/chat/AsyncUserInputCard.browser.tsx
+++ b/apps/web/src/components/chat/AsyncUserInputCard.browser.tsx
@@ -1,0 +1,75 @@
+import "../../index.css";
+import { EventId, MessageId } from "@synara/contracts";
+import type { AsyncUserInputActivity } from "@synara/shared/asyncUserInput";
+import { page } from "vitest/browser";
+import { expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { AsyncUserInputCard } from "./AsyncUserInputCard";
+
+const question: AsyncUserInputActivity = {
+  id: EventId.makeUnsafe("question-1"), kind: "user-input.async", tone: "info",
+  summary: "Question from Codex", createdAt: "2026-09-10T12:00:00.000Z", turnId: null,
+  payload: { questions: [
+    { title: "Which interaction triggers the problem?", options: ["Switching tabs", "Scrolling"] },
+    { title: "What else should I know?", options: null },
+  ] },
+};
+
+it("keeps suggested choices unsubmitted and accepts free text while work continues", async () => {
+  let finish: () => void = () => {};
+  const onRespond = vi.fn(() => new Promise<void>((resolve) => { finish = resolve; }));
+  await render(<div style={{ width: 560, padding: 16 }}><AsyncUserInputCard activity={question} onRespond={onRespond} /></div>);
+  await expect.element(page.getByRole("button", { name: "Switching tabs" })).toHaveAttribute("aria-pressed", "true");
+  expect(onRespond).not.toHaveBeenCalled();
+  await page.getByLabelText("Or write your own answer").fill("Resizing the window");
+  await page.getByLabelText("Your answer", { exact: true }).fill("Only with a long transcript");
+  await page.getByRole("button", { name: "Submit answer" }).click();
+  expect(onRespond).toHaveBeenCalledExactlyOnceWith({
+    activityId: question.id, answers: ["Resizing the window", "Only with a long transcript"],
+  });
+  await expect.element(page.getByRole("button", { name: "Submitting…" })).toBeDisabled();
+  finish();
+  await expect.element(page.getByText("Answer submitted")).toBeVisible();
+  await expect.element(page.getByText("Resizing the window")).toBeVisible();
+});
+
+it("restores submitted answers and never offers another submission after refresh", async () => {
+  const onRespond = vi.fn();
+  await render(<AsyncUserInputCard activity={{ ...question, payload: {
+    ...question.payload, response: { answers: ["Scrolling", "After a reconnect"], messageId: MessageId.makeUnsafe("answer-1") },
+  } }} onRespond={onRespond} />);
+  await expect.element(page.getByText("Answer submitted")).toBeVisible();
+  await expect.element(page.getByText("After a reconnect")).toBeVisible();
+  await expect.element(page.getByRole("button", { name: "Submit answer" })).not.toBeInTheDocument();
+  expect(onRespond).not.toHaveBeenCalled();
+});
+
+it("keeps the draft available when submission fails", async () => {
+  const onRespond = vi.fn().mockRejectedValueOnce(new Error("Connection lost")).mockResolvedValue(undefined);
+  await render(<AsyncUserInputCard activity={question} onRespond={onRespond} />);
+  await page.getByLabelText("Your answer", { exact: true }).fill("After a reconnect");
+  await page.getByRole("button", { name: "Submit answer" }).click();
+  await expect.element(page.getByRole("alert")).toHaveTextContent("Connection lost");
+  await expect.element(page.getByLabelText("Your answer", { exact: true })).toHaveValue("After a reconnect");
+  await page.getByRole("button", { name: "Submit answer" }).click();
+  await expect.element(page.getByText("Answer submitted")).toBeVisible();
+});
+
+it.each([true, false])("reopens a rolled-back reply (rendered saved answer: %s)", async (renderSavedAnswer) => {
+  const onRespond = vi.fn().mockResolvedValue(undefined);
+  const screen = await render(<AsyncUserInputCard activity={question} onRespond={onRespond} />);
+  await page.getByLabelText("Your answer", { exact: true }).fill("Original answer");
+  await page.getByRole("button", { name: "Submit answer" }).click();
+  await expect.element(page.getByText("Answer submitted")).toBeVisible();
+  if (renderSavedAnswer) {
+    await screen.rerender(<AsyncUserInputCard activity={{ ...question, payload: {
+      ...question.payload, response: { answers: ["Switching tabs", "Original answer"], messageId: MessageId.makeUnsafe("answer-1") },
+    } }} onRespond={onRespond} />);
+  }
+  await screen.rerender(<AsyncUserInputCard activity={{ ...question, payload: { ...question.payload } }} onRespond={onRespond} />);
+  await expect.element(page.getByRole("button", { name: "Submit answer" })).toBeVisible();
+  await page.getByLabelText("Your answer", { exact: true }).fill("Corrected answer");
+  await page.getByRole("button", { name: "Submit answer" }).click();
+  expect(onRespond).toHaveBeenLastCalledWith({ activityId: question.id, answers: ["Switching tabs", "Corrected answer"] });
+  expect(onRespond).toHaveBeenCalledTimes(2);
+});

--- a/apps/web/src/components/chat/AsyncUserInputCard.browser.tsx
+++ b/apps/web/src/components/chat/AsyncUserInputCard.browser.tsx
@@ -24,6 +24,16 @@ const question: AsyncUserInputActivity = {
   },
 };
 
+it("shows unsupported child-task questions without an actionable answer form", async () => {
+  await render(<AsyncUserInputCard activity={question} />);
+  await expect
+    .element(page.getByText("Replies are unavailable in this conversation"))
+    .toBeVisible();
+  await expect.element(page.getByRole("button", { name: "Submit answer" })).toBeDisabled();
+  await expect.element(page.getByRole("button", { name: "Switching tabs" })).toBeDisabled();
+  await expect.element(page.getByLabelText("Your answer", { exact: true })).toBeDisabled();
+});
+
 it("keeps suggested choices unsubmitted and accepts free text while work continues", async () => {
   let finish: () => void = () => {};
   const onRespond = vi.fn(

--- a/apps/web/src/components/chat/AsyncUserInputCard.tsx
+++ b/apps/web/src/components/chat/AsyncUserInputCard.tsx
@@ -16,7 +16,9 @@ interface AsyncUserInputCardProps {
 export function AsyncUserInputCard({ activity, onRespond }: AsyncUserInputCardProps) {
   const id = useId();
   const { questions, response } = activity.payload;
-  const [choices, setChoices] = useState(() => questions.map((question) => question.options?.[0] ?? ""));
+  const [choices, setChoices] = useState(() =>
+    questions.map((question) => question.options?.[0] ?? ""),
+  );
   const [drafts, setDrafts] = useState(() => questions.map(() => ""));
   const [submitting, setSubmitting] = useState(false);
   const [submission, setSubmission] = useState<{
@@ -27,8 +29,8 @@ export function AsyncUserInputCard({ activity, onRespond }: AsyncUserInputCardPr
   const inFlight = useRef(false);
   // Any authoritative payload update supersedes the local submission, including
   // rollback delivered before React has rendered the intermediate answered state.
-  const answered = response?.answers ??
-    (submission?.payload === activity.payload ? submission.answers : null);
+  const answered =
+    response?.answers ?? (submission?.payload === activity.payload ? submission.answers : null);
   const answers = questions.map((_, index) => drafts[index]?.trim() || choices[index] || "");
 
   async function submit() {
@@ -51,7 +53,10 @@ export function AsyncUserInputCard({ activity, onRespond }: AsyncUserInputCardPr
     <form
       className={`${COMPOSER_INPUT_SURFACE_CLASS_NAME} space-y-4 p-4`}
       aria-label="Question from Codex"
-      onSubmit={(event) => { event.preventDefault(); void submit(); }}
+      onSubmit={(event) => {
+        event.preventDefault();
+        void submit();
+      }}
     >
       <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
         {answered ? <CheckIcon className="size-3.5" /> : null}
@@ -63,7 +68,9 @@ export function AsyncUserInputCard({ activity, onRespond }: AsyncUserInputCardPr
             {question.title}
           </legend>
           {answered ? (
-            <p className="whitespace-pre-wrap break-words text-sm text-muted-foreground">{answered[index]}</p>
+            <p className="whitespace-pre-wrap break-words text-sm text-muted-foreground">
+              {answered[index]}
+            </p>
           ) : (
             <>
               {question.options?.map((option, optionIndex) => (
@@ -73,11 +80,16 @@ export function AsyncUserInputCard({ activity, onRespond }: AsyncUserInputCardPr
                   label={option}
                   selected={!drafts[index]?.trim() && choices[index] === option}
                   onSelect={() => {
-                    setChoices((previous) => previous.map((value, i) => i === index ? option : value));
-                    setDrafts((previous) => previous.map((value, i) => i === index ? "" : value));
+                    setChoices((previous) =>
+                      previous.map((value, i) => (i === index ? option : value)),
+                    );
+                    setDrafts((previous) => previous.map((value, i) => (i === index ? "" : value)));
                   }}
-                  trailing={!drafts[index]?.trim() && choices[index] === option
-                    ? <CheckIcon className="size-3.5 shrink-0" /> : null}
+                  trailing={
+                    !drafts[index]?.trim() && choices[index] === option ? (
+                      <CheckIcon className="size-3.5 shrink-0" />
+                    ) : null
+                  }
                 />
               ))}
               <label htmlFor={`${id}-${index}`} className="block text-xs text-muted-foreground">
@@ -88,7 +100,7 @@ export function AsyncUserInputCard({ activity, onRespond }: AsyncUserInputCardPr
                 value={drafts[index] ?? ""}
                 onChange={(event) => {
                   const text = event.target.value;
-                  setDrafts((previous) => previous.map((value, i) => i === index ? text : value));
+                  setDrafts((previous) => previous.map((value, i) => (i === index ? text : value)));
                 }}
                 rows={2}
                 className="w-full resize-y rounded-lg border border-border bg-transparent px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -97,10 +109,18 @@ export function AsyncUserInputCard({ activity, onRespond }: AsyncUserInputCardPr
           )}
         </fieldset>
       ))}
-      {error && !answered ? <p role="alert" className="text-xs text-destructive">{error}</p> : null}
+      {error && !answered ? (
+        <p role="alert" className="text-xs text-destructive">
+          {error}
+        </p>
+      ) : null}
       {!answered ? (
         <div className="flex justify-end">
-          <Button type="submit" size="sm" disabled={!onRespond || submitting || answers.some((answer) => !answer)}>
+          <Button
+            type="submit"
+            size="sm"
+            disabled={!onRespond || submitting || answers.some((answer) => !answer)}
+          >
             {submitting ? "Submitting…" : "Submit answer"}
           </Button>
         </div>

--- a/apps/web/src/components/chat/AsyncUserInputCard.tsx
+++ b/apps/web/src/components/chat/AsyncUserInputCard.tsx
@@ -1,0 +1,110 @@
+import { useId, useRef, useState } from "react";
+import type { AsyncUserInputResponse } from "@synara/contracts";
+import type { AsyncUserInputActivity } from "@synara/shared/asyncUserInput";
+import { CheckIcon } from "~/lib/icons";
+import { Button } from "../ui/button";
+import { ComposerChoiceRow } from "./ComposerChoiceRow";
+import { COMPOSER_INPUT_SURFACE_CLASS_NAME } from "./composerPickerStyles";
+
+export type RespondToAsyncUserInput = (response: AsyncUserInputResponse) => Promise<void>;
+
+interface AsyncUserInputCardProps {
+  activity: AsyncUserInputActivity;
+  onRespond?: RespondToAsyncUserInput;
+}
+
+export function AsyncUserInputCard({ activity, onRespond }: AsyncUserInputCardProps) {
+  const id = useId();
+  const { questions, response } = activity.payload;
+  const [choices, setChoices] = useState(() => questions.map((question) => question.options?.[0] ?? ""));
+  const [drafts, setDrafts] = useState(() => questions.map(() => ""));
+  const [submitting, setSubmitting] = useState(false);
+  const [submission, setSubmission] = useState<{
+    payload: AsyncUserInputActivity["payload"];
+    answers: readonly string[];
+  } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const inFlight = useRef(false);
+  // Any authoritative payload update supersedes the local submission, including
+  // rollback delivered before React has rendered the intermediate answered state.
+  const answered = response?.answers ??
+    (submission?.payload === activity.payload ? submission.answers : null);
+  const answers = questions.map((_, index) => drafts[index]?.trim() || choices[index] || "");
+
+  async function submit() {
+    if (!onRespond || answered || inFlight.current || answers.some((answer) => !answer)) return;
+    inFlight.current = true;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onRespond({ activityId: activity.id, answers });
+      setSubmission({ payload: activity.payload, answers });
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not submit your answer. Try again.");
+    } finally {
+      inFlight.current = false;
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form
+      className={`${COMPOSER_INPUT_SURFACE_CLASS_NAME} space-y-4 p-4`}
+      aria-label="Question from Codex"
+      onSubmit={(event) => { event.preventDefault(); void submit(); }}
+    >
+      <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        {answered ? <CheckIcon className="size-3.5" /> : null}
+        {answered ? "Answer submitted" : "Reply when you’re ready"}
+      </p>
+      {questions.map((question, index) => (
+        <fieldset key={index} disabled={submitting || !onRespond} className="min-w-0 space-y-2">
+          <legend className="mb-2 whitespace-pre-wrap text-[13px] font-medium text-foreground/90">
+            {question.title}
+          </legend>
+          {answered ? (
+            <p className="whitespace-pre-wrap break-words text-sm text-muted-foreground">{answered[index]}</p>
+          ) : (
+            <>
+              {question.options?.map((option, optionIndex) => (
+                <ComposerChoiceRow
+                  key={optionIndex}
+                  shortcut={null}
+                  label={option}
+                  selected={!drafts[index]?.trim() && choices[index] === option}
+                  onSelect={() => {
+                    setChoices((previous) => previous.map((value, i) => i === index ? option : value));
+                    setDrafts((previous) => previous.map((value, i) => i === index ? "" : value));
+                  }}
+                  trailing={!drafts[index]?.trim() && choices[index] === option
+                    ? <CheckIcon className="size-3.5 shrink-0" /> : null}
+                />
+              ))}
+              <label htmlFor={`${id}-${index}`} className="block text-xs text-muted-foreground">
+                {question.options?.length ? "Or write your own answer" : "Your answer"}
+              </label>
+              <textarea
+                id={`${id}-${index}`}
+                value={drafts[index] ?? ""}
+                onChange={(event) => {
+                  const text = event.target.value;
+                  setDrafts((previous) => previous.map((value, i) => i === index ? text : value));
+                }}
+                rows={2}
+                className="w-full resize-y rounded-lg border border-border bg-transparent px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+            </>
+          )}
+        </fieldset>
+      ))}
+      {error && !answered ? <p role="alert" className="text-xs text-destructive">{error}</p> : null}
+      {!answered ? (
+        <div className="flex justify-end">
+          <Button type="submit" size="sm" disabled={!onRespond || submitting || answers.some((answer) => !answer)}>
+            {submitting ? "Submitting…" : "Submit answer"}
+          </Button>
+        </div>
+      ) : null}
+    </form>
+  );
+}

--- a/apps/web/src/components/chat/AsyncUserInputCard.tsx
+++ b/apps/web/src/components/chat/AsyncUserInputCard.tsx
@@ -60,7 +60,11 @@ export function AsyncUserInputCard({ activity, onRespond }: AsyncUserInputCardPr
     >
       <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
         {answered ? <CheckIcon className="size-3.5" /> : null}
-        {answered ? "Answer submitted" : "Reply when you’re ready"}
+        {answered
+          ? "Answer submitted"
+          : onRespond
+            ? "Reply when you’re ready"
+            : "Replies are unavailable in this conversation"}
       </p>
       {questions.map((question, index) => (
         <fieldset key={index} disabled={submitting || !onRespond} className="min-w-0 space-y-2">

--- a/apps/web/src/components/chat/ChatTranscriptPane.tsx
+++ b/apps/web/src/components/chat/ChatTranscriptPane.tsx
@@ -100,6 +100,7 @@ interface ChatTranscriptPaneProps {
   scrollButtonVisible: boolean;
   terminalWorkspaceTerminalTabActive: boolean;
   timelineEntries: ComponentProps<typeof MessagesTimeline>["timelineEntries"];
+  onRespondToAsyncUserInput?: ComponentProps<typeof MessagesTimeline>["onRespondToAsyncUserInput"];
   timestampFormat: TimestampFormat;
   turnDiffSummaryByAssistantMessageId: Map<MessageId, TurnDiffSummary>;
   workspaceRoot: string | undefined;
@@ -114,6 +115,7 @@ interface ChatTranscriptPaneProps {
 }
 
 export function ChatTranscriptPane({
+  onRespondToAsyncUserInput,
   activeThreadId,
   activeTurnId,
   activeTurnInProgress,
@@ -240,6 +242,7 @@ export function ChatTranscriptPane({
           />
         ) : (
           <MessagesTimeline
+            {...(onRespondToAsyncUserInput ? { onRespondToAsyncUserInput } : {})}
             key={activeThreadId}
             hasMessages={hasMessages}
             isWorking={isWorking}

--- a/apps/web/src/components/chat/ComposerChoiceRow.tsx
+++ b/apps/web/src/components/chat/ComposerChoiceRow.tsx
@@ -60,6 +60,7 @@ export function ComposerChoiceRow({
     <button
       type="button"
       disabled={disabled}
+      aria-pressed={selectedProp === undefined ? undefined : selected}
       onClick={onSelect}
       className={cn(
         "group flex w-full items-start gap-2.5 rounded-lg px-2 py-1.5 text-left transition-colors duration-150",

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1,4 +1,10 @@
-import { CheckpointRef, EventId, MessageId, OrchestrationProposedPlanId, TurnId } from "@synara/contracts";
+import {
+  CheckpointRef,
+  EventId,
+  MessageId,
+  OrchestrationProposedPlanId,
+  TurnId,
+} from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 import {
   buildTurnDiffSummaryByAssistantMessageId,
@@ -25,21 +31,39 @@ import type { ChatMessage, TurnDiffSummary, WorktreeSetupSnapshot } from "../../
 
 it("keeps async question cards visible after a turn settles and updates submitted state", () => {
   const question: Extract<TimelineEntry, { kind: "async-question" }> = {
-    id: "async-card", kind: "async-question", createdAt: "2026-09-10T12:00:01.000Z",
+    id: "async-card",
+    kind: "async-question",
+    createdAt: "2026-09-10T12:00:01.000Z",
     activity: {
-      id: EventId.makeUnsafe("async-card"), kind: "user-input.async", tone: "info",
-      summary: "Question", createdAt: "2026-09-10T12:00:01.000Z", turnId: null,
+      id: EventId.makeUnsafe("async-card"),
+      kind: "user-input.async",
+      tone: "info",
+      summary: "Question",
+      createdAt: "2026-09-10T12:00:01.000Z",
+      turnId: null,
       payload: { questions: [{ title: "Which interaction?", options: ["Tabs", "Scrolling"] }] },
     },
   };
   const rows = deriveMessagesTimelineRows({
-    timelineEntries: [question], isWorking: false, worktreeSetup: null, worktreeSetupOpen: false,
-    activeTurnStartedAt: null, turnDiffSummaryByAssistantMessageId: new Map(), revertTurnCountByUserMessageId: new Map(),
+    timelineEntries: [question],
+    isWorking: false,
+    worktreeSetup: null,
+    worktreeSetupOpen: false,
+    activeTurnStartedAt: null,
+    turnDiffSummaryByAssistantMessageId: new Map(),
+    revertTurnCountByUserMessageId: new Map(),
   });
   expect(rows).toEqual([question]);
-  const submitted = { ...question, activity: { ...question.activity, payload: {
-    ...question.activity.payload, response: { answers: ["Tabs"], messageId: MessageId.makeUnsafe("answer") },
-  } } };
+  const submitted = {
+    ...question,
+    activity: {
+      ...question.activity,
+      payload: {
+        ...question.activity.payload,
+        response: { answers: ["Tabs"], messageId: MessageId.makeUnsafe("answer") },
+      },
+    },
+  };
   const previous = { byId: new Map([[question.id, question]]), result: rows };
   expect(computeStableMessagesTimelineRows([submitted], previous).result).toEqual([submitted]);
 });

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -1,4 +1,4 @@
-import { CheckpointRef, MessageId, OrchestrationProposedPlanId, TurnId } from "@synara/contracts";
+import { CheckpointRef, EventId, MessageId, OrchestrationProposedPlanId, TurnId } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 import {
   buildTurnDiffSummaryByAssistantMessageId,
@@ -22,6 +22,27 @@ import {
 } from "./MessagesTimeline.logic";
 import type { TimelineEntry, WorkLogEntry } from "../../session-logic";
 import type { ChatMessage, TurnDiffSummary, WorktreeSetupSnapshot } from "../../types";
+
+it("keeps async question cards visible after a turn settles and updates submitted state", () => {
+  const question: Extract<TimelineEntry, { kind: "async-question" }> = {
+    id: "async-card", kind: "async-question", createdAt: "2026-09-10T12:00:01.000Z",
+    activity: {
+      id: EventId.makeUnsafe("async-card"), kind: "user-input.async", tone: "info",
+      summary: "Question", createdAt: "2026-09-10T12:00:01.000Z", turnId: null,
+      payload: { questions: [{ title: "Which interaction?", options: ["Tabs", "Scrolling"] }] },
+    },
+  };
+  const rows = deriveMessagesTimelineRows({
+    timelineEntries: [question], isWorking: false, worktreeSetup: null, worktreeSetupOpen: false,
+    activeTurnStartedAt: null, turnDiffSummaryByAssistantMessageId: new Map(), revertTurnCountByUserMessageId: new Map(),
+  });
+  expect(rows).toEqual([question]);
+  const submitted = { ...question, activity: { ...question.activity, payload: {
+    ...question.activity.payload, response: { answers: ["Tabs"], messageId: MessageId.makeUnsafe("answer") },
+  } } };
+  const previous = { byId: new Map([[question.id, question]]), result: rows };
+  expect(computeStableMessagesTimelineRows([submitted], previous).result).toEqual([submitted]);
+});
 
 describe("canSubmitUserMessageEdit", () => {
   it("allows an empty edit only when hidden annotations remain attached", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -214,6 +214,7 @@ interface TimelineDiffMessage {
 }
 
 export type MessagesTimelineRow =
+  | Extract<TimelineEntry, { kind: "async-question" }>
   | {
       kind: "work";
       id: string;
@@ -620,6 +621,12 @@ export function deriveMessagesTimelineRows(input: {
       continue;
     }
 
+    if (timelineEntry.kind === "async-question") {
+      flushPendingWorkGroup({ attachToPreviousAssistant: false });
+      nextRows.push(timelineEntry);
+      continue;
+    }
+
     if (timelineEntry.kind === "work") {
       const groupedEntries = [timelineEntry.entry];
       let cursor = index + 1;
@@ -858,7 +865,7 @@ function collapseSettledTurns(
         foldIndices.push(scan);
         continue;
       }
-      if (prev.kind === "proposed-plan") {
+      if (prev.kind === "proposed-plan" || prev.kind === "async-question") {
         // The plan card stays visible, but it should not strand earlier
         // narration/work outside the final "Worked for..." disclosure.
         continue;
@@ -1169,6 +1176,8 @@ function isRowUnchanged(a: MessagesTimelineRow, b: MessagesTimelineRow): boolean
   if (a.kind !== b.kind || a.id !== b.id) return false;
 
   switch (a.kind) {
+    case "async-question":
+      return a.activity === (b as typeof a).activity;
     case "working":
       return a.createdAt === (b as typeof a).createdAt;
 

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -74,6 +74,7 @@ import { ForkSourceDivider, type ForkSourceReference } from "./ForkSourceDivider
 import { SynaraThreadCreationCard } from "./SynaraThreadCreationCard";
 import { buildExpandedImagePreview, ExpandedImagePreview } from "./ExpandedImagePreview";
 import { ProposedPlanCard } from "./ProposedPlanCard";
+import { AsyncUserInputCard, type RespondToAsyncUserInput } from "./AsyncUserInputCard";
 import { DiffStatLabel } from "./DiffStatLabel";
 import { ReviewChangesButton } from "./ReviewChangesButton";
 import { FileEntryIcon } from "./FileEntryIcon";
@@ -475,6 +476,7 @@ interface MessagesTimelineProps {
   /** Marks the transcript as a temporary chat so user bubbles render the dashed primary outline. */
   isTemporaryThread?: boolean;
   timelineEntries: ReturnType<typeof deriveTimelineEntries>;
+  onRespondToAsyncUserInput?: RespondToAsyncUserInput;
   turnDiffSummaryByAssistantMessageId: Map<MessageId, TurnDiffSummary>;
   nowIso?: string;
   expandedWorkGroups?: Record<string, boolean>;
@@ -540,6 +542,7 @@ interface MessagesTimelineProps {
 }
 
 export const MessagesTimeline = memo(function MessagesTimeline({
+  onRespondToAsyncUserInput,
   hasMessages,
   isWorking,
   workingLabel: workingLabelProp,
@@ -934,6 +937,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   const enteringMessageRowIds = useMessageSendEnterAnimations(rows, enteringUserMessageIds);
   const timelineExtraData = useMemo(
     () => ({
+      onRespondToAsyncUserInput,
       crossTaskOrigin,
       editingUserMessageId,
       enteringMessageRowIds,
@@ -953,6 +957,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       toolGroupSummaryOverrides,
     }),
     [
+      onRespondToAsyncUserInput,
       crossTaskOrigin,
       editingUserMessageId,
       enteringMessageRowIds,
@@ -1468,6 +1473,13 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       }
     >
       {forkDividerBeforeRowId === row.id ? forkSourceDivider : null}
+      {row.kind === "async-question" ? (
+        <AsyncUserInputCard
+          key={row.activity.id}
+          activity={row.activity}
+          {...(onRespondToAsyncUserInput ? { onRespond: onRespondToAsyncUserInput } : {})}
+        />
+      ) : null}
       {row.kind === "work" &&
         (() => {
           const groupId = row.id;

--- a/apps/web/src/lib/threadHandoff.ts
+++ b/apps/web/src/lib/threadHandoff.ts
@@ -1,3 +1,4 @@
+import { isNativeConversationMessageSource } from "@synara/shared/conversationEdit";
 // FILE: threadHandoff.ts
 // Purpose: Builds client-side handoff commands and imported transcript payloads.
 // Layer: Web handoff utilities
@@ -176,7 +177,8 @@ export function buildThreadHandoffImportedActivities(
 
 export function hasNativeThreadHandoffMessages(thread: Pick<Thread, "messages">): boolean {
   return thread.messages.some(
-    (message) => isImportableThreadMessage(message) && message.source === "native",
+    (message) =>
+      isImportableThreadMessage(message) && isNativeConversationMessageSource(message.source),
   );
 }
 

--- a/apps/web/src/storeEventReducer.test.ts
+++ b/apps/web/src/storeEventReducer.test.ts
@@ -37,6 +37,38 @@ import {
 import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE } from "./types";
 
 describe("store event reducer", () => {
+  it.each(["revert", "rollback"] as const)("reopens only removed async replies after %s", (removal) => {
+    const createdAt = "2026-09-10T12:00:00.000Z";
+    const turnId = TurnId.makeUnsafe("turn-1");
+    const cards = ["kept-answer", "removed-answer"].map((messageId) => makeActivity({
+      id: `question-${messageId}`, kind: "user-input.async", turnId,
+      payload: {
+        questions: [{ title: "Which interaction?", options: null }],
+        response: { answers: ["Tabs"], messageId },
+      },
+    }));
+    const state = makeState(makeThread({
+      messages: [
+        { id: MessageId.makeUnsafe("kept-answer"), role: "user", text: "Tabs", turnId, createdAt, streaming: false },
+        { id: MessageId.makeUnsafe("removed-answer"), role: "user", text: "Tabs", turnId: TurnId.makeUnsafe("turn-2"), createdAt, streaming: false },
+      ],
+      activities: cards,
+      turnDiffSummaries: [{ turnId, completedAt: createdAt, status: "ready", files: [], checkpointTurnCount: 1 }],
+    }));
+    const event = removal === "revert"
+      ? makeDomainEvent("thread.reverted", { threadId: ThreadId.makeUnsafe("thread-1"), turnCount: 1 })
+      : makeDomainEvent("thread.conversation-rolled-back", {
+          threadId: ThreadId.makeUnsafe("thread-1"), messageId: MessageId.makeUnsafe("removed-answer"),
+          numTurns: 1, removedTurnIds: [TurnId.makeUnsafe("turn-2")],
+        });
+    const thread = threadsOf(applyOrchestrationEvents(state, [event]))[0]!;
+    expect(thread.activities.find((activity) => activity.id === cards[0]!.id)?.payload).toEqual(cards[0]!.payload);
+    expect(thread.activities.find((activity) => activity.id === cards[1]!.id)?.payload).toEqual({
+      questions: [{ title: "Which interaction?", options: null }],
+    });
+    expect(thread.messages.map((message) => message.id)).toEqual(["kept-answer"]);
+  });
+
   it("hydrates and removes Spaces while clearing matching project assignments", () => {
     const spaceId = SpaceId.makeUnsafe("space-work");
     let state = applyOrchestrationEvents(makeState(makeThread()), [

--- a/apps/web/src/storeEventReducer.test.ts
+++ b/apps/web/src/storeEventReducer.test.ts
@@ -37,37 +37,70 @@ import {
 import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE } from "./types";
 
 describe("store event reducer", () => {
-  it.each(["revert", "rollback"] as const)("reopens only removed async replies after %s", (removal) => {
-    const createdAt = "2026-09-10T12:00:00.000Z";
-    const turnId = TurnId.makeUnsafe("turn-1");
-    const cards = ["kept-answer", "removed-answer"].map((messageId) => makeActivity({
-      id: `question-${messageId}`, kind: "user-input.async", turnId,
-      payload: {
+  it.each(["revert", "rollback"] as const)(
+    "reopens only removed async replies after %s",
+    (removal) => {
+      const createdAt = "2026-09-10T12:00:00.000Z";
+      const turnId = TurnId.makeUnsafe("turn-1");
+      const cards = ["kept-answer", "removed-answer"].map((messageId) =>
+        makeActivity({
+          id: `question-${messageId}`,
+          kind: "user-input.async",
+          turnId,
+          payload: {
+            questions: [{ title: "Which interaction?", options: null }],
+            response: { answers: ["Tabs"], messageId },
+          },
+        }),
+      );
+      const state = makeState(
+        makeThread({
+          messages: [
+            {
+              id: MessageId.makeUnsafe("kept-answer"),
+              role: "user",
+              text: "Tabs",
+              turnId,
+              createdAt,
+              streaming: false,
+            },
+            {
+              id: MessageId.makeUnsafe("removed-answer"),
+              role: "user",
+              text: "Tabs",
+              turnId: TurnId.makeUnsafe("turn-2"),
+              createdAt,
+              streaming: false,
+            },
+          ],
+          activities: cards,
+          turnDiffSummaries: [
+            { turnId, completedAt: createdAt, status: "ready", files: [], checkpointTurnCount: 1 },
+          ],
+        }),
+      );
+      const event =
+        removal === "revert"
+          ? makeDomainEvent("thread.reverted", {
+              threadId: ThreadId.makeUnsafe("thread-1"),
+              turnCount: 1,
+            })
+          : makeDomainEvent("thread.conversation-rolled-back", {
+              threadId: ThreadId.makeUnsafe("thread-1"),
+              messageId: MessageId.makeUnsafe("removed-answer"),
+              numTurns: 1,
+              removedTurnIds: [TurnId.makeUnsafe("turn-2")],
+            });
+      const thread = threadsOf(applyOrchestrationEvents(state, [event]))[0]!;
+      expect(thread.activities.find((activity) => activity.id === cards[0]!.id)?.payload).toEqual(
+        cards[0]!.payload,
+      );
+      expect(thread.activities.find((activity) => activity.id === cards[1]!.id)?.payload).toEqual({
         questions: [{ title: "Which interaction?", options: null }],
-        response: { answers: ["Tabs"], messageId },
-      },
-    }));
-    const state = makeState(makeThread({
-      messages: [
-        { id: MessageId.makeUnsafe("kept-answer"), role: "user", text: "Tabs", turnId, createdAt, streaming: false },
-        { id: MessageId.makeUnsafe("removed-answer"), role: "user", text: "Tabs", turnId: TurnId.makeUnsafe("turn-2"), createdAt, streaming: false },
-      ],
-      activities: cards,
-      turnDiffSummaries: [{ turnId, completedAt: createdAt, status: "ready", files: [], checkpointTurnCount: 1 }],
-    }));
-    const event = removal === "revert"
-      ? makeDomainEvent("thread.reverted", { threadId: ThreadId.makeUnsafe("thread-1"), turnCount: 1 })
-      : makeDomainEvent("thread.conversation-rolled-back", {
-          threadId: ThreadId.makeUnsafe("thread-1"), messageId: MessageId.makeUnsafe("removed-answer"),
-          numTurns: 1, removedTurnIds: [TurnId.makeUnsafe("turn-2")],
-        });
-    const thread = threadsOf(applyOrchestrationEvents(state, [event]))[0]!;
-    expect(thread.activities.find((activity) => activity.id === cards[0]!.id)?.payload).toEqual(cards[0]!.payload);
-    expect(thread.activities.find((activity) => activity.id === cards[1]!.id)?.payload).toEqual({
-      questions: [{ title: "Which interaction?", options: null }],
-    });
-    expect(thread.messages.map((message) => message.id)).toEqual(["kept-answer"]);
-  });
+      });
+      expect(thread.messages.map((message) => message.id)).toEqual(["kept-answer"]);
+    },
+  );
 
   it("hydrates and removes Spaces while clearing matching project assignments", () => {
     const spaceId = SpaceId.makeUnsafe("space-work");

--- a/apps/web/src/storeEventReducer.ts
+++ b/apps/web/src/storeEventReducer.ts
@@ -8,6 +8,7 @@ import {
   type ThreadId,
 } from "@synara/contracts";
 import { resolveThreadBranchRegressionGuard } from "@synara/shared/git";
+import { reopenAsyncUserInputAfterMessageRemoval } from "@synara/shared/asyncUserInput";
 import {
   addPinnedMessage,
   removePinnedMessage,
@@ -1584,7 +1585,15 @@ function applyOrchestrationEvent(
             thread.proposedPlans,
             retainedTurnIds,
           );
-          const activities = retainThreadActivitiesAfterRevert(thread.activities, retainedTurnIds);
+          const retainedMessageIds = new Set(messages.map((message) => message.id));
+          const activities = reopenAsyncUserInputAfterMessageRemoval(
+            retainThreadActivitiesAfterRevert(thread.activities, retainedTurnIds),
+            new Set(
+              thread.messages
+                .filter((message) => !retainedMessageIds.has(message.id))
+                .map((message) => message.id),
+            ),
+          );
           const latestCheckpoint = turnDiffSummaries.at(-1) ?? null;
 
           return {
@@ -1647,8 +1656,16 @@ function applyOrchestrationEvent(
           const proposedPlans = thread.proposedPlans.filter(
             (plan) => plan.turnId === null || !removedTurnIds.has(plan.turnId),
           );
-          const activities = thread.activities.filter(
-            (activity) => activity.turnId === null || !removedTurnIds.has(activity.turnId),
+          const retainedMessageIds = new Set(rollback.messages.map((message) => message.id));
+          const activities = reopenAsyncUserInputAfterMessageRemoval(
+            thread.activities.filter(
+              (activity) => activity.turnId === null || !removedTurnIds.has(activity.turnId),
+            ),
+            new Set(
+              thread.messages
+                .filter((message) => !retainedMessageIds.has(message.id))
+                .map((message) => message.id),
+            ),
           );
           const latestCheckpoint = turnDiffSummaries.at(-1) ?? null;
 

--- a/apps/web/src/storeNormalization.test.ts
+++ b/apps/web/src/storeNormalization.test.ts
@@ -15,6 +15,19 @@ import {
 import { makeActivity, makeReadModelThread, makeThread } from "./storeTestFixtures";
 import type { Thread } from "./types";
 
+it("retains pending and submitted async questions beyond the activity cap", () => {
+  const cards = [
+    makeActivity({ id: "async-pending", kind: "user-input.async", sequence: 1 }),
+    makeActivity({ id: "async-answered", kind: "user-input.async", sequence: 2,
+      payload: { response: { answers: ["Tabs"], messageId: "answer" } } }),
+  ];
+  const activities = normalizeActivities([
+    ...cards,
+    ...Array.from({ length: 2200 }, (_, index) => makeActivity({ id: `work-${index}`, sequence: index + 10 })),
+  ]);
+  expect(activities.filter((activity) => activity.kind === "user-input.async")).toEqual(cards);
+});
+
 type ThreadActivity = Thread["activities"][number];
 
 interface FoldStep {

--- a/apps/web/src/storeNormalization.test.ts
+++ b/apps/web/src/storeNormalization.test.ts
@@ -15,23 +15,38 @@ import {
 import { makeActivity, makeReadModelThread, makeThread } from "./storeTestFixtures";
 import type { Thread } from "./types";
 
-it("retains pending and submitted async questions beyond the activity cap", () => {
+it("retains only unresolved async questions beyond the activity cap", () => {
+  const questions = [{ title: "Which approach?", options: null }];
   const cards = [
-    makeActivity({ id: "async-pending", kind: "user-input.async", sequence: 1 }),
+    makeActivity({
+      id: "async-pending",
+      kind: "user-input.async",
+      sequence: 1,
+      payload: { questions },
+    }),
     makeActivity({
       id: "async-answered",
       kind: "user-input.async",
       sequence: 2,
-      payload: { response: { answers: ["Tabs"], messageId: "answer" } },
+      payload: { questions, response: { answers: ["Tabs"], messageId: "answer" } },
     }),
   ];
-  const activities = normalizeActivities([
-    ...cards,
-    ...Array.from({ length: 2200 }, (_, index) =>
-      makeActivity({ id: `work-${index}`, sequence: index + 10 }),
-    ),
-  ]);
-  expect(activities.filter((activity) => activity.kind === "user-input.async")).toEqual(cards);
+  const activities = normalizeActivities(
+    [
+      ...cards,
+      ...Array.from({ length: 2200 }, (_, index) =>
+        makeActivity({ id: `work-${index}`, sequence: index + 10 }),
+      ),
+    ],
+    [],
+  );
+  expect(activities.filter((activity) => activity.kind === "user-input.async")).toEqual([cards[0]]);
+  expect(activities.length).toBeLessThanOrEqual(2001);
+  const answered = normalizeActivities(
+    [...activities, { ...cards[0]!, payload: cards[1]!.payload }],
+    activities,
+  );
+  expect(answered.some((activity) => activity.id === "async-pending")).toBe(false);
 });
 
 type ThreadActivity = Thread["activities"][number];

--- a/apps/web/src/storeNormalization.test.ts
+++ b/apps/web/src/storeNormalization.test.ts
@@ -18,12 +18,18 @@ import type { Thread } from "./types";
 it("retains pending and submitted async questions beyond the activity cap", () => {
   const cards = [
     makeActivity({ id: "async-pending", kind: "user-input.async", sequence: 1 }),
-    makeActivity({ id: "async-answered", kind: "user-input.async", sequence: 2,
-      payload: { response: { answers: ["Tabs"], messageId: "answer" } } }),
+    makeActivity({
+      id: "async-answered",
+      kind: "user-input.async",
+      sequence: 2,
+      payload: { response: { answers: ["Tabs"], messageId: "answer" } },
+    }),
   ];
   const activities = normalizeActivities([
     ...cards,
-    ...Array.from({ length: 2200 }, (_, index) => makeActivity({ id: `work-${index}`, sequence: index + 10 })),
+    ...Array.from({ length: 2200 }, (_, index) =>
+      makeActivity({ id: `work-${index}`, sequence: index + 10 }),
+    ),
   ]);
   expect(activities.filter((activity) => activity.kind === "user-input.async")).toEqual(cards);
 });

--- a/apps/web/src/storeNormalization.ts
+++ b/apps/web/src/storeNormalization.ts
@@ -13,6 +13,7 @@ import {
   ThreadId,
   type TurnId,
 } from "@synara/contracts";
+import { isPendingAsyncUserInputActivity } from "@synara/shared/asyncUserInput";
 import { resolveThreadBranchRegressionGuard } from "@synara/shared/git";
 import { normalizeModelSlug } from "@synara/shared/model";
 import { deriveThreadSummaryMetadata } from "@synara/shared/threadSummary";
@@ -1313,8 +1314,8 @@ export function capThreadActivities<TActivity extends Thread["activities"][numbe
   const retainedIds = new Set(activities.slice(dropCount).map((activity) => activity.id));
   const pendingRequestIds = pendingInteractionRequestIds(activities);
   for (const activity of activities) {
-    // These are durable transcript cards, including submitted answers, not transient work logs.
-    if (activity.kind === "user-input.async") {
+    // Unresolved questions survive the cap; answered cards age out with history.
+    if (isPendingAsyncUserInputActivity(activity)) {
       retainedIds.add(activity.id);
       continue;
     }

--- a/apps/web/src/storeNormalization.ts
+++ b/apps/web/src/storeNormalization.ts
@@ -1313,6 +1313,11 @@ export function capThreadActivities<TActivity extends Thread["activities"][numbe
   const retainedIds = new Set(activities.slice(dropCount).map((activity) => activity.id));
   const pendingRequestIds = pendingInteractionRequestIds(activities);
   for (const activity of activities) {
+    // These are durable transcript cards, including submitted answers, not transient work logs.
+    if (activity.kind === "user-input.async") {
+      retainedIds.add(activity.id);
+      continue;
+    }
     const requestId = activityRequestId(activity);
     if (
       requestId !== null &&

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -40,6 +40,7 @@ import {
 import { stripProposedPlanBlocksFromText } from "./proposedPlan";
 
 import type { ChatMessage, ProposedPlan } from "./types";
+import { type AsyncUserInputActivity } from "@synara/shared/asyncUserInput";
 
 export type WorkLogRequestKind = ApprovalRequestKind;
 
@@ -202,6 +203,7 @@ export function isProviderFileEditWorkLogEntry(
 }
 
 export type TimelineEntry =
+  | { id: string; kind: "async-question"; createdAt: string; activity: AsyncUserInputActivity }
   | {
       id: string;
       kind: "message";
@@ -306,6 +308,7 @@ export function deriveWorkLogEntries(
     )
     .filter((activity) => !isQuietTurnLifecycleActivity(activity))
     .filter((activity) => activity.kind !== "account.rate-limits.updated")
+    .filter((activity) => activity.kind !== "user-input.async")
     .filter(
       (activity) =>
         activity.kind !== "context-window.updated" && activity.kind !== "context-window.configured",
@@ -2347,6 +2350,7 @@ export function deriveTimelineEntries(
   messages: ChatMessage[],
   proposedPlans: ProposedPlan[],
   workEntries: WorkLogEntry[],
+  asyncQuestions: readonly AsyncUserInputActivity[] = [],
 ): TimelineEntry[] {
   const proposedPlanTurnIds = new Set(
     proposedPlans.flatMap((proposedPlan) => (proposedPlan.turnId ? [proposedPlan.turnId] : [])),
@@ -2413,6 +2417,14 @@ export function deriveTimelineEntries(
       sortedTimelineEntries(messageRows),
       sortedTimelineEntries(proposedPlanRows),
     ),
-    sortedTimelineEntries(workRows),
+    sortedTimelineEntries([
+      ...workRows,
+      ...asyncQuestions.map((activity): TimelineEntry => ({
+        id: activity.id,
+        kind: "async-question",
+        createdAt: activity.createdAt,
+        activity,
+      })),
+    ]),
   );
 }

--- a/apps/web/src/workLog.ts
+++ b/apps/web/src/workLog.ts
@@ -2419,12 +2419,14 @@ export function deriveTimelineEntries(
     ),
     sortedTimelineEntries([
       ...workRows,
-      ...asyncQuestions.map((activity): TimelineEntry => ({
-        id: activity.id,
-        kind: "async-question",
-        createdAt: activity.createdAt,
-        activity,
-      })),
+      ...asyncQuestions.map(
+        (activity): TimelineEntry => ({
+          id: activity.id,
+          kind: "async-question",
+          createdAt: activity.createdAt,
+          activity,
+        }),
+      ),
     ]),
   );
 }

--- a/packages/contracts/src/asyncUserInput.test.ts
+++ b/packages/contracts/src/asyncUserInput.test.ts
@@ -1,0 +1,14 @@
+import { Schema } from "effect";
+import { expect, it } from "vitest";
+
+import { AsyncUserInputActivityPayload } from "./asyncUserInput";
+
+it("keeps pending and answered async question payloads JSON-compatible", () => {
+  const questions = [{ title: "Which approach?", options: null }];
+  const response = { answers: ["A"], messageId: "answer-1" };
+  const isPayload = Schema.is(AsyncUserInputActivityPayload);
+
+  expect(isPayload({ questions })).toBe(true);
+  expect(isPayload({ questions, response })).toBe(true);
+  expect(isPayload({ questions, response: undefined })).toBe(false);
+});

--- a/packages/contracts/src/asyncUserInput.ts
+++ b/packages/contracts/src/asyncUserInput.ts
@@ -21,7 +21,7 @@ export type AsyncUserInputResponse = typeof AsyncUserInputResponse.Type;
 
 export const AsyncUserInputActivityPayload = Schema.Struct({
   questions: AsyncUserInputQuestions,
-  response: Schema.optional(
+  response: Schema.optionalKey(
     Schema.Struct({
       answers: Schema.Array(TrimmedNonEmptyString),
       messageId: MessageId,

--- a/packages/contracts/src/asyncUserInput.ts
+++ b/packages/contracts/src/asyncUserInput.ts
@@ -1,0 +1,31 @@
+import { Schema } from "effect";
+import { EventId, MessageId, TrimmedNonEmptyString } from "./baseSchemas";
+
+export const CODEX_ASYNC_USER_INPUT_ACTIVITY_KIND = "user-input.async";
+
+export const AsyncUserInputQuestion = Schema.Struct({
+  title: Schema.String.check(Schema.isMinLength(1)),
+  options: Schema.NullOr(Schema.Array(Schema.String.check(Schema.isMinLength(1)))),
+});
+export type AsyncUserInputQuestion = typeof AsyncUserInputQuestion.Type;
+
+export const AsyncUserInputQuestions = Schema.Array(AsyncUserInputQuestion).check(
+  Schema.isMinLength(1),
+);
+
+export const AsyncUserInputResponse = Schema.Struct({
+  activityId: EventId,
+  answers: Schema.Array(TrimmedNonEmptyString).check(Schema.isMinLength(1)),
+});
+export type AsyncUserInputResponse = typeof AsyncUserInputResponse.Type;
+
+export const AsyncUserInputActivityPayload = Schema.Struct({
+  questions: AsyncUserInputQuestions,
+  response: Schema.optional(
+    Schema.Struct({
+      answers: Schema.Array(TrimmedNonEmptyString),
+      messageId: MessageId,
+    }),
+  ),
+});
+export type AsyncUserInputActivityPayload = typeof AsyncUserInputActivityPayload.Type;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./auth";
+export * from "./asyncUserInput";
 export * from "./automation";
 export * from "./baseSchemas";
 export * from "./browserAutomationBounds";

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -620,6 +620,27 @@ it.effect("decodes thread.meta-updated payloads with explicit provider", () =>
   }),
 );
 
+it.effect("preserves async question association through the client command boundary", () =>
+  Effect.gen(function* () {
+    const response = { activityId: "codex-async-question:thread:item", answers: ["Switching tabs"] };
+    const command = yield* decodeClientOrchestrationCommand({
+      type: "thread.turn.start",
+      commandId: "answer-question",
+      threadId: "thread-1",
+      message: { messageId: "answer-1", role: "user", text: "Switching tabs", attachments: [] },
+      asyncUserInputResponse: response,
+      dispatchMode: "steer",
+      runtimeMode: "full-access",
+      interactionMode: "default",
+      createdAt: "2026-09-10T12:00:00.000Z",
+    });
+    assert.strictEqual(command.type, "thread.turn.start");
+    if (command.type === "thread.turn.start") {
+      assert.deepEqual(command.asyncUserInputResponse, response);
+    }
+  }),
+);
+
 it.effect("strips client-sent dispatchOrigin from thread.turn.start commands", () =>
   Effect.gen(function* () {
     // dispatchOrigin is server-assigned (automation engine only). The client command

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -622,7 +622,10 @@ it.effect("decodes thread.meta-updated payloads with explicit provider", () =>
 
 it.effect("preserves async question association through the client command boundary", () =>
   Effect.gen(function* () {
-    const response = { activityId: "codex-async-question:thread:item", answers: ["Switching tabs"] };
+    const response = {
+      activityId: "codex-async-question:thread:item",
+      answers: ["Switching tabs"],
+    };
     const command = yield* decodeClientOrchestrationCommand({
       type: "thread.turn.start",
       commandId: "answer-question",

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -313,6 +313,7 @@ export type ThreadEnvironmentMode = typeof ThreadEnvironmentMode.Type;
 
 export const OrchestrationMessageSource = Schema.Literals([
   "native",
+  "async-user-input",
   "handoff-import",
   "fork-import",
 ]);

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -12,6 +12,7 @@ import {
 } from "./model";
 import { ProviderMentionReference, ProviderSkillReference } from "./providerDiscovery";
 import { ProjectKind } from "./project";
+import { AsyncUserInputResponse } from "./asyncUserInput";
 import {
   ApprovalRequestId,
   CheckpointRef,
@@ -1378,6 +1379,7 @@ export const ThreadTurnStartCommand = Schema.Struct({
   type: Schema.Literal("thread.turn.start"),
   commandId: CommandId,
   threadId: ThreadId,
+  asyncUserInputResponse: Schema.optional(AsyncUserInputResponse),
   message: Schema.Struct({
     messageId: MessageId,
     role: Schema.Literal("user"),
@@ -1419,6 +1421,7 @@ const ClientThreadTurnStartCommand = Schema.Struct({
   type: Schema.Literal("thread.turn.start"),
   commandId: CommandId,
   threadId: ThreadId,
+  asyncUserInputResponse: Schema.optional(AsyncUserInputResponse),
   message: Schema.Struct({
     messageId: MessageId,
     role: Schema.Literal("user"),

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -13,6 +13,7 @@ import {
   TurnId,
 } from "./baseSchemas";
 import { ProviderKind } from "./orchestration";
+import { AsyncUserInputQuestions } from "./asyncUserInput";
 
 const TrimmedNonEmptyStringSchema = TrimmedNonEmptyString;
 const UnknownRecordSchema = Schema.Record(Schema.String, Schema.Unknown);
@@ -428,6 +429,7 @@ export type TurnDiffUpdatedPayload = typeof TurnDiffUpdatedPayload.Type;
 
 export const ItemLifecyclePayload = Schema.Struct({
   itemType: CanonicalItemType,
+  asyncQuestions: Schema.optional(AsyncUserInputQuestions),
   status: Schema.optional(RuntimeItemStatus),
   title: Schema.optional(TrimmedNonEmptyStringSchema),
   // Free-form body (e.g. raw tool output), which legitimately carries leading

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./asyncUserInput": {
+      "types": "./src/asyncUserInput.ts",
+      "import": "./src/asyncUserInput.ts"
+    },
     "./model": {
       "types": "./src/model.ts",
       "import": "./src/model.ts"

--- a/packages/shared/src/asyncUserInput.test.ts
+++ b/packages/shared/src/asyncUserInput.test.ts
@@ -1,0 +1,26 @@
+import { expect, it } from "vitest";
+import { canRespondToAsyncUserInput, isPendingAsyncUserInputActivity } from "./asyncUserInput";
+
+it("allows async responses only on session-owning tasks", () => {
+  expect(canRespondToAsyncUserInput({ id: "root" })).toBe(true);
+  expect(canRespondToAsyncUserInput({ id: "child", parentThreadId: "root" })).toBe(false);
+  expect(canRespondToAsyncUserInput({ id: "subagent:root:child" })).toBe(false);
+});
+
+it("retains valid unanswered cards, not malformed or settled activity", () => {
+  const pending = {
+    kind: "user-input.async",
+    payload: { questions: [{ title: "Which?", options: null }] },
+  };
+  expect(isPendingAsyncUserInputActivity(pending)).toBe(true);
+  expect(isPendingAsyncUserInputActivity({ ...pending, payload: {} })).toBe(false);
+  expect(
+    isPendingAsyncUserInputActivity({
+      ...pending,
+      payload: {
+        ...pending.payload,
+        response: { answers: ["A"], messageId: "answer" },
+      },
+    }),
+  ).toBe(false);
+});

--- a/packages/shared/src/asyncUserInput.ts
+++ b/packages/shared/src/asyncUserInput.ts
@@ -29,6 +29,18 @@ export function isAsyncUserInputActivity(
   return asyncUserInputPayload(activity) !== undefined;
 }
 
+export function isPendingAsyncUserInputActivity(activity: ActivityFields): boolean {
+  const payload = asyncUserInputPayload(activity);
+  return payload !== undefined && payload.response === undefined;
+}
+
+export function canRespondToAsyncUserInput(thread: {
+  readonly id: string;
+  readonly parentThreadId?: string | null | undefined;
+}): boolean {
+  return !thread.parentThreadId && !thread.id.startsWith("subagent:");
+}
+
 export function reopenAsyncUserInputAfterMessageRemoval<T extends ActivityFields>(
   activities: readonly T[],
   removedMessageIds: ReadonlySet<string>,

--- a/packages/shared/src/asyncUserInput.ts
+++ b/packages/shared/src/asyncUserInput.ts
@@ -1,0 +1,48 @@
+import {
+  AsyncUserInputActivityPayload,
+  CODEX_ASYNC_USER_INPUT_ACTIVITY_KIND,
+  type AsyncUserInputQuestion,
+  type OrchestrationThreadActivity,
+} from "@synara/contracts";
+import { Schema } from "effect";
+
+const isAsyncUserInputPayload = Schema.is(AsyncUserInputActivityPayload);
+
+type ActivityFields = { readonly kind: string; readonly payload: unknown };
+
+function asyncUserInputPayload(activity: ActivityFields): AsyncUserInputActivityPayload | undefined {
+  return activity.kind === CODEX_ASYNC_USER_INPUT_ACTIVITY_KIND &&
+    isAsyncUserInputPayload(activity.payload)
+    ? activity.payload
+    : undefined;
+}
+
+export type AsyncUserInputActivity = Omit<OrchestrationThreadActivity, "payload"> & {
+  payload: AsyncUserInputActivityPayload;
+};
+
+export function isAsyncUserInputActivity(
+  activity: OrchestrationThreadActivity,
+): activity is AsyncUserInputActivity {
+  return asyncUserInputPayload(activity) !== undefined;
+}
+
+export function reopenAsyncUserInputAfterMessageRemoval<T extends ActivityFields>(
+  activities: readonly T[],
+  removedMessageIds: ReadonlySet<string>,
+): T[] {
+  return activities.map((activity) => {
+    const payload = asyncUserInputPayload(activity);
+    if (!payload?.response || !removedMessageIds.has(payload.response.messageId)) {
+      return activity;
+    }
+    return { ...activity, payload: { questions: payload.questions } };
+  });
+}
+
+export function formatAsyncUserInputResponse(
+  questions: readonly AsyncUserInputQuestion[],
+  answers: readonly string[],
+): string {
+  return questions.map((question, index) => `${question.title}\n${answers[index]}`).join("\n\n");
+}

--- a/packages/shared/src/asyncUserInput.ts
+++ b/packages/shared/src/asyncUserInput.ts
@@ -10,7 +10,9 @@ const isAsyncUserInputPayload = Schema.is(AsyncUserInputActivityPayload);
 
 type ActivityFields = { readonly kind: string; readonly payload: unknown };
 
-function asyncUserInputPayload(activity: ActivityFields): AsyncUserInputActivityPayload | undefined {
+function asyncUserInputPayload(
+  activity: ActivityFields,
+): AsyncUserInputActivityPayload | undefined {
   return activity.kind === CODEX_ASYNC_USER_INPUT_ACTIVITY_KIND &&
     isAsyncUserInputPayload(activity.payload)
     ? activity.payload

--- a/packages/shared/src/conversationEdit.test.ts
+++ b/packages/shared/src/conversationEdit.test.ts
@@ -7,6 +7,21 @@ import {
 } from "./conversationEdit";
 
 describe("conversationEdit", () => {
+  it("does not expose generated async answers or the prompt before them for editing", () => {
+    const messages = [
+      { id: "prompt", role: "user", source: "native", turnId: "turn-1" },
+      { id: "answer", role: "user", source: "async-user-input", turnId: "turn-1" },
+    ];
+    expect(resolveLatestTailUserMessageEditTarget({ messages })).toEqual({
+      editable: false,
+      reason: "non-native-message",
+    });
+    expect(resolveTailUserMessageEditTarget({ messages, messageId: "prompt" })).toEqual({
+      editable: false,
+      reason: "not-latest-native-user-message",
+    });
+  });
+
   it("collects unique turn ids from a target message through the tail", () => {
     expect(
       collectTailTurnIds({

--- a/packages/shared/src/conversationEdit.ts
+++ b/packages/shared/src/conversationEdit.ts
@@ -33,8 +33,12 @@ export type TailUserMessageEditTarget =
         | "spans-multiple-turns";
     };
 
+export function isNativeConversationMessageSource(source: string | undefined): boolean {
+  return source === undefined || source === "native" || source === "async-user-input";
+}
+
 function isNativeEditableSource(source: string | undefined): boolean {
-  return source === undefined || source === "native";
+  return isNativeConversationMessageSource(source) && source !== "async-user-input";
 }
 
 function collectUniqueTurnIds<TTurnId extends string>(
@@ -57,7 +61,7 @@ export function collectTailTurnIds<TTurnId extends string>(input: {
 function findLatestNativeUserMessageIndex(messages: ReadonlyArray<EditableMessageLike>): number {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
-    if (message?.role === "user" && isNativeEditableSource(message.source)) {
+    if (message?.role === "user" && isNativeConversationMessageSource(message.source)) {
       return index;
     }
   }


### PR DESCRIPTION
## Summary

- Add end-to-end async user-input handling across Codex, orchestration, provider runtime, contracts, and web state.
- Persist and project pending questions so sessions can resume reliably after user responses.
- Add chat UI cards and composer choices for answering asynchronous prompts.
- Expand reducer, normalization, projection, adapter, and orchestration test coverage.

## Testing

- Added focused unit and integration tests across server, orchestration, provider, contracts, and web layers.
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes Codex steer semantics, turn-start/retry paths, and orchestration projection SQL—areas where duplicate delivery or lost pending questions would be user-visible.
> 
> **Overview**
> Adds **end-to-end asynchronous Codex questions** (`user-input.async`): the adapter maps completed agent messages with `asyncQuestions`, runtime ingestion keeps the turn streaming while questions are pending, and orchestration admits answers via `thread.turn.start` with `asyncUserInputResponse` (formatted user message, `async-user-input` source, steer dispatch).
> 
> **Persistence and read models** keep unresolved question cards visible past activity caps (`includeActivityId` for command validation, SQL/projection/client normalization), and **reopen** cards when rollback/revert removes the answer message. Child/subagent threads cannot respond.
> 
> **Codex `steerTurn` no longer falls back to `sendTurn`** when there is no steerable active turn; it throws typed errors that the adapter surfaces as `turn-not-active` / `turn-not-steerable`. The provider reactor uses those signals to avoid duplicate sends on steer timeouts, run normal turn-start (with baselines) after a race with turn end, or **queue** answers until review/compaction finishes.
> 
> The chat UI adds **`AsyncUserInputCard`** in the transcript and wires submission through orchestration commands. Harness text now steers agents toward `request_user_input_async` when available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10d17dd411b80b16774739c9e92cd487ed3dddda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->