### PR TITLE
Recover pending Claude questions across restarts and expired sessions

### DIFF
--- a/apps/server/src/effectServer.ts
+++ b/apps/server/src/effectServer.ts
@@ -1,3 +1,4 @@
+import { ProjectionPendingInteractionRepositoryLive } from "./persistence/Layers/ProjectionPendingInteractions";
 import http from "node:http";
 
 import type { ServerSettingsError } from "@synara/contracts";
@@ -216,7 +217,9 @@ export const createEffectServer = Effect.fn(function* (
   // Heal turns orphaned by the previous process exit (their in-memory runtimes
   // died, so they can never complete on their own) before clients can observe
   // the stale "Working" state.
-  yield* reconcileRestartStuckTurns;
+  yield* reconcileRestartStuckTurns.pipe(
+    Effect.provide(ProjectionPendingInteractionRepositoryLive),
+  );
   // The reconciliation above terminalizes durable turn projections without a
   // provider terminal event. Remove their replay-ledger rows now so the next
   // process start cannot replay state-dependent commands against the terminal

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -15,7 +15,7 @@ import {
   setThreadMarkerDone,
   setThreadMarkerLabel,
 } from "@synara/shared/threadMarkers";
-import { isStalePendingRequestFailureDetail } from "@synara/shared/threadSummary";
+import { createStalePendingInteractionMatcher } from "@synara/shared/pendingInteractions";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Effect, FileSystem, Layer, Option, Path, Stream } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
@@ -1729,9 +1729,7 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
               // while every actual response hit a dead provider.
               if (
                 existingRow.value.status === "confirmed" ||
-                !isStalePendingRequestFailureDetail(
-                  payloadNonEmptyString(activity.payload, "detail") ?? undefined,
-                )
+                !createStalePendingInteractionMatcher([activity])(existingRow.value)
               ) {
                 return;
               }

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -11563,7 +11563,7 @@ describe("ProviderCommandReactor", () => {
       }),
     );
     expect(Option.getOrUndefined(retryableApproval)).toMatchObject({
-      status: "retryable",
+      status: "uncertain",
       responseCommandId: "cmd-approval-respond-stopped",
       decision: "accept",
       resolvedAt: null,
@@ -11635,15 +11635,15 @@ describe("ProviderCommandReactor", () => {
       );
     });
     expect(harness.respondToUserInput).not.toHaveBeenCalled();
-    const retryableUserInput = await Effect.runPromise(
+    const expiredUserInput = await Effect.runPromise(
       harness.pendingInteractionRepository.getByIdentity({
         threadId: ThreadId.makeUnsafe("thread-1"),
         interactionKind: "userInput",
         requestId: asApprovalRequestId("user-input-request-stopped"),
       }),
     );
-    expect(Option.getOrUndefined(retryableUserInput)).toMatchObject({
-      status: "retryable",
+    expect(Option.getOrUndefined(expiredUserInput)).toMatchObject({
+      status: "uncertain",
       responseCommandId: "cmd-user-input-respond-stopped",
       decision: null,
       resolvedAt: null,
@@ -11936,154 +11936,168 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
-  it("surfaces stale provider user-input failures without faking user-input resolution", async () => {
-    const harness = await createHarness();
-    const now = new Date().toISOString();
-    harness.respondToUserInput.mockImplementation(() =>
-      Effect.fail(
-        new ProviderAdapterRequestError({
-          provider: "claudeAgent",
-          method: "item/tool/respondToUserInput",
-          detail: "Unknown pending user-input request: user-input-request-1",
-        }),
-      ),
-    );
+  it.each(["callback-missing", "runtime-unavailable", "stale-interaction"] as const)(
+    "expires %s user-input failures without faking resolution or retrying a dead callback",
+    async (reason) => {
+      const harness = await createHarness();
+      const now = new Date().toISOString();
+      harness.respondToUserInput.mockImplementation(() =>
+        Effect.fail(
+          reason === "callback-missing"
+            ? new ProviderAdapterRequestError({
+                provider: "claudeAgent",
+                method: "item/tool/respondToUserInput",
+                detail: "Unknown pending user-input request: user-input-request-1",
+              })
+            : new ProviderValidationError({
+                operation: "ProviderService.respondToUserInput",
+                issue: "Callback runtime no longer exists",
+                reason,
+              }),
+        ),
+      );
 
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.session.set",
-        commandId: CommandId.makeUnsafe("cmd-session-set-for-user-input-error"),
-        threadId: ThreadId.makeUnsafe("thread-1"),
-        session: {
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.session.set",
+          commandId: CommandId.makeUnsafe("cmd-session-set-for-user-input-error"),
           threadId: ThreadId.makeUnsafe("thread-1"),
-          status: "running",
-          providerName: "claudeAgent",
-          runtimeMode: "approval-required",
-          activeTurnId: null,
-          lastError: null,
-          updatedAt: now,
-        },
-        createdAt: now,
-      }),
-    );
-
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.activity.append",
-        commandId: CommandId.makeUnsafe("cmd-user-input-requested"),
-        threadId: ThreadId.makeUnsafe("thread-1"),
-        activity: {
-          id: EventId.makeUnsafe("activity-user-input-requested"),
-          tone: "info",
-          kind: "user-input.requested",
-          summary: "User input requested",
-          payload: {
-            requestId: "user-input-request-1",
-            questions: [
-              {
-                id: "sandbox_mode",
-                header: "Sandbox",
-                question: "Which mode should be used?",
-                options: [
-                  {
-                    label: "workspace-write",
-                    description: "Allow workspace writes only",
-                  },
-                ],
-              },
-            ],
+          session: {
+            threadId: ThreadId.makeUnsafe("thread-1"),
+            status: "running",
+            providerName: "claudeAgent",
+            runtimeMode: "approval-required",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: now,
           },
-          turnId: null,
           createdAt: now,
-        },
-        createdAt: now,
-      }),
-    );
+        }),
+      );
 
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.user-input.respond",
-        commandId: CommandId.makeUnsafe("cmd-user-input-respond-stale"),
-        threadId: ThreadId.makeUnsafe("thread-1"),
-        requestId: asApprovalRequestId("user-input-request-1"),
-        answers: {
-          sandbox_mode: "workspace-write",
-        },
-        createdAt: now,
-      }),
-    );
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.activity.append",
+          commandId: CommandId.makeUnsafe("cmd-user-input-requested"),
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          activity: {
+            id: EventId.makeUnsafe("activity-user-input-requested"),
+            tone: "info",
+            kind: "user-input.requested",
+            summary: "User input requested",
+            payload: {
+              requestId: "user-input-request-1",
+              questions: [
+                {
+                  id: "sandbox_mode",
+                  header: "Sandbox",
+                  question: "Which mode should be used?",
+                  options: [
+                    {
+                      label: "workspace-write",
+                      description: "Allow workspace writes only",
+                    },
+                  ],
+                },
+              ],
+            },
+            turnId: null,
+            createdAt: now,
+          },
+          createdAt: now,
+        }),
+      );
 
-    await waitFor(
-      async () =>
-        (await readHarnessThread(harness))?.activities.some(
-          (activity) => activity.kind === "provider.user-input.respond.failed",
-        ) === true,
-    );
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.user-input.respond",
+          commandId: CommandId.makeUnsafe("cmd-user-input-respond-stale"),
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          requestId: asApprovalRequestId("user-input-request-1"),
+          answers: {
+            sandbox_mode: "workspace-write",
+          },
+          createdAt: now,
+        }),
+      );
 
-    const thread = await readHarnessThread(harness);
-    expect(thread).toBeDefined();
+      await waitFor(
+        async () =>
+          (await readHarnessThread(harness))?.activities.some(
+            (activity) => activity.kind === "provider.user-input.respond.failed",
+          ) === true,
+      );
 
-    const failureActivity = thread?.activities.find(
-      (activity) => activity.kind === "provider.user-input.respond.failed",
-    );
-    expect(failureActivity).toBeDefined();
-    expect(failureActivity?.payload).toMatchObject({
-      requestId: "user-input-request-1",
-      responseCommandId: "cmd-user-input-respond-stale",
-      settlementStatus: "uncertain",
-      detail: expect.stringContaining("Stale pending user-input request: user-input-request-1"),
-    });
-    const uncertainUserInput = await Effect.runPromise(
-      harness.pendingInteractionRepository.getByIdentity({
-        threadId: ThreadId.makeUnsafe("thread-1"),
-        interactionKind: "userInput",
-        requestId: asApprovalRequestId("user-input-request-1"),
-      }),
-    );
-    expect(Option.getOrUndefined(uncertainUserInput)).toMatchObject({
-      status: "uncertain",
-      responseCommandId: "cmd-user-input-respond-stale",
-      decision: null,
-      resolvedAt: null,
-    });
+      const thread = await readHarnessThread(harness);
+      expect(thread).toBeDefined();
 
-    const resolvedActivity = thread?.activities.find(
-      (activity) =>
-        activity.kind === "user-input.resolved" &&
-        typeof activity.payload === "object" &&
-        activity.payload !== null &&
-        (activity.payload as Record<string, unknown>).requestId === "user-input-request-1",
-    );
-    expect(resolvedActivity).toBeUndefined();
+      const failureActivity = thread?.activities.find(
+        (activity) => activity.kind === "provider.user-input.respond.failed",
+      );
+      expect(failureActivity).toBeDefined();
+      expect(failureActivity?.payload).toMatchObject({
+        requestId: "user-input-request-1",
+        responseCommandId: "cmd-user-input-respond-stale",
+        settlementStatus: "uncertain",
+        detail: expect.stringContaining("Stale pending user-input request: user-input-request-1"),
+      });
+      const uncertainUserInput = await Effect.runPromise(
+        harness.pendingInteractionRepository.getByIdentity({
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          interactionKind: "userInput",
+          requestId: asApprovalRequestId("user-input-request-1"),
+        }),
+      );
+      expect(Option.getOrUndefined(uncertainUserInput)).toMatchObject({
+        status: "uncertain",
+        responseCommandId: "cmd-user-input-respond-stale",
+        decision: null,
+        resolvedAt: null,
+      });
 
