### PR TITLE
Harden orchestration replay and provider startup against stalls

### DIFF
--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -31,6 +31,7 @@ import {
   type OrchestrationProjectionPipelineShape,
 } from "../Services/ProjectionPipeline.ts";
 import { ServerConfig } from "../../config.ts";
+import { ORCHESTRATION_EVENT_PUBSUB_CAPACITY } from "../orchestrationAdmission.ts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 
 /**
@@ -741,6 +742,50 @@ describe("OrchestrationEngine", () => {
     ]);
     await system.dispose();
   });
+
+  it("keeps dispatch responsive and replays every event when a subscriber falls behind", async () => {
+    const system = await createOrchestrationSystem();
+    const { engine } = system;
+    const projectId = asProjectId("project-slow-subscriber");
+    // Overflow by more than one durable replay page (500 events).
+    const count = ORCHESTRATION_EVENT_PUBSUB_CAPACITY + 510;
+    try {
+      const initial = await system.run(
+        engine.dispatch({
+          type: "project.create",
+          commandId: CommandId.makeUnsafe("cmd-slow-subscriber-create"),
+          projectId,
+          title: "Slow subscriber",
+          workspaceRoot: "/tmp/slow-subscriber",
+          defaultModelSelection: null,
+          createdAt: now(),
+        }),
+      );
+      const result = await system.run(
+        Effect.gen(function* () {
+          // Attach before loading/processing work, as startup and reactors do.
+          const live = yield* engine.subscribeDomainEvents;
+          for (let i = 0; i < count; i++) {
+            yield* engine.dispatch({
+              type: "project.meta.update",
+              commandId: CommandId.makeUnsafe(`cmd-slow-subscriber-${i}`),
+              projectId,
+              title: `Update ${i}`,
+            });
+          }
+          return Array.from(yield* Stream.runCollect(Stream.take(live, count)));
+        }).pipe(Effect.scoped, Effect.timeoutOption("8 seconds")),
+      );
+      expect(Option.isSome(result)).toBe(true);
+      const events = Option.getOrThrow(result);
+      expect(events.map((event) => event.sequence)).toEqual(
+        Array.from({ length: count }, (_, i) => initial.sequence + i + 1),
+      );
+      expect(events.at(-1)?.payload).toMatchObject({ title: `Update ${count - 1}` });
+    } finally {
+      await system.dispose();
+    }
+  }, 15_000);
 
   it("streams persisted domain events in order", async () => {
     const system = await createOrchestrationSystem();

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
@@ -179,9 +179,11 @@ const makeOrchestrationEngine = Effect.gen(function* () {
     normal: yield* Queue.bounded<CommandEnvelope>(ORCHESTRATION_COMMAND_QUEUE_CAPACITY),
     wake: yield* Queue.unbounded<void>(),
   } satisfies OrchestrationCommandQueues<CommandEnvelope>;
-  const eventPubSub = yield* PubSub.bounded<OrchestrationEvent>(
+  const eventPubSub = yield* PubSub.sliding<OrchestrationEvent>(
     ORCHESTRATION_EVENT_PUBSUB_CAPACITY,
   );
+  const eventPublicationLock = yield* Semaphore.make(1);
+  let lastPublishedSequence = 0;
   const initiallyIdle = yield* Deferred.make<void>();
   yield* Deferred.succeed(initiallyIdle, undefined).pipe(Effect.orDie);
   const engineAdmissionState = yield* Ref.make<EngineAdmissionState>({
@@ -204,12 +206,21 @@ const makeOrchestrationEngine = Effect.gen(function* () {
   > | null>(null);
   const lastSuccessfulProjectionRepairAtMs = yield* Ref.make(0);
 
-  // Committed events are durable before they reach this boundary. Once
-  // publication starts, a dispatch deadline must not interrupt it and leave
-  // live consumers behind the durable log. Bounded PubSub backpressure is
-  // therefore lossless; engine scope close shuts the bus to release it.
+  // Reactors can dispatch commands while consuming these events. Waiting for
+  // a slow subscriber here would deadlock the single command worker. Keep a
+  // bounded live window; subscribers recover overflow from the durable log.
   const publishCommittedEvent = (event: OrchestrationEvent) =>
-    Effect.uninterruptible(PubSub.publish(eventPubSub, event)).pipe(Effect.asVoid);
+    eventPublicationLock
+      .withPermits(1)(
+        PubSub.publish(eventPubSub, event).pipe(
+          Effect.andThen(
+            Effect.sync(() => {
+              lastPublishedSequence = Math.max(lastPublishedSequence, event.sequence);
+            }),
+          ),
+        ),
+      )
+      .pipe(Effect.uninterruptible);
 
   const makeCommandTimeoutError = (command: OrchestrationCommand) =>
     new OrchestrationCommandTimeoutError({
@@ -1099,6 +1110,7 @@ const makeOrchestrationEngine = Effect.gen(function* () {
   yield* projectionPipeline.bootstrap;
 
   commandReadModel = yield* projectionSnapshotQuery.getCommandReadModel();
+  lastPublishedSequence = yield* eventStore.getHighWaterSequence();
 
   const finishEnvelope = Ref.modify(engineAdmissionState, (current) => {
     const outstanding = Math.max(0, current.outstanding - 1);
@@ -1265,9 +1277,33 @@ const makeOrchestrationEngine = Effect.gen(function* () {
   const getEventHighWaterSequence = eventStore.getHighWaterSequence();
   const getThreadTitleHighWaterSequence = (threadId: string) =>
     eventStore.getThreadTitleHighWaterSequence(threadId);
-  const subscribeDomainEvents: OrchestrationEngineShape["subscribeDomainEvents"] = PubSub.subscribe(
-    eventPubSub,
-  ).pipe(Effect.map((subscription) => Stream.fromEffectRepeat(PubSub.take(subscription))));
+  const subscribeDomainEvents: OrchestrationEngineShape["subscribeDomainEvents"] =
+    eventPublicationLock.withPermits(1)(
+      Effect.gen(function* () {
+        // Capture the cursor atomically with attachment, so a publication cannot
+        // fall between the live subscription and its initial replay boundary.
+        const subscription = yield* PubSub.subscribe(eventPubSub);
+        let cursor = lastPublishedSequence;
+        return Stream.fromEffectRepeat(PubSub.take(subscription)).pipe(
+          Stream.flatMap((event) => {
+            if (event.sequence <= cursor) return Stream.empty;
+            const gap =
+              event.sequence > cursor + 1
+                ? eventStore
+                    .readFromSequence(cursor, Number.MAX_SAFE_INTEGER, event.sequence - 1)
+                    .pipe(Stream.orDie)
+                : Stream.empty;
+            return Stream.concat(gap, Stream.succeed(event)).pipe(
+              Stream.tap((delivered) =>
+                Effect.sync(() => {
+                  cursor = delivered.sequence;
+                }),
+              ),
+            );
+          }),
+        );
+      }),
+    );
 
   // Compatibility bridge for older tests and out-of-tree callers. Production
   // code should use ProjectionSnapshotQuery directly instead of depending on

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -30,6 +30,63 @@ const projectionSnapshotLayer = it.layer(
 );
 
 projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
+  it.effect(
+    "selects the latest turn per thread with stable ties and preserves historical update time",
+    () =>
+      Effect.gen(function* () {
+        const query = yield* ProjectionSnapshotQuery;
+        const sql = yield* SqlClient.SqlClient;
+        yield* sql`DELETE FROM projection_projects`;
+        yield* sql`DELETE FROM projection_threads`;
+        yield* sql`DELETE FROM projection_state`;
+        yield* sql`DELETE FROM projection_turns`;
+        yield* sql`DELETE FROM projection_thread_sessions`;
+        yield* sql`DELETE FROM projection_thread_messages`;
+        yield* sql`DELETE FROM projection_thread_activities`;
+        yield* sql`DELETE FROM projection_thread_proposed_plans`;
+        yield* sql`
+        INSERT INTO projection_projects (
+          project_id, title, workspace_root, scripts_json, created_at, updated_at
+        ) VALUES ('latest-project', 'Latest', '/tmp/latest', '[]',
+          '2026-09-10T00:00:00.000Z', '2026-09-10T00:00:00.000Z')
+      `;
+        yield* sql`
+        INSERT INTO projection_threads (
+          thread_id, project_id, title, model_selection_json, latest_turn_id, created_at, updated_at
+        ) VALUES
+          ('latest-a', 'latest-project', 'A', '{"provider":"pi","model":"openai/gpt-4o"}',
+            'turn-old', '2026-09-10T00:00:00.000Z', '2026-09-10T00:00:00.000Z'),
+          ('latest-b', 'latest-project', 'B', '{"provider":"pi","model":"openai/gpt-4o"}',
+            NULL, '2026-09-10T00:00:00.000Z', '2026-09-10T00:00:00.000Z')
+      `;
+        yield* sql`
+        INSERT INTO projection_turns (
+          thread_id, turn_id, state, requested_at, completed_at, checkpoint_files_json
+        ) VALUES
+          ('latest-a', 'turn-old', 'completed', '2026-09-10T00:00:01.000Z', '2026-09-10T00:00:09.000Z', '[]'),
+          ('latest-a', 'turn-a', 'completed', '2026-09-10T00:00:02.000Z', NULL, '[]'),
+          ('latest-a', 'turn-z', 'running', '2026-09-10T00:00:02.000Z', NULL, '[]'),
+          ('latest-a', NULL, 'pending', '2026-09-10T00:00:10.000Z', NULL, '[]'),
+          ('latest-b', 'turn-old', 'completed', '2026-09-10T00:00:03.000Z', NULL, '[]')
+      `;
+        for (const snapshot of [
+          yield* query.getSnapshot(),
+          yield* query.getShellSnapshot(),
+          yield* query.getCommandReadModel(),
+        ]) {
+          assert.equal(
+            snapshot.threads.find((thread) => thread.id === "latest-a")?.latestTurn?.turnId,
+            "turn-z",
+          );
+          assert.equal(
+            snapshot.threads.find((thread) => thread.id === "latest-b")?.latestTurn?.turnId,
+            "turn-old",
+          );
+          assert.equal(snapshot.updatedAt, "2026-09-10T00:00:09.000Z");
+        }
+      }),
+  );
+
   it.effect("marks only an empty shell with an active durable project for repair", () =>
     Effect.gen(function* () {
       const snapshotQuery = yield* ProjectionSnapshotQuery;

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -179,6 +179,7 @@ const ProjectionLatestTurnDbRowSchema = Schema.Struct({
   assistantMessageId: Schema.NullOr(MessageId),
   sourceProposedPlanThreadId: Schema.NullOr(ThreadId),
   sourceProposedPlanId: Schema.NullOr(OrchestrationProposedPlanId),
+  historyUpdatedAt: Schema.optional(Schema.NullOr(IsoDateTime)),
 });
 const ProjectionStateDbRowSchema = ProjectionState;
 const ProjectionCountsRowSchema = Schema.Struct({
@@ -613,6 +614,7 @@ function collectProjectedLatestTurns(rows: ReadonlyArray<ProjectionLatestTurnDbR
   const byThread = new Map<string, OrchestrationLatestTurn>();
   let updatedAt: string | null = null;
   for (const row of rows) {
+    updatedAt = maxOptionalIso(updatedAt, row.historyUpdatedAt);
     updatedAt = maxIso(updatedAt, row.requestedAt);
     updatedAt = maxOptionalIso(updatedAt, row.startedAt);
     updatedAt = maxOptionalIso(updatedAt, row.completedAt);
@@ -1379,24 +1381,42 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
       `,
   });
 
+  // Seek one turn per thread using the existing (thread_id, requested_at) index.
+  // Keep the history timestamp as a scalar aggregate instead of decoding every
+  // historical turn merely to discard it in collectProjectedLatestTurns.
   const listLatestTurnRows = SqlSchema.findAll({
     Request: Schema.Void,
     Result: ProjectionLatestTurnDbRowSchema,
     execute: () =>
       sql`
         SELECT
-          thread_id AS "threadId",
-          turn_id AS "turnId",
-          state,
-          requested_at AS "requestedAt",
-          started_at AS "startedAt",
-          completed_at AS "completedAt",
-          assistant_message_id AS "assistantMessageId",
-          source_proposed_plan_thread_id AS "sourceProposedPlanThreadId",
-          source_proposed_plan_id AS "sourceProposedPlanId"
-        FROM projection_turns
-        WHERE turn_id IS NOT NULL
-        ORDER BY thread_id ASC, requested_at DESC, turn_id DESC
+          latest.thread_id AS "threadId",
+          latest.turn_id AS "turnId",
+          latest.state,
+          latest.requested_at AS "requestedAt",
+          latest.started_at AS "startedAt",
+          latest.completed_at AS "completedAt",
+          latest.assistant_message_id AS "assistantMessageId",
+          latest.source_proposed_plan_thread_id AS "sourceProposedPlanThreadId",
+          latest.source_proposed_plan_id AS "sourceProposedPlanId",
+          (
+            SELECT MAX(MAX(
+              requested_at,
+              COALESCE(started_at, requested_at),
+              COALESCE(completed_at, requested_at)
+            ))
+            FROM projection_turns
+            WHERE turn_id IS NOT NULL
+          ) AS "historyUpdatedAt"
+        FROM projection_threads AS threads
+        JOIN projection_turns AS latest ON latest.row_id = (
+          SELECT row_id
+          FROM projection_turns
+          WHERE thread_id = threads.thread_id AND turn_id IS NOT NULL
+          ORDER BY requested_at DESC, turn_id DESC
+          LIMIT 1
+        )
+        ORDER BY latest.thread_id ASC
       `,
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -4824,15 +4824,9 @@ const make = Effect.gen(function* () {
   // serially in the same source but do not acquire delivery claims yet.
   const startProviderIntentSource = Effect.gen(function* () {
     const liveEventSource = yield* orchestrationEngine.subscribeDomainEvents;
-    // Detach the engine from this reactor's processing latency. The engine
-    // publishes committed events into a bounded PubSub from an uninterruptible
-    // section of its single command worker, so a subscriber that stalls (a hung
-    // provider call, or just slow boot replay below) back-pressures the worker
-    // and then fails every dispatched command with a dispatch timeout. Draining
-    // into an unbounded queue immediately after subscribing keeps the engine
-    // free while boot work runs; ordering is preserved because the queue is FIFO
-    // and `processOrderedEvent` skips anything at or below the durable cursor.
-    const liveEventQueue = yield* Queue.unbounded<OrchestrationEvent, Cause.Done>();
+    // Preserve the source/consumer handoff without retaining an unbounded event
+    // mirror while startup or a provider call runs. The engine replays overflow.
+    const liveEventQueue = yield* Queue.bounded<OrchestrationEvent, Cause.Done>(1);
     yield* Stream.runIntoQueue(liveEventSource, liveEventQueue).pipe(Effect.forkScoped);
     const liveEvents = Stream.fromQueue(liveEventQueue);
     const consumerState = yield* deliveryRepository.getConsumerState(

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -8,7 +8,8 @@ import type {
   Provider,
   QuestionRequest,
 } from "@opencode-ai/sdk/v2";
-import { Deferred, Effect, Exit, Fiber, Layer, Scope, Stream } from "effect";
+import { Deferred, Effect, Exit, Fiber, Layer, Option, Scope, Stream } from "effect";
+import { TestClock } from "effect/testing";
 import { describe, it, expect, vi } from "vitest";
 
 import { ServerConfig } from "../../config.ts";
@@ -74,7 +75,10 @@ function createMockOpenCodeRuntime(options?: {
   readonly pendingQuestions?: ReadonlyArray<QuestionRequest>;
   readonly questionList?: () => Promise<unknown>;
   readonly permissionReply?: (input: Record<string, unknown>) => Promise<unknown>;
-  readonly mcpAdd?: (input: Record<string, unknown>) => Promise<unknown>;
+  readonly mcpAdd?: (
+    input: Record<string, unknown>,
+    options?: { signal?: AbortSignal },
+  ) => Promise<unknown>;
   readonly serverExit?: Effect.Effect<number>;
   readonly sessionCreateError?: Error;
   readonly sessionUpdate?: (input: Record<string, unknown>) => Promise<unknown>;
@@ -175,10 +179,10 @@ function createMockOpenCodeRuntime(options?: {
       list: options?.commandList ?? (async () => ({ data: [] })),
     },
     mcp: {
-      add: async (input: Record<string, unknown>) => {
+      add: async (input: Record<string, unknown>, requestOptions?: { signal?: AbortSignal }) => {
         mcpAddCalls.push(input);
         return options?.mcpAdd
-          ? options.mcpAdd(input)
+          ? options.mcpAdd(input, requestOptions)
           : { data: { synara: { status: "connected" } } };
       },
     },
@@ -1393,6 +1397,58 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
     );
 
     expect(gateway.revoked).toEqual(["gateway-token-1"]);
+    expect(gateway.ownerByToken.size).toBe(0);
+    expect(JSON.stringify(runtime.promptCalls[0])).toContain("Synara MCP control is unavailable");
+  });
+
+  it("cancels stalled MCP setup and starts with the gateway marked unavailable", async () => {
+    const requested = Effect.runSync(Deferred.make<void>());
+    let requestSignal: AbortSignal | undefined;
+    const runtime = createMockOpenCodeRuntime({
+      mcpAdd: async (_input, options) => {
+        requestSignal = options?.signal;
+        Effect.runSync(Deferred.succeed(requested, undefined));
+        return await new Promise(() => {});
+      },
+    });
+    const gateway = makeGatewayCredentials();
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        const threadId = asThreadId("thread-stalled-gateway");
+        const starting = yield* adapter
+          .startSession({
+            provider: "opencode",
+            threadId,
+            runtimeMode: "full-access",
+          })
+          .pipe(Effect.forkChild);
+        yield* Deferred.await(requested);
+        yield* TestClock.adjust("10 seconds");
+        const session = yield* Fiber.join(starting);
+        expect(session.status).toBe("ready");
+        expect(requestSignal?.aborted).toBe(true);
+        yield* adapter.sendTurn({
+          threadId,
+          input: "hello",
+          attachments: [],
+          modelSelection: { provider: "opencode", model: "openai/gpt-5" },
+        });
+        yield* adapter.stopSession(threadId);
+      }).pipe(
+        Effect.provide(
+          makeOpenCodeAdapterLive({ runtime: runtime.runtime }).pipe(
+            Layer.provide(Layer.succeed(AgentGatewayCredentials, gateway.credentials)),
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), { prefix: "opencode-gateway-timeout-test-" }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ),
+        Effect.provide(TestClock.layer()),
+        Effect.scoped,
+      ),
+    );
     expect(gateway.ownerByToken.size).toBe(0);
     expect(JSON.stringify(runtime.promptCalls[0])).toContain("Synara MCP control is unavailable");
   });
@@ -4914,6 +4970,56 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
         },
       },
     });
+  });
+
+  it("starts and sends a turn while optional model inventory is stalled", async () => {
+    const runtime = createMockOpenCodeRuntime();
+    let inventoryCancelled = false;
+    const stalledRuntime = {
+      ...runtime.runtime,
+      loadOpenCodeInventory: () =>
+        Effect.never.pipe(
+          Effect.onInterrupt(() =>
+            Effect.sync(() => {
+              inventoryCancelled = true;
+            }),
+          ),
+        ),
+    };
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        return yield* Effect.gen(function* () {
+          const session = yield* adapter.startSession({
+            provider: "opencode",
+            threadId: asThreadId("thread-stalled-inventory"),
+            runtimeMode: "full-access",
+          });
+          const turn = yield* adapter.sendTurn({
+            threadId: session.threadId,
+            input: "hello",
+            attachments: [],
+            modelSelection: { provider: "opencode", model: "openai/gpt-5.4" },
+          });
+          yield* adapter.stopSession(session.threadId);
+          return { session, turn };
+        }).pipe(Effect.timeoutOption("1 second"));
+      }).pipe(
+        Effect.provide(
+          makeOpenCodeAdapterLive({ runtime: stalledRuntime }).pipe(
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), { prefix: "opencode-inventory-test-" }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ),
+      ),
+    );
+
+    expect(Option.isSome(result)).toBe(true);
+    expect(runtime.promptCalls).toHaveLength(1);
+    expect(inventoryCancelled).toBe(true);
   });
 
   it("does not block sendTurn when the OpenCode prompt request stalls during startup", async () => {

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -200,13 +200,16 @@ const installOpenCodeGatewayMcp = Effect.fn("installOpenCodeGatewayMcp")(functio
   readonly displayName: string;
   readonly connection: AgentGatewaySessionLease["connection"];
 }) {
-  const result = yield* runOpenCodeSdk("mcp.add", () =>
-    input.client.mcp.add({
-      directory: input.directory,
-      name: SYNARA_MCP_SERVER_NAME,
-      config: buildOpenCodeMcpServer(input.connection),
-    }),
-  );
+  const result = yield* runOpenCodeSdk("mcp.add", (signal) =>
+    input.client.mcp.add(
+      {
+        directory: input.directory,
+        name: SYNARA_MCP_SERVER_NAME,
+        config: buildOpenCodeMcpServer(input.connection),
+      },
+      { signal },
+    ),
+  ).pipe(Effect.timeout("10 seconds"));
   const status = result.data?.[SYNARA_MCP_SERVER_NAME];
   if (status?.status === "connected") {
     return;
@@ -3474,17 +3477,24 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
                                 ),
                           ),
                         );
-                    const loadModelContextLimits = openCodeRuntime
-                      .loadOpenCodeInventory(client)
-                      .pipe(
-                        Effect.map(buildOpenCodeModelContextLimitMap),
-                        Effect.catchCause(() => Effect.succeed(new Map<string, number>())),
-                      );
-                    // Session creation and metadata discovery are independent once the server is up.
-                    const [openCodeSessionId, modelContextLimitBySlug] = yield* Effect.all(
-                      [createSessionId, loadModelContextLimits],
-                      { concurrency: "unbounded" },
+                    const modelContextLimitBySlug = new Map<string, number>();
+                    // Context metadata is optional. A slow discovery endpoint
+                    // must not hold a usable session behind the startup deadline.
+                    yield* openCodeRuntime.loadOpenCodeInventory(client).pipe(
+                      Effect.map(buildOpenCodeModelContextLimitMap),
+                      Effect.timeoutOption("10 seconds"),
+                      Effect.map(Option.getOrElse(() => new Map<string, number>())),
+                      Effect.catchCause(() => Effect.succeed(new Map<string, number>())),
+                      Effect.tap((limits) =>
+                        Effect.sync(() => {
+                          for (const [slug, limit] of limits) {
+                            modelContextLimitBySlug.set(slug, limit);
+                          }
+                        }),
+                      ),
+                      Effect.forkIn(sessionScope),
                     );
+                    const openCodeSessionId = yield* createSessionId;
 
                     return {
                       sessionScope,

--- a/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
@@ -9,13 +9,8 @@ import type {
   AgentSessionEvent,
   InlineExtension,
 } from "@earendil-works/pi-coding-agent";
-import { Effect, Layer, Stream } from "effect";
-import {
-  ApprovalRequestId,
-  ThreadId,
-  type ProviderRuntimeEvent,
-  type TurnId,
-} from "@synara/contracts";
+import { Effect, Layer, Schema, Stream } from "effect";
+import { ApprovalRequestId, ThreadId, ProviderRuntimeEvent, type TurnId } from "@synara/contracts";
 import { afterEach, expect, it, vi } from "vitest";
 import {
   AgentGatewayCredentials,
@@ -205,6 +200,63 @@ async function withAdapter(
 async function send(adapter: PiAdapterShape) {
   return Effect.runPromise(adapter.sendTurn({ threadId, input: "Test this turn" }));
 }
+
+it.each([
+  { toolName: "bash", args: { command: "printf hello \n" }, title: "printf hello" },
+  { toolName: "bash", args: { command: " \n" }, title: "bash" },
+  { toolName: "read", args: { path: "file.txt " }, title: "read file.txt" },
+  { toolName: "grep", args: { pattern: "needle \n" }, title: "grep needle" },
+])(
+  "persists $toolName lifecycle titles without changing tool arguments: $title",
+  async ({ toolName, args, title }) => {
+    responses("until-abort");
+    await withAdapter(async (adapter, events) => {
+      const turn = await send(adapter);
+      const session = captured.sessions[0]!;
+      await waitFor(() => expect(session.isStreaming).toBe(true));
+      const emit = (event: AgentSessionEvent) =>
+        (session as unknown as { _emit(event: AgentSessionEvent): void })._emit(event);
+      emit({ type: "tool_execution_start", toolCallId: "title-tool", toolName, args });
+      emit({
+        type: "tool_execution_update",
+        toolCallId: "title-tool",
+        toolName,
+        args,
+        partialResult: { content: [{ type: "text", text: "working" }], details: {} },
+      });
+      emit({
+        type: "tool_execution_end",
+        toolCallId: "title-tool",
+        toolName,
+        result: { content: [{ type: "text", text: "done" }], details: {} },
+        isError: false,
+      });
+      const toolEvents = () =>
+        events.filter(
+          (event) =>
+            (event.type === "item.started" ||
+              event.type === "item.updated" ||
+              event.type === "item.completed") &&
+            event.itemId === "pi-tool-title-tool",
+        );
+      await waitFor(() => expect(toolEvents()).toHaveLength(3));
+      for (const event of toolEvents()) {
+        const encodable = await Effect.runPromise(
+          Schema.encodeEffect(Schema.fromJsonString(ProviderRuntimeEvent))(event).pipe(
+            Effect.match({ onFailure: () => false, onSuccess: () => true }),
+          ),
+        );
+        expect(encodable).toBe(true);
+        expect(event.payload).toMatchObject({ title });
+      }
+      const snapshot = await Effect.runPromise(adapter.readThread(threadId));
+      expect(snapshot.turns.find((entry) => entry.id === turn.turnId)?.items).toContainEqual(
+        expect.objectContaining({ callId: "title-tool", args }),
+      );
+      await Effect.runPromise(adapter.interruptTurn(threadId, turn.turnId));
+    });
+  },
+);
 
 it("retains only the latest cumulative tool snapshot while preserving final output", async () => {
   responses("until-abort");

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -1045,16 +1045,16 @@ function toolItemType(toolName: string): PiTrackedToolCall["itemType"] {
 }
 
 function toolTitle(toolName: string, args: unknown): string {
-  const command = toolName === "bash" ? toolCommand(args) : undefined;
+  const command = toolName === "bash" ? trimPiDisplayText(toolCommand(args)) : undefined;
   if (command) return command;
-  const filePath = toolPath(args);
+  const filePath = trimPiDisplayText(toolPath(args));
   if (
     filePath &&
     (toolName === "read" || toolName === "edit" || toolName === "write" || toolName === "ls")
   ) {
     return `${toolName} ${filePath}`;
   }
-  const query = toolSearchQuery(toolName, args);
+  const query = trimPiDisplayText(toolSearchQuery(toolName, args));
   if (query && (toolName === "find" || toolName === "grep")) {
     return `${toolName} ${query}`;
   }

--- a/apps/server/src/provider/opencodeRuntime.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.test.ts
@@ -5,7 +5,8 @@
 
 import { pathToFileURL } from "node:url";
 
-import { Duration, Effect, Exit, Fiber, Layer, Scope, Sink, Stream } from "effect";
+import { Deferred, Duration, Effect, Exit, Fiber, Layer, Scope, Sink, Stream } from "effect";
+import type { OpencodeClient } from "@opencode-ai/sdk/v2";
 import { type ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import { TestClock } from "effect/testing";
 import type { ChatAttachment } from "@synara/contracts";
@@ -149,6 +150,42 @@ function openCodeRuntimePoolTestLayer(state: {
     TestClock.layer(),
   );
 }
+
+it("bounds optional console discovery and aborts its stalled HTTP request", async () => {
+  const requested = Effect.runSync(Deferred.make<void>());
+  let requestSignal: AbortSignal | undefined;
+  const client = {
+    provider: { list: async () => ({ data: { all: [], connected: [], default: {} } }) },
+    app: { agents: async () => ({ data: [] }) },
+    experimental: {
+      console: {
+        get: async (_input: unknown, options?: { signal?: AbortSignal }) => {
+          requestSignal = options?.signal;
+          Effect.runSync(Deferred.succeed(requested, undefined));
+          return await new Promise(() => {});
+        },
+      },
+    },
+  } as unknown as OpencodeClient;
+  const inventory = await Effect.runPromise(
+    Effect.gen(function* () {
+      const runtime = yield* OpenCodeRuntime;
+      const loading = yield* runtime.loadOpenCodeInventory(client).pipe(Effect.forkChild);
+      yield* Deferred.await(requested);
+      yield* TestClock.adjust("2 seconds");
+      return yield* Fiber.join(loading);
+    }).pipe(
+      Effect.provide(openCodeRuntimePoolTestLayer({ spawnUrls: [], killUrls: [] })),
+      Effect.scoped,
+    ),
+  );
+  expect(inventory).toEqual({
+    providerList: { all: [], connected: [], default: {} },
+    agents: [],
+    consoleState: null,
+  });
+  expect(requestSignal?.aborted).toBe(true);
+});
 
 describe("toOpenCodeFileParts", () => {
   it("materializes image attachments as SDK file parts", () => {

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -128,7 +128,7 @@ export function openCodeRuntimeErrorDetail(cause: unknown): string {
 
 export const runOpenCodeSdk = <A>(
   operation: string,
-  fn: () => Promise<A>,
+  fn: (signal: AbortSignal) => Promise<A>,
 ): Effect.Effect<A, OpenCodeRuntimeError> =>
   Effect.tryPromise({
     try: fn,
@@ -1284,7 +1284,7 @@ const makeOpenCodeRuntime = (options?: OpenCodeRuntimeLiveOptions) =>
       });
 
     const loadProviders = (client: OpencodeClient) =>
-      runOpenCodeSdk("provider.list", () => client.provider.list()).pipe(
+      runOpenCodeSdk("provider.list", (signal) => client.provider.list(undefined, { signal })).pipe(
         Effect.filterMapOrFail(
           (list) =>
             list.data
@@ -1300,7 +1300,7 @@ const makeOpenCodeRuntime = (options?: OpenCodeRuntimeLiveOptions) =>
       );
 
     const loadAgents = (client: OpencodeClient) =>
-      runOpenCodeSdk("app.agents", () => client.app.agents()).pipe(
+      runOpenCodeSdk("app.agents", (signal) => client.app.agents(undefined, { signal })).pipe(
         Effect.map((result) => result.data ?? []),
       );
 
@@ -1316,9 +1316,13 @@ const makeOpenCodeRuntime = (options?: OpenCodeRuntimeLiveOptions) =>
       );
 
     const loadConsoleState = (client: OpencodeClient) =>
-      runOpenCodeSdk("experimental.console.get", () => client.experimental.console.get()).pipe(
+      runOpenCodeSdk("experimental.console.get", (signal) =>
+        client.experimental.console.get(undefined, { signal }),
+      ).pipe(
         Effect.map((result) => result.data ?? null),
         // Console metadata is optional and should not block model discovery.
+        Effect.timeoutOption("2 seconds"),
+        Effect.map(Option.getOrElse(() => null)),
         Effect.catch(() => Effect.succeed(null)),
       );
 


### PR DESCRIPTION
## Summary

- Make orchestration event publication responsive with bounded sliding delivery and durable replay for slow subscribers.
- Select the latest projected turn per thread deterministically while preserving historical update timestamps.
- Prevent provider startup from blocking on stalled OpenCode MCP setup or optional model inventory.
- Normalize Pi tool lifecycle titles without modifying persisted tool arguments.
- Add regression coverage for event replay, snapshot selection, provider startup timeouts, and tool titles.

## Testing

- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core orchestration event delivery and subscription semantics (possible ordering/replay edge cases) plus provider session startup paths that affect availability when OpenCode endpoints hang.
> 
> **Overview**
> **Orchestration live events** no longer block the command worker when reactors or boot replay lag. The engine uses a **bounded sliding PubSub**, tracks **`lastPublishedSequence`** under a publication lock, and **`subscribeDomainEvents`** fills sequence gaps from the durable log so slow consumers still see every event in order. The provider reactor drops the unbounded event mirror in favor of a **capacity-1 handoff queue**, relying on engine replay for overflow.
> 
> **Projection snapshots** pick the **latest turn per thread** with deterministic ties (`requested_at`, then `turn_id`) via an indexed per-thread seek, while **`updatedAt`** still reflects the max historical turn timestamps through a new **`historyUpdatedAt`** aggregate.
> 
> **OpenCode startup** passes **`AbortSignal`** through SDK calls, applies **timeouts** to MCP setup (~10s) and optional inventory/console discovery, and **forks model inventory** so session creation is not held behind slow metadata.
> 
> **Pi tool lifecycle titles** trim whitespace/newlines for display only; persisted tool arguments are unchanged.
> 
> Regression tests cover slow-subscriber replay, latest-turn selection, MCP/inventory stalls, and Pi title encoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7544c31c7c439be2d3a505e057008a326d53118c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->