-    // An `uncertain` settlement must not lock the interaction out forever: a
-    // later response command re-claims the row and is forwarded again.
-    harness.respondToUserInput.mockImplementation(() => Effect.void);
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.user-input.respond",
-        commandId: CommandId.makeUnsafe("cmd-user-input-respond-retry"),
-        threadId: ThreadId.makeUnsafe("thread-1"),
-        requestId: asApprovalRequestId("user-input-request-1"),
-        answers: {
-          sandbox_mode: "workspace-write",
-        },
-        createdAt: new Date().toISOString(),
-      }),
-    );
-    await waitFor(() => harness.respondToUserInput.mock.calls.length === 2);
-    const reclaimedUserInput = await Effect.runPromise(
-      harness.pendingInteractionRepository.getByIdentity({
-        threadId: ThreadId.makeUnsafe("thread-1"),
-        interactionKind: "userInput",
-        requestId: asApprovalRequestId("user-input-request-1"),
-      }),
-    );
-    expect(Option.getOrUndefined(reclaimedUserInput)).toMatchObject({
-      status: "responding",
-      responseCommandId: "cmd-user-input-respond-retry",
-    });
-  });
+      const resolvedActivity = thread?.activities.find(
+        (activity) =>
+          activity.kind === "user-input.resolved" &&
+          typeof activity.payload === "object" &&
+          activity.payload !== null &&
+          (activity.payload as Record<string, unknown>).requestId === "user-input-request-1",
+      );
+      expect(resolvedActivity).toBeUndefined();
+
+      // Explicit invalidation is terminal, unlike an ambiguous delivery failure.
+      harness.respondToUserInput.mockImplementation(() => Effect.void);
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.user-input.respond",
+          commandId: CommandId.makeUnsafe("cmd-user-input-respond-retry"),
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          requestId: asApprovalRequestId("user-input-request-1"),
+          answers: {
+            sandbox_mode: "workspace-write",
+          },
+          createdAt: new Date().toISOString(),
+        }),
+      );
+      await waitFor(
+        async () =>
+          (await readHarnessThread(harness))?.activities.filter(
+            (activity) => activity.kind === "provider.user-input.respond.failed",
+          ).length === 2,
+      );
+      expect(harness.respondToUserInput).toHaveBeenCalledTimes(1);
+      const reclaimedUserInput = await Effect.runPromise(
+        harness.pendingInteractionRepository.getByIdentity({
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          interactionKind: "userInput",
+          requestId: asApprovalRequestId("user-input-request-1"),
+        }),
+      );
+      expect(Option.getOrUndefined(reclaimedUserInput)).toMatchObject({
+        status: "uncertain",
+        responseCommandId: "cmd-user-input-respond-stale",
+      });
+    },
+  );
 
   it("keeps full-context AskUserQuestion rejection retryable across session recovery", async () => {
     const harness = await createHarness();
@@ -12237,85 +12251,117 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
-  it("surfaces unclaimable user-input responses instead of dropping them silently", async () => {
-    const harness = await createHarness();
-    const now = new Date().toISOString();
+  it.each([undefined, "generation-stale"])(
+    "surfaces unclaimable responses (%s) without expiring the current generation",
+    async (generation) => {
+      const harness = await createHarness();
+      const now = new Date().toISOString();
 
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.session.set",
-        commandId: CommandId.makeUnsafe("cmd-session-set-for-unclaimable"),
-        threadId: ThreadId.makeUnsafe("thread-1"),
-        session: {
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.session.set",
+          commandId: CommandId.makeUnsafe("cmd-session-set-for-unclaimable"),
           threadId: ThreadId.makeUnsafe("thread-1"),
-          status: "running",
-          providerName: "claudeAgent",
-          runtimeMode: "approval-required",
-          activeTurnId: null,
-          lastError: null,
-          updatedAt: now,
-        },
-        createdAt: now,
-      }),
-    );
-
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.activity.append",
-        commandId: CommandId.makeUnsafe("cmd-user-input-requested-unclaimable"),
-        threadId: ThreadId.makeUnsafe("thread-1"),
-        activity: {
-          id: EventId.makeUnsafe("activity-user-input-requested-unclaimable"),
-          tone: "info",
-          kind: "user-input.requested",
-          summary: "User input requested",
-          payload: {
-            requestId: "user-input-request-unclaimable",
-            lifecycleGeneration: "generation-current",
-            questions: [],
+          session: {
+            threadId: ThreadId.makeUnsafe("thread-1"),
+            status: "running",
+            providerName: "claudeAgent",
+            runtimeMode: "approval-required",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: now,
           },
-          turnId: null,
           createdAt: now,
-        },
-        createdAt: now,
-      }),
-    );
+        }),
+      );
 
-    // A response carrying a lifecycle generation the durable row does not have
-    // can never claim it. This used to be dropped with no activity and no
-    // resolution, leaving the prompt permanently stuck.
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.user-input.respond",
-        commandId: CommandId.makeUnsafe("cmd-user-input-respond-unclaimable"),
-        threadId: ThreadId.makeUnsafe("thread-1"),
-        requestId: asApprovalRequestId("user-input-request-unclaimable"),
-        lifecycleGeneration: "generation-stale",
-        answers: { input: "continue" },
-        createdAt: now,
-      }),
-    );
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.activity.append",
+          commandId: CommandId.makeUnsafe("cmd-user-input-requested-unclaimable"),
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          activity: {
+            id: EventId.makeUnsafe("activity-user-input-requested-unclaimable"),
+            tone: "info",
+            kind: "user-input.requested",
+            summary: "User input requested",
+            payload: {
+              requestId: "user-input-request-unclaimable",
+              lifecycleGeneration: "generation-current",
+              questions: [],
+            },
+            turnId: null,
+            createdAt: now,
+          },
+          createdAt: now,
+        }),
+      );
 
-    await waitFor(
-      async () =>
-        (await readHarnessThread(harness))?.activities.some(
-          (activity) => activity.kind === "provider.user-input.respond.failed",
-        ) === true,
-    );
-    expect(harness.respondToUserInput).not.toHaveBeenCalled();
+      // A response carrying a lifecycle generation the durable row does not have
+      // can never claim it. This used to be dropped with no activity and no
+      // resolution, leaving the prompt permanently stuck.
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.user-input.respond",
+          commandId: CommandId.makeUnsafe("cmd-user-input-respond-unclaimable"),
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          requestId: asApprovalRequestId("user-input-request-unclaimable"),
+          ...(generation ? { lifecycleGeneration: generation } : {}),
+          answers: { input: "continue" },
+          createdAt: now,
+        }),
+      );
 
-    const failureActivity = (await readHarnessThread(harness))?.activities.find(
-      (activity) => activity.kind === "provider.user-input.respond.failed",
-    );
-    expect(failureActivity?.payload).toMatchObject({
-      requestId: "user-input-request-unclaimable",
-      responseCommandId: "cmd-user-input-respond-unclaimable",
-      settlementStatus: "uncertain",
-      detail: expect.stringContaining(
-        "Stale pending user-input request: user-input-request-unclaimable",
-      ),
-    });
-  });
+      await waitFor(
+        async () =>
+          (await readHarnessThread(harness))?.activities.some(
+            (activity) => activity.kind === "provider.user-input.respond.failed",
+          ) === true,
+      );
+      expect(harness.respondToUserInput).not.toHaveBeenCalled();
+
+      const failureActivity = (await readHarnessThread(harness))?.activities.find(
+        (activity) => activity.kind === "provider.user-input.respond.failed",
+      );
+      expect(failureActivity?.payload).toMatchObject({
+        requestId: "user-input-request-unclaimable",
+        responseCommandId: "cmd-user-input-respond-unclaimable",
+        settlementStatus: generation ? "uncertain" : "retryable",
+        detail: expect.stringContaining(
+          generation ? "Stale pending user-input request:" : "generation is missing",
+        ),
+      });
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.activity.append",
+          commandId: CommandId.makeUnsafe("old-reconciliation"),
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          createdAt: now,
+          activity: {
+            id: EventId.makeUnsafe("old-reconciliation"),
+            kind: "provider.user-input.respond.failed",
+            tone: "error",
+            summary: "Old callback expired",
+            turnId: null,
+            createdAt: now,
+            payload: {
+              requestId: "user-input-request-unclaimable",
+              lifecycleGeneration: "generation-stale",
+              detail: "Stale pending user-input request: user-input-request-unclaimable",
+            },
+          },
+        }),
+      );
+      const outstanding = await Effect.runPromise(
+        harness.pendingInteractionRepository.listUnsettled({
+          threadId: ThreadId.makeUnsafe("thread-1"),
+        }),
+      );
+      expect(outstanding).toEqual([
+        expect.objectContaining({ lifecycleGeneration: "generation-current", status: "pending" }),
+      ]);
+    },
+  );
 
   it("pauses a goal on explicit session stop during a Devin recovery gap", async () => {
     const harness = await createHarness({

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -522,6 +522,16 @@ function providerPromptOverflowIssue(goalPromptOverheadChars: number): string {
     : "The latest message is too long to include Synara Debug mode instructions. Shorten the message and retry.";
 }
 
+function isUnavailableInteractionRuntime(cause: Cause.Cause<ProviderServiceError>): boolean {
+  return Option.match(Cause.findErrorOption(cause), {
+    onNone: () => false,
+    onSome: (error) =>
+      (error._tag === "ProviderValidationError" && error.reason !== undefined) ||
+      error._tag === "ProviderAdapterSessionNotFoundError" ||
+      error._tag === "ProviderAdapterSessionClosedError",
+  });
+}
+
 function isUnknownPendingApprovalRequestError(cause: Cause.Cause<ProviderServiceError>): boolean {
   const error = Cause.squash(cause);
   if (Schema.is(ProviderAdapterRequestError)(error)) {
@@ -3890,6 +3900,20 @@ const make = Effect.gen(function* () {
         // outcome and needs no user-visible settlement.
         return null;
       }
+      if (
+        pendingRow?.lifecycleGeneration != null &&
+        event.payload.lifecycleGeneration === undefined
+      ) {
+        // An old client must refresh the request identity. A generation-less stale
+        // marker would also invalidate the replacement callback it never addressed.
+        yield* appendInteractionResponseFailure(event, {
+          interactionKind: input.interactionKind,
+          detail:
+            "Refresh this thread before answering: the provider lifecycle generation is missing.",
+          settlementStatus: "retryable",
+        });
+        return null;
+      }
       // No durable row, or a row this command can never claim (e.g. a lifecycle
       // generation mismatch). Silence here permanently stranded the prompt: the
       // client saw neither a resolution nor a failure, so every retry was
@@ -3919,16 +3943,22 @@ const make = Effect.gen(function* () {
       // settlement would orphan it and silently swallow every future response.
       yield* appendInteractionResponseFailure(event, {
         interactionKind: input.interactionKind,
-        detail: "No provider session thread is bound to this thread.",
-        settlementStatus: "retryable",
+        detail: buildStalePendingRequestFailureDetail(
+          input.interactionKind === "approval" ? "approval" : "user-input",
+          event.payload.requestId,
+        ),
+        settlementStatus: "uncertain",
       });
       return null;
     }
     if (providerThread.session?.status !== "stopped") return providerThread.id;
     yield* appendInteractionResponseFailure(event, {
       interactionKind: input.interactionKind,
-      detail: "No active provider session is bound to this thread.",
-      settlementStatus: "retryable",
+      detail: buildStalePendingRequestFailureDetail(
+        input.interactionKind === "approval" ? "approval" : "user-input",
+        event.payload.requestId,
+      ),
+      settlementStatus: "uncertain",
     });
     return null;
   });
@@ -3955,7 +3985,8 @@ const make = Effect.gen(function* () {
       .pipe(
         Effect.asVoid,
         Effect.catchCause((cause) => {
-          const unknownPendingRequest = isUnknownPendingApprovalRequestError(cause);
+          const unknownPendingRequest =
+            isUnavailableInteractionRuntime(cause) || isUnknownPendingApprovalRequestError(cause);
           return appendInteractionResponseFailure(event, {
             interactionKind: "approval",
             detail: unknownPendingRequest
@@ -3989,7 +4020,8 @@ const make = Effect.gen(function* () {
       .pipe(
         Effect.asVoid,
         Effect.catchCause((cause) => {
-          const unknownPendingRequest = isUnknownPendingUserInputRequestError(cause);
+          const unknownPendingRequest =
+            isUnavailableInteractionRuntime(cause) || isUnknownPendingUserInputRequestError(cause);
           return appendInteractionResponseFailure(event, {
             interactionKind: "userInput",
             detail: unknownPendingRequest

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -1,3 +1,5 @@
+import { ProjectionPendingInteractionRepositoryLive } from "../../persistence/Layers/ProjectionPendingInteractions.ts";
+import { ProjectionPendingInteractionRepository } from "../../persistence/Services/ProjectionPendingInteractions.ts";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -1535,71 +1537,88 @@ describe("ProviderRuntimeIngestion", () => {
     );
   });
 
-  it("settles orphaned pending interactions when a provider session (re)starts", async () => {
-    const harness = await createHarness();
-    const now = new Date().toISOString();
+  it.each(["pending", "responding", "uncertain"] as const)(
+    "settles orphaned %s interactions when a provider session (re)starts",
+    async (status) => {
+      const harness = await createHarness();
+      const now = new Date().toISOString();
 
-    // A user-input request left behind by a previous runtime: its in-memory
-    // callback cannot survive the restart, so no response can ever consume it.
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.activity.append",
-        commandId: CommandId.makeUnsafe("cmd-user-input-requested-orphaned"),
-        threadId: ThreadId.makeUnsafe("thread-1"),
-        activity: {
-          id: asEventId("activity-user-input-requested-orphaned"),
-          tone: "info",
-          kind: "user-input.requested",
-          summary: "User input requested",
-          payload: {
-            requestId: "user-input-request-orphaned",
-            lifecycleGeneration: "generation-before-restart",
-            questions: [],
+      // A user-input request left behind by a previous runtime: its in-memory
+      // callback cannot survive the restart, so no response can ever consume it.
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.activity.append",
+          commandId: CommandId.makeUnsafe("cmd-user-input-requested-orphaned"),
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          activity: {
+            id: asEventId("activity-user-input-requested-orphaned"),
+            tone: "info",
+            kind: "user-input.requested",
+            summary: "User input requested",
+            payload: {
+              requestId: "user-input-request-orphaned",
+              lifecycleGeneration: "generation-before-restart",
+              questions: [],
+            },
+            turnId: null,
+            createdAt: now,
           },
-          turnId: null,
           createdAt: now,
-        },
-        createdAt: now,
-      }),
-    );
+        }),
+      );
 
-    harness.emit({
-      type: "session.started",
-      eventId: asEventId("evt-session-restarted-orphaned"),
-      provider: "codex",
-      threadId: asThreadId("thread-1"),
-      createdAt: new Date().toISOString(),
-    });
-    await harness.drain();
+      const pendingRepository = await runtime!.runPromise(
+        Effect.service(ProjectionPendingInteractionRepository).pipe(
+          Effect.provide(ProjectionPendingInteractionRepositoryLive),
+        ),
+      );
+      const existing = (
+        await Effect.runPromise(
+          pendingRepository.listByThreadId({ threadId: asThreadId("thread-1") }),
+        )
+      )[0]!;
+      await Effect.runPromise(pendingRepository.upsert({ ...existing, status }));
 
-    const readModel = await Effect.runPromise(harness.engine.getReadModel());
-    const thread = readModel.threads.find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"));
-    const failureActivity = thread?.activities.find(
-      (activity) => activity.kind === "provider.user-input.respond.failed",
-    );
-    expect(failureActivity?.payload).toMatchObject({
-      requestId: "user-input-request-orphaned",
-      lifecycleGeneration: "generation-before-restart",
-      detail: expect.stringContaining(
-        "Stale pending user-input request: user-input-request-orphaned",
-      ),
-    });
+      harness.emit({
+        type: "session.started",
+        eventId: asEventId("evt-session-restarted-orphaned"),
+        provider: "codex",
+        threadId: asThreadId("thread-1"),
+        createdAt: new Date().toISOString(),
+      });
+      await harness.drain();
 
-    // Re-ingesting another session start must not duplicate the settlement.
-    harness.emit({
-      type: "session.started",
-      eventId: asEventId("evt-session-restarted-orphaned-again"),
-      provider: "codex",
-      threadId: asThreadId("thread-1"),
-      createdAt: new Date().toISOString(),
-    });
-    await harness.drain();
-    const readModelAfter = await Effect.runPromise(harness.engine.getReadModel());
-    const failuresAfter = readModelAfter.threads
-      .find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"))
-      ?.activities.filter((activity) => activity.kind === "provider.user-input.respond.failed");
-    expect(failuresAfter).toHaveLength(1);
-  });
+      const readModel = await Effect.runPromise(harness.engine.getReadModel());
+      const thread = readModel.threads.find(
+        (entry) => entry.id === ThreadId.makeUnsafe("thread-1"),
+      );
+      const failureActivity = thread?.activities.find(
+        (activity) => activity.kind === "provider.user-input.respond.failed",
+      );
+      expect(failureActivity?.payload).toMatchObject({
+        requestId: "user-input-request-orphaned",
+        lifecycleGeneration: "generation-before-restart",
+        detail: expect.stringContaining(
+          "Stale pending user-input request: user-input-request-orphaned",
+        ),
+      });
+
+      // Re-ingesting another session start must not duplicate the settlement.
+      harness.emit({
+        type: "session.started",
+        eventId: asEventId("evt-session-restarted-orphaned-again"),
+        provider: "codex",
+        threadId: asThreadId("thread-1"),
+        createdAt: new Date().toISOString(),
+      });
+      await harness.drain();
+      const readModelAfter = await Effect.runPromise(harness.engine.getReadModel());
+      const failuresAfter = readModelAfter.threads
+        .find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"))
+        ?.activities.filter((activity) => activity.kind === "provider.user-input.respond.failed");
+      expect(failuresAfter).toHaveLength(1);
+    },
+  );
 
   it("clears running turn state when a stop emits turn.aborted without a turn id", async () => {
     const harness = await createHarness();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1858,11 +1858,10 @@ const make = Effect.gen(function* () {
     now: string,
   ) =>
     Effect.gen(function* () {
-      const rows = yield* pendingInteractions.listByThreadId({ threadId });
+      const rows = yield* pendingInteractions.listUnsettled({ threadId });
       for (const row of rows) {
-        // `uncertain` rows were already reported as unanswerable; re-reporting
-        // on every session start would duplicate the failure activity.
-        if (row.status === "confirmed" || row.status === "uncertain") continue;
+        // An uncertain delivery is not proof that its callback was invalidated.
+        if (row.status === "uncertain" && row.interactionKind === "approval") continue;
         const isApproval = row.interactionKind === "approval";
         const requestKind = isApproval ? ("approval" as const) : ("user-input" as const);
         const commandId = providerCommandId(event, `stale-pending-${requestKind}`, row.requestId);

--- a/apps/server/src/orchestration/startupTurnReconciliation.test.ts
+++ b/apps/server/src/orchestration/startupTurnReconciliation.test.ts
@@ -1,8 +1,13 @@
+import { Effect, Option } from "effect";
+import { OrchestrationEngineService } from "./Services/OrchestrationEngine.ts";
+import { ProjectionSnapshotQuery } from "./Services/ProjectionSnapshotQuery.ts";
+import { ProjectionPendingInteractionRepository } from "../persistence/Services/ProjectionPendingInteractions.ts";
 import { ApprovalRequestId, EventId, ThreadId, TurnId } from "@synara/contracts";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   planRestartTurnReconciliation,
+  reconcileRestartStuckTurns,
   type ReconcilableThread,
 } from "./startupTurnReconciliation.ts";
 
@@ -644,4 +649,58 @@ describe("planRestartTurnReconciliation", () => {
     expect(first[0]?.commandId).toBe(second[0]?.commandId);
     expect(first[0]?.commandId).toBe(`restart-reconcile:stuck:${NOW}`);
   });
+});
+
+describe("reconcileRestartStuckTurns selection", () => {
+  it.each(["uncertain", "responding"] as const)(
+    "finds %s callbacks on completed threads even with false summary flags",
+    async (status) => {
+      const thread = {
+        ...makeThread("orphan", {
+          session: makeSession("orphan", { status: "ready", activeTurnId: null }),
+          latestTurn: { state: "completed" },
+        }),
+        activities: [],
+        hasPendingApprovals: false,
+        hasPendingUserInput: false,
+      };
+      const row = {
+        interactionKind: "userInput" as const,
+        requestId: ApprovalRequestId.makeUnsafe("orphaned-question"),
+        threadId: thread.id,
+        lifecycleGeneration: "lost-runtime",
+        status,
+        createdAt: NOW,
+      };
+      const dispatch = vi.fn(() => Effect.void);
+      const getThreadDetailById = vi.fn(() =>
+        Effect.succeed(Option.some({ ...thread, pendingInteractions: [row] })),
+      );
+      await Effect.runPromise(
+        reconcileRestartStuckTurns.pipe(
+          Effect.provideService(OrchestrationEngineService, {
+            getReadModel: () =>
+              Effect.succeed({ threads: [thread, makeThread("untouched", { activities: [] })] }),
+            dispatch,
+          } as never),
+          Effect.provideService(ProjectionSnapshotQuery, { getThreadDetailById } as never),
+          Effect.provideService(ProjectionPendingInteractionRepository, {
+            listUnsettled: () => Effect.succeed([row]),
+          } as never),
+        ),
+      );
+      expect(getThreadDetailById).toHaveBeenCalledExactlyOnceWith(thread.id);
+      expect(dispatch).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          type: "thread.activity.append",
+          activity: expect.objectContaining({
+            payload: expect.objectContaining({
+              requestId: row.requestId,
+              lifecycleGeneration: "lost-runtime",
+            }),
+          }),
+        }),
+      );
+    },
+  );
 });

--- a/apps/server/src/orchestration/startupTurnReconciliation.ts
+++ b/apps/server/src/orchestration/startupTurnReconciliation.ts
@@ -43,7 +43,8 @@ import {
   derivePendingThreadRequestIds,
   type PendingThreadRequestKind,
 } from "@synara/shared/threadSummary";
-import { Effect, Option } from "effect";
+import { Array as Arr, Effect, Option } from "effect";
+import { ProjectionPendingInteractionRepository } from "../persistence/Services/ProjectionPendingInteractions.ts";
 
 import {
   CHECKPOINT_REVERT_FAILED_ACTIVITY_KIND,
@@ -116,8 +117,8 @@ function planStalePendingRequestCommands(input: {
       // their callback has already been explicitly invalidated.
       if (
         interaction.status === "confirmed" ||
-        (interaction.status === "uncertain" &&
-          (interaction.interactionKind === "approval" || isAlreadyStale(interaction)))
+        isAlreadyStale(interaction) ||
+        (interaction.status === "uncertain" && interaction.interactionKind === "approval")
       ) {
         continue;
       }
@@ -316,20 +317,32 @@ export function planRestartTurnReconciliation(input: {
 export const reconcileRestartStuckTurns: Effect.Effect<
   void,
   never,
-  OrchestrationEngineService | ProjectionSnapshotQuery
+  OrchestrationEngineService | ProjectionSnapshotQuery | ProjectionPendingInteractionRepository
 > = Effect.gen(function* () {
   const engine = yield* OrchestrationEngineService;
   const snapshotQuery = yield* ProjectionSnapshotQuery;
 
   const readModel = yield* engine.getReadModel();
 
+  const pendingInteractions = yield* ProjectionPendingInteractionRepository;
+  const unsettled = yield* pendingInteractions
+    .listUnsettled({})
+    .pipe(
+      Effect.catchCause((cause) =>
+        Effect.logWarning("failed to read restart-orphaned callbacks", { cause }).pipe(
+          Effect.as([]),
+        ),
+      ),
+    );
+  const unsettledByThread = new Map(Object.entries(Arr.groupBy(unsettled, (row) => row.threadId)));
   const now = new Date().toISOString();
   const threadsNeedingRestartCleanup = readModel.threads.filter(
     (thread) =>
       needsRestartReconciliation(thread) ||
       threadHasCheckpointRevertInProgress(thread) ||
       thread.hasPendingApprovals ||
-      thread.hasPendingUserInput,
+      thread.hasPendingUserInput ||
+      unsettledByThread.has(thread.id),
   );
   if (threadsNeedingRestartCleanup.length === 0) {
     return;
@@ -337,16 +350,19 @@ export const reconcileRestartStuckTurns: Effect.Effect<
 
   const reconcilableThreads = yield* Effect.forEach(
     threadsNeedingRestartCleanup,
-    (thread) =>
-      snapshotQuery.getThreadDetailById(thread.id).pipe(
-        Effect.map((detail) => Option.getOrElse(detail, () => thread)),
+    (thread) => {
+      const pendingInteractions = unsettledByThread.get(thread.id);
+      const fallback = pendingInteractions ? { ...thread, pendingInteractions } : thread;
+      return snapshotQuery.getThreadDetailById(thread.id).pipe(
+        Effect.map((detail) => Option.getOrElse(detail, () => fallback)),
         Effect.catchCause((cause) =>
           Effect.logWarning("restart turn reconciliation continuing without thread activities", {
             threadId: thread.id,
             cause,
-          }).pipe(Effect.as(thread)),
+          }).pipe(Effect.as(fallback)),
         ),
-      ),
+      );
+    },
     { concurrency: 4 },
   );
 

--- a/apps/server/src/persistence/Layers/ProjectionPendingInteractions.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionPendingInteractions.test.ts
@@ -2,6 +2,8 @@ import { ApprovalRequestId, ThreadId } from "@synara/contracts";
 import { assert, it } from "@effect/vitest";
 import { Effect, Layer } from "effect";
 
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import { buildStalePendingRequestFailureDetail } from "@synara/shared/threadSummary";
 import { ProjectionPendingInteractionRepository } from "../Services/ProjectionPendingInteractions.ts";
 import { ProjectionPendingInteractionRepositoryLive } from "./ProjectionPendingInteractions.ts";
 import { SqlitePersistenceMemory } from "./Sqlite.ts";
@@ -131,6 +133,55 @@ layer("ProjectionPendingInteractionRepository", (it) => {
         assert.strictEqual(row.value.responseCommandId, "command-claim-a");
       }
     }),
+  );
+
+  it.effect(
+    "never reclaims an explicitly invalidated callback, but preserves replacements and other threads",
+    () =>
+      Effect.gen(function* () {
+        const repository = yield* ProjectionPendingInteractionRepository;
+        const sql = yield* SqlClient.SqlClient;
+        const threadId = ThreadId.makeUnsafe("expired-thread");
+        const requestId = ApprovalRequestId.makeUnsafe("expired-request");
+        const row = {
+          interactionKind: "userInput" as const,
+          threadId,
+          requestId,
+          turnId: null,
+          lifecycleGeneration: "old",
+          status: "uncertain" as const,
+          decision: null,
+          responseCommandId: null,
+          responseRequestedAt: null,
+          createdAt: "2026-09-10T10:00:00.000Z",
+          resolvedAt: null,
+        };
+        yield* repository.upsert(row);
+        const payload = JSON.stringify({
+          requestId,
+          lifecycleGeneration: "old",
+          detail: buildStalePendingRequestFailureDetail("user-input", requestId),
+        });
+        yield* sql`INSERT INTO projection_thread_activities (activity_id, thread_id, tone, kind, summary, payload_json, turn_id, created_at, sequence)
+        VALUES ('expired-activity', ${threadId}, 'error', 'provider.user-input.respond.failed', 'Expired', ${payload}, NULL, '2026-09-10T10:01:00.000Z', 1)`;
+        const claim = {
+          threadId,
+          requestId,
+          interactionKind: "userInput" as const,
+          lifecycleGeneration: "old",
+          responseCommandId: "retry-expired" as never,
+          decision: null,
+          requestedAt: "2026-09-10T10:02:00.000Z",
+        };
+        assert.isFalse(yield* repository.claimResponse(claim));
+        assert.deepEqual(yield* repository.listUnsettled({ threadId }), []);
+        yield* repository.upsert({ ...row, lifecycleGeneration: "new", status: "pending" });
+        assert.equal((yield* repository.listUnsettled({ threadId })).length, 1);
+        assert.isTrue(yield* repository.claimResponse({ ...claim, lifecycleGeneration: "new" }));
+        const otherThread = ThreadId.makeUnsafe("other-expired-thread");
+        yield* repository.upsert({ ...row, threadId: otherThread });
+        assert.isTrue(yield* repository.claimResponse({ ...claim, threadId: otherThread }));
+      }),
   );
 
   it.effect("re-claims an uncertain interaction so a later response can settle it", () =>

--- a/apps/server/src/persistence/Layers/ProjectionPendingInteractions.ts
+++ b/apps/server/src/persistence/Layers/ProjectionPendingInteractions.ts
@@ -1,7 +1,10 @@
-import { respondingInteractionReclaimCutoff } from "@synara/shared/pendingInteractions";
+import {
+  createStalePendingInteractionMatcher,
+  respondingInteractionReclaimCutoff,
+} from "@synara/shared/pendingInteractions";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import * as SqlSchema from "effect/unstable/sql/SqlSchema";
-import { Effect, Layer } from "effect";
+import { Array as Arr, Effect, Layer, Option, Schema } from "effect";
 
 import { toPersistenceSqlError } from "../Errors.ts";
 import {
@@ -61,6 +64,44 @@ const makeProjectionPendingInteractionRepository = Effect.gen(function* () {
       FROM projection_pending_interactions
       WHERE thread_id = ${threadId}
       ORDER BY created_at ASC, interaction_kind ASC, request_id ASC
+    `,
+  });
+
+  const listUnsettledRows = SqlSchema.findAll({
+    Request: Schema.Struct({ threadId: Schema.optionalKey(Schema.String) }),
+    Result: ProjectionPendingInteraction,
+    execute: ({ threadId }) => sql`
+      SELECT interaction_kind AS "interactionKind", request_id AS "requestId",
+        thread_id AS "threadId", turn_id AS "turnId", lifecycle_generation AS "lifecycleGeneration",
+        status, decision, response_command_id AS "responseCommandId",
+        response_requested_at AS "responseRequestedAt", created_at AS "createdAt", resolved_at AS "resolvedAt"
+      FROM projection_pending_interactions
+      WHERE status != 'confirmed'
+        AND NOT (interaction_kind = 'approval' AND status = 'uncertain')
+        AND ${threadId === undefined ? sql`1 = 1` : sql`thread_id = ${threadId}`}
+    `,
+  });
+
+  // Read only response failures for candidate callbacks, never whole transcripts.
+  const failureActivities = SqlSchema.findAll({
+    Request: Schema.Struct({ threadId: Schema.optionalKey(Schema.String) }),
+    Result: Schema.Struct({
+      threadId: Schema.String,
+      kind: Schema.String,
+      createdAt: Schema.String,
+      payload: Schema.fromJsonString(Schema.Json),
+    }),
+    execute: ({ threadId }) => sql`
+      SELECT activity.thread_id AS "threadId", activity.kind,
+        activity.created_at AS "createdAt", activity.payload_json AS payload
+      FROM projection_thread_activities AS activity
+      WHERE activity.kind IN ('provider.approval.respond.failed', 'provider.user-input.respond.failed')
+        AND ${threadId === undefined ? sql`1 = 1` : sql`activity.thread_id = ${threadId}`}
+        AND EXISTS (
+          SELECT 1 FROM projection_pending_interactions AS pending
+          WHERE pending.thread_id = activity.thread_id AND pending.status != 'confirmed'
+            AND pending.request_id = json_extract(activity.payload_json, '$.requestId')
+        )
     `,
   });
 
@@ -187,6 +228,26 @@ const makeProjectionPendingInteractionRepository = Effect.gen(function* () {
           toPersistenceSqlError("ProjectionPendingInteractionRepository.listByThreadId"),
         ),
       ),
+    listUnsettled: (input) =>
+      Effect.gen(function* () {
+        const rows = yield* listUnsettledRows(input);
+        if (rows.length === 0) return rows;
+        const activities = yield* failureActivities(input);
+        const byThread = new Map(
+          Object.entries(Arr.groupBy(activities, (activity) => activity.threadId)),
+        );
+        const matchers = new Map(
+          [...byThread].map(([threadId, failures]) => [
+            threadId,
+            createStalePendingInteractionMatcher(failures),
+          ]),
+        );
+        return rows.filter((row) => !matchers.get(row.threadId)?.(row));
+      }).pipe(
+        Effect.mapError(
+          toPersistenceSqlError("ProjectionPendingInteractionRepository.listUnsettled"),
+        ),
+      ),
     getPendingCountsByThreadId: (input) =>
       getPendingCounts(input).pipe(
         Effect.mapError(
@@ -202,8 +263,14 @@ const makeProjectionPendingInteractionRepository = Effect.gen(function* () {
         ),
       ),
     claimResponse: (input) =>
-      claimRow(input).pipe(
-        Effect.map((rows) => rows.length === 1),
+      Effect.gen(function* () {
+        const row = yield* getRow(input);
+        if (Option.isNone(row) || row.value.status === "confirmed") return false;
+        const failures = yield* failureActivities({ threadId: input.threadId });
+        if (createStalePendingInteractionMatcher(failures)(row.value)) return false;
+        return (yield* claimRow(input)).length === 1;
+      }).pipe(
+        sql.withTransaction,
         Effect.mapError(
           toPersistenceSqlError("ProjectionPendingInteractionRepository.claimResponse"),
         ),

--- a/apps/server/src/persistence/Services/ProjectionPendingInteractions.ts
+++ b/apps/server/src/persistence/Services/ProjectionPendingInteractions.ts
@@ -65,6 +65,10 @@ export interface ProjectionPendingInteractionRepositoryShape {
   readonly listByThreadId: (
     input: typeof ListProjectionPendingInteractionsInput.Type,
   ) => Effect.Effect<ReadonlyArray<ProjectionPendingInteraction>, ProjectionRepositoryError>;
+  /** Outstanding callbacks, excluding explicit invalidations; omitting threadId is for boot recovery. */
+  readonly listUnsettled: (input: {
+    readonly threadId?: ThreadId;
+  }) => Effect.Effect<ReadonlyArray<ProjectionPendingInteraction>, ProjectionRepositoryError>;
   readonly getPendingCountsByThreadId: (
     input: typeof ListProjectionPendingInteractionsInput.Type,
   ) => Effect.Effect<ProjectionPendingInteractionCounts, ProjectionRepositoryError>;

--- a/apps/server/src/provider/Errors.ts
+++ b/apps/server/src/provider/Errors.ts
@@ -95,6 +95,7 @@ export class ProviderValidationError extends Schema.TaggedErrorClass<ProviderVal
   {
     operation: Schema.String,
     issue: Schema.String,
+    reason: Schema.optional(Schema.Literals(["runtime-unavailable", "stale-interaction"])),
     cause: Schema.optional(Schema.Defect),
   },
 ) {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -10568,6 +10568,60 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
     );
   });
 
+  it.effect("denies an already aborted AskUserQuestion without publishing a prompt", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+      });
+      yield* Stream.take(adapter.streamEvents, 3).pipe(Stream.runDrain);
+      const canUseTool = harness.getLastCreateQueryInput()!.options.canUseTool!;
+      const questions = [
+        {
+          id: "Q",
+          header: "Q",
+          question: "Continue?",
+          options: [{ label: "Yes", description: "Proceed" }],
+        },
+      ];
+      const denied = yield* Effect.promise(() =>
+        canUseTool(
+          "AskUserQuestion",
+          { questions },
+          {
+            signal: AbortSignal.abort(),
+            toolUseID: "aborted-ask",
+            requestId: "aborted-ask",
+          },
+        ),
+      );
+      assert.equal(denied?.behavior, "deny");
+      const next = canUseTool(
+        "AskUserQuestion",
+        { questions },
+        {
+          signal: new AbortController().signal,
+          toolUseID: "live-ask",
+          requestId: "live-ask",
+        },
+      );
+      const event = yield* Stream.runHead(adapter.streamEvents);
+      assert.equal(event._tag, "Some");
+      if (event._tag !== "Some" || event.value.type !== "user-input.requested")
+        return assert.fail("Expected live question");
+      assert.equal(event.value.providerRefs?.providerItemId, "live-ask");
+      yield* adapter.respondToUserInput(
+        THREAD_ID,
+        ApprovalRequestId.makeUnsafe(event.value.requestId!),
+        { Q: "Yes" },
+      );
+      assert.equal((yield* Effect.promise(() => next))?.behavior, "allow");
+    }).pipe(Effect.provide(harness.layer));
+  });
+
   it.effect("denies AskUserQuestion when the waiting turn is aborted", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -4919,6 +4919,17 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           callbackOptions: Parameters<CanUseTool>[2],
         ) =>
           Effect.gen(function* () {
+            if (
+              callbackOptions.signal.aborted ||
+              context.stopped ||
+              (callbackOptions.agentID !== undefined &&
+                context.terminalTaskIds.has(callbackOptions.agentID))
+            ) {
+              return {
+                behavior: "deny",
+                message: "User cancelled tool execution.",
+              } satisfies PermissionResult;
+            }
             const requestId = ApprovalRequestId.makeUnsafe(yield* Random.nextUUIDv4);
             const interactionTurnId =
               context.turnState?.turnId ??
@@ -4955,8 +4966,11 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               settlementStarted: false,
             };
 
-            // Emit user-input.requested so the UI can present the questions.
+            // Stamp before registering ownership so terminal settlement cannot
+            // publish a resolution before its request while the clock yields.
             const requestedStamp = yield* makeEventStamp();
+            pendingUserInputs.set(requestId, pendingInput);
+            // Emit user-input.requested so the UI can present the questions.
             yield* offerRuntimeEvent(context, {
               type: "user-input.requested",
               eventId: requestedStamp.eventId,
@@ -4978,7 +4992,6 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               },
             });
 
-            pendingUserInputs.set(requestId, pendingInput);
             if (
               callbackOptions.agentID !== undefined &&
               context.terminalTaskIds.has(callbackOptions.agentID)
@@ -4999,6 +5012,8 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               );
             };
             callbackOptions.signal.addEventListener("abort", onAbort, { once: true });
+            // Abort may have happened during event publication, before registration.
+            if (callbackOptions.signal.aborted) onAbort();
 
             // Block until the user provides answers.
             const result = yield* Deferred.await(resultDeferred).pipe(

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -1289,6 +1289,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
         new ProviderValidationError({
           operation: "ProviderService.respondToRequest",
           issue: `Cannot respond to stale request 'request-from-old-generation' from provider generation '${String(firstGeneration)}'.`,
+          reason: "stale-interaction",
         }),
       );
       assert.equal(routing.codex.respondToRequest.mock.calls.length, responseCallCount);
@@ -1307,6 +1308,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
         new ProviderValidationError({
           operation: "ProviderService.respondToUserInput",
           issue: `Cannot respond to stale request 'user-input-from-old-generation' from provider generation '${String(firstGeneration)}'.`,
+          reason: "stale-interaction",
         }),
       );
       assert.equal(routing.codex.respondToUserInput.mock.calls.length, userInputResponseCallCount);
@@ -1961,6 +1963,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
         new ProviderValidationError({
           operation: "ProviderService.sendTurn",
           issue: `Cannot route thread '${session.threadId}' because no persisted provider binding exists.`,
+          reason: "runtime-unavailable",
         }),
       );
     }),
@@ -3158,6 +3161,43 @@ routing.layer("ProviderServiceLive routing", (it) => {
         assert.equal(startPayload.threadId, initial.threadId);
       }
       assert.equal(routing.claude.sendTurn.mock.calls.length, 1);
+    }),
+  );
+
+  it.effect("classifies a lost Claude question runtime without silently recovering it", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = asThreadId("lost-question-runtime");
+      yield* provider.startSession(threadId, {
+        provider: "claudeAgent",
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const binding = Option.getOrThrow(yield* directory.getBinding(threadId));
+      yield* routing.claude.stopAll();
+      const starts = routing.claude.startSession.mock.calls.length;
+      const responses = routing.claude.respondToUserInput.mock.calls.length;
+      const result = yield* Effect.result(
+        provider.respondToUserInput({
+          threadId,
+          requestId: asRequestId("lost-question"),
+          lifecycleGeneration: binding.lifecycleGeneration,
+          answers: { Q: "Answer" },
+        }),
+      );
+      assertFailure(
+        result,
+        new ProviderValidationError({
+          operation: "ProviderService.respondToUserInput",
+          issue:
+            "Cannot respond to request 'lost-question' because the provider runtime is not active.",
+          reason: "runtime-unavailable",
+        }),
+      );
+      assert.equal(routing.claude.startSession.mock.calls.length, starts);
+      assert.equal(routing.claude.respondToUserInput.mock.calls.length, responses);
+      yield* provider.stopSession({ threadId });
     }),
   );
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -1676,10 +1676,11 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               lifecycleGeneration: lifecycle.currentGeneration(input.threadId),
             } as const;
           }
-          return yield* toValidationError(
-            input.operation,
-            `Cannot route thread '${input.threadId}' because no persisted provider binding exists.`,
-          );
+          return yield* new ProviderValidationError({
+            operation: input.operation,
+            issue: `Cannot route thread '${input.threadId}' because no persisted provider binding exists.`,
+            reason: "runtime-unavailable",
+          });
         }
         const adapter = yield* registry.getByProvider(binding.provider);
         if (input.allowRecovery) {
@@ -2573,10 +2574,11 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             allowRecovery: false,
           });
           if (!routed.isActive) {
-            return yield* toValidationError(
+            return yield* new ProviderValidationError({
               operation,
-              `Cannot respond to request '${input.requestId}' because the provider runtime is not active.`,
-            );
+              issue: `Cannot respond to request '${input.requestId}' because the provider runtime is not active.`,
+              reason: "runtime-unavailable",
+            });
           }
           const routedGeneration = routed.lifecycleGeneration ?? currentGeneration;
           if (
@@ -2593,10 +2595,11 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             input.lifecycleGeneration !== undefined &&
             input.lifecycleGeneration !== routedGeneration
           ) {
-            return yield* toValidationError(
+            return yield* new ProviderValidationError({
               operation,
-              `Cannot respond to stale request '${input.requestId}' from provider generation '${input.lifecycleGeneration}'.`,
-            );
+              issue: `Cannot respond to stale request '${input.requestId}' from provider generation '${input.lifecycleGeneration}'.`,
+              reason: "stale-interaction",
+            });
           }
           if (response.kind === "approval") {
             yield* routed.adapter.respondToRequest(

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -1,3 +1,7 @@
+import {
+  buildStalePendingRequestFailureDetail,
+  pendingRequestInstanceKey,
+} from "@synara/shared/threadSummary";
 // Production CSS is part of the behavior under test because row height depends on it.
 import "../index.css";
 
@@ -2275,6 +2279,155 @@ describe("ChatView transcript geometry (full app)", () => {
       await mounted.cleanup();
     }
   });
+
+  it.each(["manual", "auto-advance", "custom"] as const)(
+    "preserves three answers (%s) on transient failure and restores expired questions without sending a message",
+    async (navigation) => {
+      const requestId = ApprovalRequestId.makeUnsafe("question-recovery");
+      const generation = "question-generation";
+      const requestKey = pendingRequestInstanceKey(requestId, generation);
+      const questions = [1, 2, 3].map((id) => ({
+        id: String(id),
+        header: `Question ${id}`,
+        question: `Choose option ${id}?`,
+        ...(navigation !== "auto-advance" ? { multiSelect: true } : {}),
+        options: [{ label: `Choice ${id}`, description: "Selected answer" }],
+      }));
+      const snapshot = createSnapshotForTargetUser({
+        targetMessageId: MessageId.makeUnsafe("msg-question-recovery"),
+        targetText: "Discuss the design",
+      });
+      const thread = snapshot.threads[0]!;
+      const request = { requestId, lifecycleGeneration: generation, createdAt: NOW_ISO, questions };
+      const pendingThread = {
+        ...thread,
+        activities: [
+          {
+            id: EventId.makeUnsafe("question-request"),
+            createdAt: NOW_ISO,
+            kind: "user-input.requested",
+            summary: "Questions",
+            tone: "info" as const,
+            turnId: null,
+            sequence: 900,
+            payload: { requestId, lifecycleGeneration: generation, questions },
+          },
+        ],
+        pendingInteractions: [
+          {
+            interactionKind: "userInput" as const,
+            requestId,
+            threadId: thread.id,
+            turnId: null,
+            lifecycleGeneration: generation,
+            status: "pending" as const,
+            decision: null,
+            responseCommandId: null,
+            responseRequestedAt: null,
+            createdAt: NOW_ISO,
+            resolvedAt: null,
+          },
+        ],
+      };
+      useComposerDraftStore.getState().setPrompt(THREAD_ID, "Keep this existing draft.");
+      const mounted = await mountChatView({
+        viewport: DEFAULT_VIEWPORT,
+        snapshot: { ...snapshot, threads: [pendingThread] },
+      });
+      const previousNativeApi = window.nativeApi;
+      const api = readNativeApi()!;
+      let expire = false;
+      const dispatchCommand = vi.fn(async () => {
+        if (!expire) throw new Error("Temporary connection failure");
+        fixture.snapshot = {
+          ...fixture.snapshot,
+          snapshotSequence: fixture.snapshot.snapshotSequence + 1,
+          threads: [
+            {
+              ...pendingThread,
+              pendingInteractions: pendingThread.pendingInteractions.map((row) => ({
+                ...row,
+                status: "uncertain" as const,
+              })),
+              activities: [
+                ...pendingThread.activities,
+                {
+                  id: EventId.makeUnsafe("question-expired"),
+                  createdAt: NOW_ISO,
+                  kind: "provider.user-input.respond.failed",
+                  summary: "Expired",
+                  tone: "error" as const,
+                  turnId: null,
+                  sequence: 2,
+                  payload: {
+                    requestId,
+                    lifecycleGeneration: generation,
+                    detail: buildStalePendingRequestFailureDetail("user-input", requestId),
+                  },
+                },
+              ],
+            },
+          ],
+        };
+      });
+      Object.defineProperty(window, "nativeApi", {
+        configurable: true,
+        value: { ...api, orchestration: { ...api.orchestration, dispatchCommand } },
+      });
+      try {
+        for (const id of [1, 2, 3]) {
+          await page.getByRole("button", { name: new RegExp(`Choice ${id}`) }).click();
+          if (id < 3)
+            await page.getByRole("button", { name: "Next question", exact: true }).first().click();
+        }
+        if (navigation === "custom") {
+          await userEvent.click(await waitForComposerEditor());
+          await userEvent.keyboard("Custom answer");
+        }
+        const submit = page.getByRole("button", { name: "Submit answers", exact: true });
+        await expect.element(submit).toBeEnabled();
+        const button = submit.element() as HTMLButtonElement;
+        button.click();
+        button.click();
+        await vi.waitFor(() => expect(dispatchCommand).toHaveBeenCalledTimes(1));
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        expect(dispatchCommand).toHaveBeenCalledTimes(1);
+        await expect.element(submit).toBeEnabled();
+        expect(
+          useComposerDraftStore.getState().draftsByThreadId[THREAD_ID]?.pendingUserInputDrafts?.[
+            requestKey
+          ],
+        ).toEqual({
+          request,
+          answers: Object.fromEntries(
+            [1, 2, 3].map((id) => [
+              String(id),
+              navigation === "custom" && id === 3
+                ? { customAnswer: "Custom answer" }
+                : { customAnswer: "", selectedOptionLabels: [`Choice ${id}`] },
+            ]),
+          ),
+        });
+        expire = true;
+        await submit.click();
+        await expect.element(page.getByRole("button", { name: "Restore answers" })).toBeVisible();
+        await expect.element(submit).not.toBeInTheDocument();
+        await page.getByRole("button", { name: "Restore answers" }).click();
+        expect(useComposerDraftStore.getState().draftsByThreadId[THREAD_ID]?.prompt).toBe(
+          `Keep this existing draft.\n\nChoose option 1?\nChoice 1\n\nChoose option 2?\nChoice 2\n\nChoose option 3?\n${navigation === "custom" ? "Custom answer" : "Choice 3"}`,
+        );
+        expect(dispatchCommand).toHaveBeenCalledTimes(2);
+      } finally {
+        if (previousNativeApi)
+          Object.defineProperty(window, "nativeApi", {
+            configurable: true,
+            value: previousNativeApi,
+          });
+        else Reflect.deleteProperty(window, "nativeApi");
+        await mounted.cleanup();
+      }
+    },
+  );
 
   it("keeps near-cap composer work bounded while live activities arrive", async () => {
     const percentile = (samples: readonly number[], fraction: number): number => {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1,3 +1,6 @@
+import { ComposerExpiredUserInputNotice } from "./chat/ComposerExpiredUserInputNotice";
+import { usePendingUserInputDrafts } from "./chat/usePendingUserInputDrafts";
+import { expiredUserInputDrafts } from "../pendingUserInputRecovery";
 import {
   type AutomationDefinition,
   type AutomationSchedule,
@@ -1527,10 +1530,6 @@ export default function ChatView({
   const [respondingUserInputRequestKeys, setRespondingUserInputRequestKeys] = useState<string[]>(
     [],
   );
-  const [pendingUserInputAnswersByRequestId, setPendingUserInputAnswersByRequestId] = useState<
-    Record<string, Record<string, PendingUserInputDraftAnswer>>
-  >({});
-  const pendingUserInputAnswersByRequestIdRef = useRef(pendingUserInputAnswersByRequestId);
   const [pendingUserInputQuestionIndexByRequestId, setPendingUserInputQuestionIndexByRequestId] =
     useState<Record<string, number>>({});
   const [planSidebarOpen, setPlanSidebarOpen] = useState(false);
@@ -2881,6 +2880,16 @@ export default function ChatView({
       threadActivities,
       userInputResponseClaimReferenceAt,
     ],
+  );
+  const {
+    answers: pendingUserInputAnswersByRequestId,
+    answersRef: pendingUserInputAnswersByRequestIdRef,
+    setAnswers: setPendingUserInputAnswersByRequestId,
+    drafts: pendingUserInputDrafts,
+  } = usePendingUserInputDrafts(threadId, pendingUserInputs, activeThread?.pendingInteractions);
+  const expiredQuestionDrafts = useMemo(
+    () => expiredUserInputDrafts(pendingUserInputDrafts, threadActivities),
+    [pendingUserInputDrafts, threadActivities],
   );
   const activePendingUserInput = pendingUserInputs[0] ?? null;
   const activePendingUserInputKey = activePendingUserInput
@@ -9223,6 +9232,8 @@ export default function ChatView({
     [activeThreadId, runtimeMode, setComposerDraftRuntimeMode, setStoreThreadError],
   );
 
+  const userInputSubmissionsRef = useRef(new Set<string>());
+  const [userInputSubmissionVersion, setUserInputSubmissionVersion] = useState(0);
   const onRespondToUserInput = useCallback(
     async (
       requestId: ApprovalRequestId,
@@ -9232,6 +9243,10 @@ export default function ChatView({
       const api = readNativeApi();
       if (!api || !activeThreadId) return;
       const requestKey = pendingRequestInstanceKey(requestId, lifecycleGeneration);
+      const submissionKey = `${activeThreadId}:${requestKey}`;
+      if (userInputSubmissionsRef.current.has(submissionKey)) return;
+      userInputSubmissionsRef.current.add(submissionKey);
+      setUserInputSubmissionVersion((version) => version + 1);
       const dispatchAnswers = hasCompletePendingUserInputAnswers(answers)
         ? answers
         : omitNullPendingUserInputAnswers(answers);
@@ -9239,8 +9254,8 @@ export default function ChatView({
       setRespondingUserInputRequestKeys((existing) =>
         existing.includes(requestKey) ? existing : [...existing, requestKey],
       );
-      await api.orchestration
-        .dispatchCommand({
+      try {
+        await api.orchestration.dispatchCommand({
           type: "thread.user-input.respond",
           commandId: newCommandId(),
           threadId: activeThreadId,
@@ -9248,14 +9263,25 @@ export default function ChatView({
           answers: dispatchAnswers,
           ...(lifecycleGeneration !== undefined ? { lifecycleGeneration } : {}),
           createdAt: new Date().toISOString(),
-        })
-        .catch((err: unknown) => {
-          setStoreThreadError(
-            activeThreadId,
-            err instanceof Error ? err.message : "Failed to submit user input.",
-          );
         });
-      setRespondingUserInputRequestKeys((existing) => existing.filter((key) => key !== requestKey));
+        // Refresh identities and settlement after command acceptance; acceptance
+        // alone does not mean Claude received the answer.
+        clearThreadDetailResumeCursor(activeThreadId);
+        await api.orchestration.subscribeThread(buildThreadSubscribeInput(activeThreadId));
+      } catch (err) {
+        setStoreThreadError(
+          activeThreadId,
+          describeErrorMessage(
+            err,
+            "Could not submit or refresh the answer. Your answers are saved.",
+          ),
+        );
+      } finally {
+        userInputSubmissionsRef.current.delete(submissionKey);
+        setRespondingUserInputRequestKeys((existing) =>
+          existing.filter((key) => key !== requestKey),
+        );
+      }
     },
     [activeThreadId, setStoreThreadError],
   );
@@ -9319,7 +9345,12 @@ export default function ChatView({
       setComposerTrigger(null);
       return nextDraftAnswer;
     },
-    [activePendingUserInput, activePendingUserInputKey],
+    [
+      activePendingUserInput,
+      activePendingUserInputKey,
+      pendingUserInputAnswersByRequestIdRef,
+      setPendingUserInputAnswersByRequestId,
+    ],
   );
 
   const onChangeActivePendingUserInputCustomAnswer = useCallback(
@@ -9355,7 +9386,11 @@ export default function ChatView({
         cursorAdjacentToMention ? null : detectComposerTrigger(value, expandedCursor),
       );
     },
-    [activePendingUserInputKey],
+    [
+      activePendingUserInputKey,
+      pendingUserInputAnswersByRequestIdRef,
+      setPendingUserInputAnswersByRequestId,
+    ],
   );
 
   const onAdvanceActivePendingUserInput = useCallback(
@@ -9413,6 +9448,8 @@ export default function ChatView({
       activePendingUserInputKey,
       onRespondToUserInput,
       setActivePendingUserInputQuestionIndex,
+      setPendingUserInputAnswersByRequestId,
+      pendingUserInputAnswersByRequestIdRef,
     ],
   );
 
@@ -10593,7 +10630,13 @@ export default function ChatView({
       });
       return nextCursor;
     },
-    [activePendingProgress?.activeQuestion, activePendingUserInputKey, setPrompt],
+    [
+      activePendingProgress?.activeQuestion,
+      activePendingUserInputKey,
+      setPrompt,
+      setPendingUserInputAnswersByRequestId,
+      pendingUserInputAnswersByRequestIdRef,
+    ],
   );
 
   const readComposerSnapshot = useCallback((): {
@@ -11969,6 +12012,7 @@ export default function ChatView({
                 <div className="pb-2">
                   <ComposerPendingUserInputPanel
                     pendingUserInputs={pendingUserInputs}
+                    submissionVersion={userInputSubmissionVersion}
                     isResponding={activePendingIsResponding}
                     answers={activePendingDraftAnswers}
                     questionIndex={activePendingQuestionIndex}
@@ -11978,6 +12022,22 @@ export default function ChatView({
                     onCancel={onCancelActivePendingUserInput}
                   />
                 </div>
+              ) : null}
+              {expiredQuestionDrafts[0] &&
+              pendingUserInputs.length === 0 &&
+              !activePendingApproval ? (
+                <ComposerExpiredUserInputNotice
+                  threadId={threadId}
+                  requestKey={expiredQuestionDrafts[0][0]}
+                  draft={expiredQuestionDrafts[0][1]}
+                  onRestore={(nextPrompt) => {
+                    promptRef.current = nextPrompt;
+                    setComposerCursor(
+                      collapseExpandedComposerCursor(nextPrompt, nextPrompt.length),
+                    );
+                    scheduleComposerFocus();
+                  }}
+                />
               ) : null}
               {emptyLandingControls}
             </div>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -9254,34 +9254,37 @@ export default function ChatView({
       setRespondingUserInputRequestKeys((existing) =>
         existing.includes(requestKey) ? existing : [...existing, requestKey],
       );
-      try {
-        await api.orchestration.dispatchCommand({
-          type: "thread.user-input.respond",
-          commandId: newCommandId(),
-          threadId: activeThreadId,
-          requestId,
-          answers: dispatchAnswers,
-          ...(lifecycleGeneration !== undefined ? { lifecycleGeneration } : {}),
-          createdAt: new Date().toISOString(),
+      await Promise.resolve()
+        .then(async () => {
+          await api.orchestration.dispatchCommand({
+            type: "thread.user-input.respond",
+            commandId: newCommandId(),
+            threadId: activeThreadId,
+            requestId,
+            answers: dispatchAnswers,
+            ...(lifecycleGeneration !== undefined ? { lifecycleGeneration } : {}),
+            createdAt: new Date().toISOString(),
+          });
+          // Refresh identities and settlement after command acceptance; acceptance
+          // alone does not mean Claude received the answer.
+          clearThreadDetailResumeCursor(activeThreadId);
+          await api.orchestration.subscribeThread(buildThreadSubscribeInput(activeThreadId));
+        })
+        .catch((err: unknown) => {
+          setStoreThreadError(
+            activeThreadId,
+            describeErrorMessage(
+              err,
+              "Could not submit or refresh the answer. Your answers are saved.",
+            ),
+          );
+        })
+        .finally(() => {
+          userInputSubmissionsRef.current.delete(submissionKey);
+          setRespondingUserInputRequestKeys((existing) =>
+            existing.filter((key) => key !== requestKey),
+          );
         });
-        // Refresh identities and settlement after command acceptance; acceptance
-        // alone does not mean Claude received the answer.
-        clearThreadDetailResumeCursor(activeThreadId);
-        await api.orchestration.subscribeThread(buildThreadSubscribeInput(activeThreadId));
-      } catch (err) {
-        setStoreThreadError(
-          activeThreadId,
-          describeErrorMessage(
-            err,
-            "Could not submit or refresh the answer. Your answers are saved.",
-          ),
-        );
-      } finally {
-        userInputSubmissionsRef.current.delete(submissionKey);
-        setRespondingUserInputRequestKeys((existing) =>
-          existing.filter((key) => key !== requestKey),
-        );
-      }
     },
     [activeThreadId, setStoreThreadError],
   );

--- a/apps/web/src/components/chat/ComposerExpiredUserInputNotice.tsx
+++ b/apps/web/src/components/chat/ComposerExpiredUserInputNotice.tsx
@@ -1,0 +1,49 @@
+import type { ThreadId } from "@synara/contracts";
+import { useComposerDraftStore } from "../../composerDraftStore";
+import {
+  restoreUserInputDraft,
+  type PendingUserInputRecoveryDraft,
+} from "../../pendingUserInputRecovery";
+
+export function ComposerExpiredUserInputNotice({
+  threadId,
+  requestKey,
+  draft,
+  onRestore,
+}: {
+  threadId: ThreadId;
+  requestKey: string;
+  draft: PendingUserInputRecoveryDraft;
+  onRestore: (prompt: string) => void;
+}) {
+  const dismiss = () => {
+    const store = useComposerDraftStore.getState();
+    const drafts = store.draftsByThreadId[threadId]?.pendingUserInputDrafts ?? {};
+    store.setPendingUserInputDrafts(
+      threadId,
+      Object.fromEntries(Object.entries(drafts).filter(([key]) => key !== requestKey)),
+    );
+  };
+  const restore = () => {
+    const store = useComposerDraftStore.getState();
+    store.restorePromptHistorySavedDraft(threadId);
+    const current = useComposerDraftStore.getState().draftsByThreadId[threadId];
+    const prompt = restoreUserInputDraft(current?.prompt ?? "", draft);
+    store.setPrompt(threadId, prompt);
+    dismiss();
+    onRestore(prompt);
+  };
+  return (
+    <div className="mb-2 rounded-xl border border-border px-4 py-3 text-sm" role="status">
+      <p>These questions have expired. Restore your answers to review and send as a new message.</p>
+      <div className="mt-2 flex gap-3">
+        <button type="button" className="font-medium underline" onClick={restore}>
+          Restore answers
+        </button>
+        <button type="button" className="text-muted-foreground" onClick={dismiss}>
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -16,6 +16,7 @@ import { COMPOSER_INPUT_SURFACE_CLASS_NAME } from "./composerPickerStyles";
 
 interface PendingUserInputPanelProps {
   pendingUserInputs: PendingUserInput[];
+  submissionVersion: number;
   isResponding: boolean;
   answers: Record<string, PendingUserInputDraftAnswer>;
   questionIndex: number;
@@ -31,6 +32,7 @@ const NAV_BUTTON_CLASS_NAME =
 // Keep pending-input choices neutral so they read like Codex list controls instead of accent buttons.
 export function ComposerPendingUserInputPanel({
   pendingUserInputs,
+  submissionVersion,
   isResponding,
   answers,
   questionIndex,
@@ -47,6 +49,7 @@ export function ComposerPendingUserInputPanel({
     <ComposerPendingUserInputCard
       key={`${activePrompt.requestId}:${activePrompt.lifecycleGeneration ?? "legacy"}`}
       prompt={activePrompt}
+      submissionVersion={submissionVersion}
       isResponding={isResponding}
       answers={answers}
       questionIndex={questionIndex}
@@ -60,6 +63,7 @@ export function ComposerPendingUserInputPanel({
 
 function ComposerPendingUserInputCard({
   prompt,
+  submissionVersion,
   isResponding,
   answers,
   questionIndex,
@@ -69,6 +73,7 @@ function ComposerPendingUserInputCard({
   onCancel,
 }: {
   prompt: PendingUserInput;
+  submissionVersion: number;
   isResponding: boolean;
   answers: Record<string, PendingUserInputDraftAnswer>;
   questionIndex: number;
@@ -87,8 +92,8 @@ function ComposerPendingUserInputCard({
   }, [onAdvance]);
 
   // Cancel a pending auto-advance on unmount, and whenever the active question
-  // changes or a response goes in flight — otherwise a manual Next/Submit landing
-  // inside the 200ms window leaves a stale timer that advances or submits again.
+  // changes or a response is attempted. The version also catches immediate
+  // failures whose true/false loading state React batches into a single render.
   useEffect(() => {
     return () => {
       if (autoAdvanceTimerRef.current !== null) {
@@ -96,7 +101,7 @@ function ComposerPendingUserInputCard({
         autoAdvanceTimerRef.current = null;
       }
     };
-  }, [activeQuestion?.id, isResponding]);
+  }, [activeQuestion?.id, isResponding, submissionVersion]);
 
   const handleOptionSelection = (questionId: string, optionLabel: string) => {
     const nextDraftAnswer = onToggleOption(questionId, optionLabel);

--- a/apps/web/src/components/chat/usePendingUserInputDrafts.ts
+++ b/apps/web/src/components/chat/usePendingUserInputDrafts.ts
@@ -1,0 +1,71 @@
+import type { OrchestrationPendingInteraction, ThreadId } from "@synara/contracts";
+import { pendingRequestInstanceKey } from "@synara/shared/threadSummary";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
+import { useComposerDraftStore, useComposerThreadDraft } from "../../composerDraftStore";
+import type { PendingUserInput } from "../../pendingInteractionDerivation";
+import type { PendingUserInputDraftAnswer } from "../../pendingUserInput";
+import type { PendingUserInputRecoveryDraft } from "../../pendingUserInputRecovery";
+
+type Answers = Record<string, Record<string, PendingUserInputDraftAnswer>>;
+const EMPTY_DRAFTS: Record<string, PendingUserInputRecoveryDraft> = {};
+
+function draftAnswers(drafts: Record<string, PendingUserInputRecoveryDraft>): Answers {
+  return Object.fromEntries(Object.entries(drafts).map(([key, draft]) => [key, draft.answers]));
+}
+
+export function usePendingUserInputDrafts(
+  threadId: ThreadId,
+  requests: ReadonlyArray<PendingUserInput>,
+  interactions: ReadonlyArray<OrchestrationPendingInteraction> | undefined,
+) {
+  const drafts = useComposerThreadDraft(threadId).pendingUserInputDrafts ?? EMPTY_DRAFTS;
+  const answers = useMemo(() => draftAnswers(drafts), [drafts]);
+  const answersRef = useRef<Answers>(answers);
+  const requestsRef = useRef(requests);
+  useLayoutEffect(() => {
+    answersRef.current = answers;
+    requestsRef.current = requests;
+  }, [answers, requests, threadId]);
+
+  const setAnswers = useCallback(
+    (update: (existing: Answers) => Answers) => {
+      const store = useComposerDraftStore.getState();
+      const existing = store.draftsByThreadId[threadId]?.pendingUserInputDrafts ?? EMPTY_DRAFTS;
+      const nextAnswers = update(draftAnswers(existing));
+      const nextDrafts = { ...existing };
+      for (const [key, requestAnswers] of Object.entries(nextAnswers)) {
+        const request =
+          existing[key]?.request ??
+          requestsRef.current.find(
+            (entry) =>
+              pendingRequestInstanceKey(entry.requestId, entry.lifecycleGeneration) === key,
+          );
+        if (request) nextDrafts[key] = { request, answers: requestAnswers };
+      }
+      answersRef.current = nextAnswers;
+      store.setPendingUserInputDrafts(threadId, nextDrafts);
+    },
+    [threadId],
+  );
+
+  // Command acceptance is not delivery. Keep the answer through transient
+  // failures and only discard it after authoritative settlement.
+  useEffect(() => {
+    const confirmed = new Set(
+      (interactions ?? [])
+        .filter((row) => row.interactionKind === "userInput" && row.status === "confirmed")
+        .map((row) =>
+          pendingRequestInstanceKey(row.requestId, row.lifecycleGeneration ?? undefined),
+        ),
+    );
+    if (!Object.keys(drafts).some((key) => confirmed.has(key))) return;
+    useComposerDraftStore
+      .getState()
+      .setPendingUserInputDrafts(
+        threadId,
+        Object.fromEntries(Object.entries(drafts).filter(([key]) => !confirmed.has(key))),
+      );
+  }, [drafts, interactions, threadId]);
+
+  return { answers, answersRef, setAnswers, drafts };
+}

--- a/apps/web/src/composerDraftActions.ts
+++ b/apps/web/src/composerDraftActions.ts
@@ -558,6 +558,18 @@ export const createComposerDraftStoreState =
         return { draftsByThreadId: nextDraftsByThreadId };
       });
     },
+    setPendingUserInputDrafts: (threadId, drafts) => {
+      set((state) => {
+        const nextDraft = {
+          ...(state.draftsByThreadId[threadId] ?? createEmptyThreadDraft()),
+          pendingUserInputDrafts: drafts,
+        };
+        const draftsByThreadId = { ...state.draftsByThreadId };
+        if (shouldRemoveDraft(nextDraft)) delete draftsByThreadId[threadId];
+        else draftsByThreadId[threadId] = nextDraft;
+        return { draftsByThreadId };
+      });
+    },
     setPrompt: (threadId, prompt) => {
       if (threadId.length === 0) {
         return;

--- a/apps/web/src/composerDraftDomain.ts
+++ b/apps/web/src/composerDraftDomain.ts
@@ -1,3 +1,4 @@
+import type { PendingUserInputRecoveryDraft } from "./pendingUserInputRecovery";
 // FILE: composerDraftDomain.ts
 // Purpose: Defines composer draft state, stable defaults, and content/project normalization.
 // Exports: Internal domain primitives plus public facade types.
@@ -167,6 +168,7 @@ export interface QueuedComposerPlanFollowUp {
 export type QueuedComposerTurn = QueuedComposerChatTurn | QueuedComposerPlanFollowUp;
 
 export interface ComposerThreadDraftState {
+  pendingUserInputDrafts?: Record<string, PendingUserInputRecoveryDraft>;
   prompt: string;
   // Non-null only while composer prompt-history browsing is active: the user's
   // real draft, kept safe while `prompt` temporarily holds a recalled history
@@ -236,6 +238,10 @@ interface ProjectDraftThread extends DraftThreadState {
 }
 
 export interface ComposerDraftStoreState {
+  setPendingUserInputDrafts: (
+    threadId: ThreadId,
+    drafts: Record<string, PendingUserInputRecoveryDraft>,
+  ) => void;
   draftsByThreadId: Record<ThreadId, ComposerThreadDraftState>;
   draftThreadsByThreadId: Record<ThreadId, DraftThreadState>;
   projectDraftThreadIdByProjectId: Record<string, ThreadId>;
@@ -828,6 +834,7 @@ function clonePromptHistorySavedDraft(
 
 export function shouldRemoveDraft(draft: ComposerThreadDraftState): boolean {
   return (
+    Object.keys(draft.pendingUserInputDrafts ?? {}).length === 0 &&
     draft.prompt.length === 0 &&
     draft.promptHistorySavedDraft === null &&
     draft.images.length === 0 &&

--- a/apps/web/src/composerDraftPersistence.ts
+++ b/apps/web/src/composerDraftPersistence.ts
@@ -1,3 +1,4 @@
+import { normalizePendingUserInputDrafts } from "./pendingUserInputRecovery";
 // FILE: composerDraftPersistence.ts
 // Purpose: Owns composer draft schema v6, migrations, partialization, merge normalization, and hydration.
 // Exports: Persist middleware transitions and persisted state type.
@@ -262,6 +263,7 @@ type PersistedComposerPromptHistorySavedDraft =
   typeof PersistedComposerPromptHistorySavedDraft.Type;
 
 const PersistedComposerThreadDraftState = Schema.Struct({
+  pendingUserInputDrafts: Schema.optionalKey(Schema.Record(Schema.String, Schema.Unknown)),
   prompt: Schema.String,
   // Set only while composer prompt-history browsing is active: the user's real
   // draft snapshot, kept safe while `prompt` temporarily holds a recalled history entry.
@@ -932,6 +934,9 @@ function normalizePersistedDraftsByThreadId(
       continue;
     }
     const draftCandidate = draftValue as PersistedComposerThreadDraftState;
+    const pendingUserInputDrafts = normalizePendingUserInputDrafts(
+      draftCandidate.pendingUserInputDrafts,
+    );
     const promptCandidate = typeof draftCandidate.prompt === "string" ? draftCandidate.prompt : "";
     const promptHistorySavedDraft = normalizePersistedPromptHistorySavedDraft(
       draftCandidate.promptHistorySavedDraft,
@@ -1049,6 +1054,7 @@ function normalizePersistedDraftsByThreadId(
     const hasQueuedTurns = normalizedQueuedTurns.length > 0;
     const hasReferenceData = skills.length > 0 || mentions.length > 0;
     if (
+      Object.keys(pendingUserInputDrafts).length === 0 &&
       promptCandidate.length === 0 &&
       promptHistorySavedDraft === null &&
       attachments.length === 0 &&
@@ -1068,6 +1074,7 @@ function normalizePersistedDraftsByThreadId(
       continue;
     }
     nextDraftsByThreadId[threadId as ThreadId] = {
+      ...(Object.keys(pendingUserInputDrafts).length > 0 ? { pendingUserInputDrafts } : {}),
       prompt,
       ...(promptHistorySavedDraft !== null ? { promptHistorySavedDraft } : {}),
       attachments,
@@ -1216,6 +1223,7 @@ export function partializeComposerDraftStoreState(
     const hasQueuedTurns = persistedQueuedTurns.length > 0;
     const hasReferenceData = draft.skills.length > 0 || draft.mentions.length > 0;
     if (
+      Object.keys(draft.pendingUserInputDrafts ?? {}).length === 0 &&
       draft.prompt.length === 0 &&
       draft.promptHistorySavedDraft === null &&
       draft.persistedAttachments.length === 0 &&
@@ -1235,6 +1243,9 @@ export function partializeComposerDraftStoreState(
       continue;
     }
     const persistedDraft: DeepMutable<PersistedComposerThreadDraftState> = {
+      ...(Object.keys(draft.pendingUserInputDrafts ?? {}).length > 0
+        ? { pendingUserInputDrafts: draft.pendingUserInputDrafts }
+        : {}),
       prompt: draft.prompt,
       ...(draft.promptHistorySavedDraft !== null
         ? {
@@ -1532,6 +1543,13 @@ export function toHydratedThreadDraft(
   const activeProvider = normalizeProviderKind(persistedDraft.activeProvider) ?? null;
 
   return {
+    ...(persistedDraft.pendingUserInputDrafts
+      ? {
+          pendingUserInputDrafts: normalizePendingUserInputDrafts(
+            persistedDraft.pendingUserInputDrafts,
+          ),
+        }
+      : {}),
     prompt: persistedDraft.prompt,
     promptHistorySavedDraft: hydratePromptHistorySavedDraft(persistedDraft.promptHistorySavedDraft),
     images: hydrateImagesFromPersisted(persistedDraft.attachments),

--- a/apps/web/src/pendingUserInputRecovery.test.ts
+++ b/apps/web/src/pendingUserInputRecovery.test.ts
@@ -1,0 +1,95 @@
+import { ApprovalRequestId, EventId, ThreadId } from "@synara/contracts";
+import {
+  buildStalePendingRequestFailureDetail,
+  pendingRequestInstanceKey,
+} from "@synara/shared/threadSummary";
+import { afterEach, expect, it } from "vitest";
+import {
+  expiredUserInputDrafts,
+  restoreUserInputDraft,
+  type PendingUserInputRecoveryDraft,
+} from "./pendingUserInputRecovery";
+import { partializeComposerDraftStoreState, useComposerDraftStore } from "./composerDraftStore";
+import {
+  normalizeCurrentPersistedComposerDraftStoreState,
+  toHydratedThreadDraft,
+} from "./composerDraftPersistence";
+
+const requestId = ApprovalRequestId.makeUnsafe("saved-question");
+const key = pendingRequestInstanceKey(requestId, "generation-a");
+const draft: PendingUserInputRecoveryDraft = {
+  request: {
+    requestId,
+    lifecycleGeneration: "generation-a",
+    createdAt: "2026-09-10T10:00:00.000Z",
+    questions: [
+      {
+        id: "1",
+        header: "Color",
+        question: "Which color?",
+        options: [{ label: "Blue", description: "Brand" }],
+      },
+      { id: "2", header: "Features", question: "Which features?", options: [], multiSelect: true },
+      { id: "3", header: "Notes", question: "Anything else?", options: [] },
+    ],
+  },
+  answers: {
+    "1": { selectedOptionLabels: ["Blue"] },
+    "2": { selectedOptionLabels: ["Search", "Tabs"] },
+    "3": { customAnswer: "Keep it simple" },
+  },
+};
+afterEach(() => useComposerDraftStore.setState({ draftsByThreadId: {} }));
+
+it("preserves structured answers without a normal prompt through persistence and reload", () => {
+  const threadId = ThreadId.makeUnsafe("saved-thread");
+  const store = useComposerDraftStore.getState();
+  store.setPendingUserInputDrafts(threadId, { [key]: draft });
+  store.setPrompt(threadId, "");
+  const persisted = partializeComposerDraftStoreState(useComposerDraftStore.getState());
+  const normalized = normalizeCurrentPersistedComposerDraftStoreState(
+    JSON.parse(JSON.stringify(persisted)),
+  );
+  const hydrated = toHydratedThreadDraft(threadId, normalized.draftsByThreadId[threadId]!);
+  expect(hydrated.pendingUserInputDrafts).toEqual({ [key]: draft });
+  store.clearComposerContent(threadId);
+  expect(
+    useComposerDraftStore.getState().draftsByThreadId[threadId]?.pendingUserInputDrafts,
+  ).toEqual({ [key]: draft });
+});
+
+it("only offers recovery for an explicit invalidation of the saved instance", () => {
+  const failure = {
+    id: EventId.makeUnsafe("expired"),
+    kind: "provider.user-input.respond.failed",
+    summary: "Failed",
+    tone: "error" as const,
+    createdAt: "2026-09-10T10:01:00.000Z",
+    turnId: null,
+    payload: {
+      requestId,
+      lifecycleGeneration: "generation-a",
+      detail: "temporary transport failure",
+    },
+  };
+  expect(expiredUserInputDrafts({ [key]: draft }, [failure])).toEqual([]);
+  const expired = {
+    ...failure,
+    payload: {
+      ...failure.payload,
+      detail: buildStalePendingRequestFailureDetail("user-input", requestId),
+    },
+  };
+  expect(expiredUserInputDrafts({ [key]: draft }, [expired])).toEqual([[key, draft]]);
+  expect(
+    expiredUserInputDrafts({ [key]: draft }, [
+      { ...expired, payload: { ...expired.payload, lifecycleGeneration: "different-generation" } },
+    ]),
+  ).toEqual([]);
+});
+
+it("restores all question-answer pairs after the existing normal draft", () => {
+  expect(restoreUserInputDraft("Existing draft", draft)).toBe(
+    "Existing draft\n\nWhich color?\nBlue\n\nWhich features?\nSearch, Tabs\n\nAnything else?\nKeep it simple",
+  );
+});

--- a/apps/web/src/pendingUserInputRecovery.ts
+++ b/apps/web/src/pendingUserInputRecovery.ts
@@ -1,0 +1,87 @@
+import {
+  ApprovalRequestId,
+  UserInputQuestion,
+  type OrchestrationThreadActivity,
+} from "@synara/contracts";
+import { createStalePendingInteractionMatcher } from "@synara/shared/pendingInteractions";
+import { pendingRequestInstanceKey } from "@synara/shared/threadSummary";
+import { Schema } from "effect";
+import type { PendingUserInput } from "./pendingInteractionDerivation";
+import {
+  resolvePendingUserInputAnswer,
+  type PendingUserInputDraftAnswer,
+} from "./pendingUserInput";
+
+export interface PendingUserInputRecoveryDraft {
+  request: PendingUserInput;
+  answers: Record<string, PendingUserInputDraftAnswer>;
+}
+
+const StoredDraft = Schema.Struct({
+  request: Schema.Struct({
+    requestId: ApprovalRequestId,
+    lifecycleGeneration: Schema.optionalKey(Schema.String),
+    createdAt: Schema.String,
+    questions: Schema.Array(UserInputQuestion),
+  }),
+  answers: Schema.Record(
+    Schema.String,
+    Schema.Struct({
+      customAnswer: Schema.optionalKey(Schema.String),
+      selectedOptionLabels: Schema.optionalKey(Schema.Array(Schema.String)),
+    }),
+  ),
+});
+
+export function normalizePendingUserInputDrafts(
+  value: unknown,
+): Record<string, PendingUserInputRecoveryDraft> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([key, draft]) => {
+      if (
+        !Schema.is(StoredDraft)(draft) ||
+        key !==
+          pendingRequestInstanceKey(draft.request.requestId, draft.request.lifecycleGeneration)
+      ) {
+        return [];
+      }
+      const stored: typeof StoredDraft.Type = draft;
+      const answers = Object.fromEntries(
+        Object.entries(stored.answers).map(([id, answer]) => [
+          id,
+          {
+            ...(answer.customAnswer !== undefined ? { customAnswer: answer.customAnswer } : {}),
+            ...(answer.selectedOptionLabels
+              ? { selectedOptionLabels: [...answer.selectedOptionLabels] }
+              : {}),
+          },
+        ]),
+      );
+      return [[key, { request: stored.request, answers }]];
+    }),
+  );
+}
+
+export function expiredUserInputDrafts(
+  drafts: Record<string, PendingUserInputRecoveryDraft>,
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): Array<[string, PendingUserInputRecoveryDraft]> {
+  const isStale = createStalePendingInteractionMatcher(activities);
+  return Object.entries(drafts).filter(([, draft]) =>
+    isStale({ ...draft.request, interactionKind: "userInput" }),
+  );
+}
+
+export function restoreUserInputDraft(
+  prompt: string,
+  draft: PendingUserInputRecoveryDraft,
+): string {
+  const pairs = draft.request.questions.flatMap((question) => {
+    const answer = resolvePendingUserInputAnswer(question, draft.answers[question.id]);
+    return answer === null
+      ? []
+      : [`${question.question}\n${Array.isArray(answer) ? answer.join(", ") : answer}`];
+  });
+  return [prompt, pairs.join("\n\n")].filter((part) => part.length > 0).join("\n\n");
+}


### PR DESCRIPTION
## Summary

- Persist and reconcile pending user interactions during startup and provider runtime ingestion.
- Improve Claude question handling and recovery when sessions restart or requests expire.
- Preserve composer drafts and show clear UI notices/panels for recoverable and expired user input.
- Add coverage across provider, orchestration, persistence, startup reconciliation, and web recovery flows.

## Testing

- Added and updated unit and browser-oriented tests covering pending interaction recovery, Claude adapter behavior, provider commands, runtime ingestion, startup reconciliation, and composer draft persistence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes settlement status, claim rules, and startup reconciliation for pending interactions across orchestration and provider paths; incorrect matching could wedge or incorrectly expire prompts, though coverage is extensive.
> 
> **Overview**
> Tightens **pending approval/user-input** lifecycle so dead provider callbacks stop looking answerable while transient failures stay retryable.
> 
> **Server:** Introduces `listUnsettled` and `createStalePendingInteractionMatcher` so explicitly invalidated callbacks are excluded from reclaim, boot reconciliation, and session-restart settlement; `claimResponse` refuses re-claims after a stale failure activity. Startup `reconcileRestartStuckTurns` scans unsettled rows globally (not only summary flags) and wires the pending-interaction repository on the effect server. **Provider command handling** maps missing lifecycle generation to a **retryable** “refresh thread” failure, treats lost/stopped runtimes and classified `ProviderValidationError` reasons as **uncertain** stale prompts, and broadens “unknown pending request” to unavailable runtimes. **Claude AskUserQuestion** denies aborted/stopped prompts earlier and registers pending state before emitting events. **Projection** reconciliation uses the shared matcher when settling rows without a response command id.
> 
> **Web:** Persists per-request user-input answer drafts, dedupes submit + refreshes thread detail after dispatch, and shows **Restore answers** when an explicit stale invalidation matches the saved prompt instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f363c69744112da510440ed4afe5f04b4cec7881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->