### PR TITLE
feat(web): use Pierre editor for file previews

### DIFF
--- a/apps/web/src/components/WorkspaceFilePreview.editing.browser.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.editing.browser.tsx
@@ -10,10 +10,11 @@ import type {
   ProjectReadFileResult,
   ProjectWatchFileInput,
 } from "@synara/contracts";
+import { StrictMode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { page } from "vitest/browser";
+import { page, userEvent, type Locator } from "vitest/browser";
 import { afterEach, expect, it, vi } from "vitest";
-import { render } from "vitest-browser-react";
+import { render, cleanup } from "vitest-browser-react";
 
 import { WorkspaceFilePreview } from "./WorkspaceFilePreview";
 
@@ -53,19 +54,33 @@ function loadedFile(overrides: Partial<ProjectReadFileResult> = {}): ProjectRead
   };
 }
 
+const primaryModifier = /Mac/.test(navigator.platform) ? "Meta" : "Control";
+
+function shortcut(key: string): string {
+  return `{${primaryModifier}>}${key}{/${primaryModifier}}`;
+}
+
+async function replaceEditorContents(editor: Locator, contents: string): Promise<void> {
+  await editor.click();
+  await userEvent.keyboard(shortcut("a"));
+  // Fill replaces DOM text without updating Pierre's document; use native input.
+  await userEvent.keyboard(contents.replace(/[{[]/g, "$&$&").replace(/\n/g, "{Enter}"));
+}
+
 function pressKeyboardSave(element: Element): void {
   element.dispatchEvent(
     new KeyboardEvent("keydown", {
       key: "s",
       ctrlKey: true,
       bubbles: true,
+      composed: true,
       cancelable: true,
     }),
   );
 }
 
-afterEach(() => {
-  document.body.innerHTML = "";
+afterEach(async () => {
+  await cleanup();
 });
 
 it("requests only the resolved preview file for gutters and refreshes it on file events", async () => {
@@ -124,8 +139,8 @@ it("tracks dirty state and saves the loaded version with Ctrl+S", async () => {
     );
 
     const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
-    await expect.element(editor).toHaveTextContent("export const value = 1;\n");
-    await editor.fill("export const value = 2;\n");
+    await expect.element(editor).toHaveTextContent("export const value = 1;");
+    await replaceEditorContents(editor, "export const value = 2;\n");
     await expect.element(page.getByRole("status", { name: "Unsaved changes" })).toBeVisible();
 
     pressKeyboardSave(editor.element());
@@ -165,12 +180,12 @@ it("keeps the buffer dirty and shows guarded write failures", async () => {
     );
 
     const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
-    await editor.fill("manual edit\n");
+    await replaceEditorContents(editor, "manual edit\n");
     pressKeyboardSave(editor.element());
 
     await expect.element(page.getByRole("alert")).toHaveTextContent(conflictMessage);
     await expect.element(page.getByRole("status", { name: "Unsaved changes" })).toBeVisible();
-    await expect.element(editor).toHaveTextContent("manual edit\n");
+    await expect.element(editor).toHaveTextContent("manual edit");
     expect(writeFile).toHaveBeenCalledTimes(1);
   } finally {
     restoreNativeApi();
@@ -194,8 +209,9 @@ it("revalidates on file events without overwriting a dirty edit buffer", async (
       return unsubscribe;
     },
   );
+  const writeFile = vi.fn().mockResolvedValue({ relativePath: FILE_PATH, version: SAVED_VERSION });
   const restoreNativeApi = installNativeApi({
-    projects: { readFile, onFileChange },
+    projects: { readFile, onFileChange, writeFile },
   } as unknown as NativeApi);
 
   try {
@@ -206,8 +222,8 @@ it("revalidates on file events without overwriting a dirty edit buffer", async (
     );
 
     const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
-    await expect.element(editor).toHaveTextContent("export const value = 1;\n");
-    await editor.fill("manual edit\n");
+    await expect.element(editor).toHaveTextContent("export const value = 1;");
+    await replaceEditorContents(editor, "manual edit\n");
     await vi.waitFor(() => expect(onFileChange).toHaveBeenCalledTimes(1));
 
     fileChangeSubscription.listener?.({
@@ -217,7 +233,7 @@ it("revalidates on file events without overwriting a dirty edit buffer", async (
     });
 
     await vi.waitFor(() => expect(readFile).toHaveBeenCalledTimes(2));
-    await expect.element(editor).toHaveTextContent("manual edit\n");
+    await expect.element(editor).toHaveTextContent("manual edit");
     await expect
       .element(page.getByText("This file changed on disk. Your unsaved edits are preserved."))
       .toBeVisible();
@@ -225,7 +241,19 @@ it("revalidates on file events without overwriting a dirty edit buffer", async (
     const reloadButton = document.querySelector<HTMLButtonElement>('[role="alert"] button');
     expect(reloadButton).not.toBeNull();
     reloadButton?.click();
-    await expect.element(editor).toHaveTextContent("external edit\n");
+    await expect.element(editor).toHaveTextContent("external edit");
+    await replaceEditorContents(editor, "after reload\n");
+    pressKeyboardSave(editor.element());
+    await vi.waitFor(() =>
+      expect(writeFile).toHaveBeenCalledWith({
+        cwd: WORKSPACE_ROOT,
+        relativePath: FILE_PATH,
+        contents: "after reload\n",
+        expectedVersion: externalVersion,
+        encoding: "utf8",
+        lineEnding: "lf",
+      }),
+    );
   } finally {
     restoreNativeApi();
   }
@@ -248,7 +276,7 @@ it("stops revalidation when a kept-mounted preview becomes hidden", async () => 
 
     await expect
       .element(page.getByRole("textbox", { name: `Edit ${FILE_PATH}` }))
-      .toHaveTextContent("export const value = 1;\n");
+      .toHaveTextContent("export const value = 1;");
     await vi.waitFor(() => expect(onFileChange).toHaveBeenCalledTimes(1));
 
     await screen.rerender(
@@ -285,7 +313,7 @@ it("switches the watcher to a workspace path resolved by the file read", async (
 
     await expect
       .element(page.getByRole("textbox", { name: `Edit ${FILE_PATH}` }))
-      .toHaveTextContent("export const value = 1;\n");
+      .toHaveTextContent("export const value = 1;");
     await vi.waitFor(() =>
       expect(onFileChange).toHaveBeenLastCalledWith(
         { cwd: WORKSPACE_ROOT, relativePath: resolvedPath },
@@ -328,8 +356,8 @@ it("preserves dirty edits when reloading the changed disk version fails", async 
     );
 
     const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
-    await expect.element(editor).toHaveTextContent("export const value = 1;\n");
-    await editor.fill("manual edit\n");
+    await expect.element(editor).toHaveTextContent("export const value = 1;");
+    await replaceEditorContents(editor, "manual edit\n");
     await vi.waitFor(() => expect(onFileChange).toHaveBeenCalledTimes(1));
     fileChangeSubscription.listener?.({
       type: "changed",
@@ -342,7 +370,7 @@ it("preserves dirty edits when reloading the changed disk version fails", async 
     await reloadButton.click();
 
     await vi.waitFor(() => expect(readFile).toHaveBeenCalledTimes(3));
-    await expect.element(editor).toHaveTextContent("manual edit\n");
+    await expect.element(editor).toHaveTextContent("manual edit");
     await expect.element(page.getByText("Transient read failure")).toBeVisible();
     await expect.element(page.getByRole("status", { name: "Unsaved changes" })).toBeVisible();
   } finally {
@@ -379,7 +407,7 @@ it("keeps markdown task previews and guarded versions in sync after an editor sa
     );
 
     const editor = page.getByRole("textbox", { name: `Edit ${markdownPath}` });
-    await editor.fill("- [ ] updated task\n");
+    await replaceEditorContents(editor, "- [ ] updated task\n");
     pressKeyboardSave(editor.element());
     await vi.waitFor(() => expect(writeFile).toHaveBeenCalledTimes(1));
     await page.getByRole("radio", { name: "Preview" }).click();
@@ -462,11 +490,11 @@ it("keeps a successful save when an older watcher read resolves afterwards", asy
       </QueryClientProvider>,
     );
     const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
-    await expect.element(editor).toHaveTextContent("export const value = 1;\n");
+    await expect.element(editor).toHaveTextContent("export const value = 1;");
     await vi.waitFor(() => expect(onFileChange).toHaveBeenCalledTimes(1));
     subscription.listener?.({ type: "changed", relativePath: FILE_PATH, mtimeMs: 1 });
     await vi.waitFor(() => expect(readFile).toHaveBeenCalledTimes(2));
-    await editor.fill("saved contents\n");
+    await replaceEditorContents(editor, "saved contents\n");
     pressKeyboardSave(editor.element());
     await vi.waitFor(() => expect(writeFile).toHaveBeenCalledTimes(1));
     await vi.waitFor(() =>
@@ -475,8 +503,8 @@ it("keeps a successful save when an older watcher read resolves afterwards", asy
     completeRead(loadedFile());
     await pendingRead;
     await vi.waitFor(() => expect(queryClient.isFetching()).toBe(0));
-    await expect.element(editor).toHaveTextContent("saved contents\n");
-    await editor.fill("next saved contents\n");
+    await expect.element(editor).toHaveTextContent("saved contents");
+    await replaceEditorContents(editor, "next saved contents\n");
     pressKeyboardSave(editor.element());
     await vi.waitFor(() =>
       expect(writeFile).toHaveBeenNthCalledWith(2, {
@@ -492,5 +520,70 @@ it("keeps a successful save when an older watcher read resolves afterwards", asy
     completeRead(loadedFile());
     queryClient.clear();
     restoreNativeApi();
+  }
+});
+
+it("preserves unsaved Markdown edits across Preview and Source", async () => {
+  const readFile = vi
+    .fn()
+    .mockResolvedValue(loadedFile({ relativePath: "README.md", contents: "original\n" }));
+  const writeFile = vi
+    .fn()
+    .mockResolvedValue({ relativePath: "README.md", version: SAVED_VERSION });
+  const restore = installNativeApi({ projects: { readFile, writeFile } } as unknown as NativeApi);
+  try {
+    await render(
+      <StrictMode>
+        <QueryClientProvider client={makeQueryClient()}>
+          <WorkspaceFilePreview workspaceRoot={WORKSPACE_ROOT} filePath="README.md" editable />
+        </QueryClientProvider>
+      </StrictMode>,
+    );
+    const editor = page.getByRole("textbox", { name: "Edit README.md" });
+    await editor.click();
+    await userEvent.keyboard(shortcut("a") + "unsaved");
+    await expect.element(page.getByRole("status", { name: "Unsaved changes" })).toBeVisible();
+    await expect.element(editor).toHaveTextContent("unsaved");
+    await page.getByRole("radio", { name: "Preview", exact: true }).click();
+    const editorShell = document.querySelector<HTMLElement>(".editor-file-editor__pierre")!;
+    expect(getComputedStyle(editorShell).display).toBe("none");
+    expect(editorShell.getBoundingClientRect().height).toBe(0);
+    await page.getByRole("radio", { name: "Source", exact: true }).click();
+    await expect.element(editor).toHaveTextContent("unsaved");
+  } finally {
+    restore();
+  }
+});
+
+it("preserves edits and focus when a save completes while typing", async () => {
+  let complete!: (v: { relativePath: string; version: string }) => void;
+  const pending = new Promise<{ relativePath: string; version: string }>((r) => (complete = r));
+  const readFile = vi.fn().mockResolvedValue(loadedFile());
+  const writeFile = vi.fn().mockReturnValue(pending);
+  const restore = installNativeApi({ projects: { readFile, writeFile } } as unknown as NativeApi);
+  try {
+    await render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <WorkspaceFilePreview workspaceRoot={WORKSPACE_ROOT} filePath={FILE_PATH} editable />
+      </QueryClientProvider>,
+    );
+    const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
+    await editor.click();
+    await userEvent.keyboard(shortcut("a") + "first");
+    await userEvent.keyboard(shortcut("s"));
+    await vi.waitFor(() => expect(writeFile).toHaveBeenCalledTimes(1));
+    await userEvent.keyboard("second");
+    await expect.element(editor).toHaveTextContent("firstsecond");
+    complete({ relativePath: FILE_PATH, version: SAVED_VERSION });
+    await vi.waitFor(() => expect(document.querySelector('[aria-busy="true"]')).toBeNull());
+    await expect.element(editor).toHaveTextContent("firstsecond");
+    expect(editor.element().getRootNode()).toBeInstanceOf(ShadowRoot);
+    expect((editor.element().getRootNode() as ShadowRoot).activeElement).toBe(editor.element());
+    await userEvent.keyboard(shortcut("z"));
+    await expect.element(editor).not.toHaveTextContent("firstsecond");
+    await userEvent.keyboard(`{${primaryModifier}>}{Shift>}z{/Shift}{/${primaryModifier}}`);
+    await expect.element(editor).toHaveTextContent("firstsecond");
+  } finally {
+    restore();
   }
 });

--- a/apps/web/src/components/WorkspaceFilePreview.editing.browser.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.editing.browser.tsx
@@ -124,7 +124,7 @@ it("tracks dirty state and saves the loaded version with Ctrl+S", async () => {
     );
 
     const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
-    await expect.element(editor).toHaveValue("export const value = 1;\n");
+    await expect.element(editor).toHaveTextContent("export const value = 1;\n");
     await editor.fill("export const value = 2;\n");
     await expect.element(page.getByRole("status", { name: "Unsaved changes" })).toBeVisible();
 
@@ -170,7 +170,7 @@ it("keeps the buffer dirty and shows guarded write failures", async () => {
 
     await expect.element(page.getByRole("alert")).toHaveTextContent(conflictMessage);
     await expect.element(page.getByRole("status", { name: "Unsaved changes" })).toBeVisible();
-    await expect.element(editor).toHaveValue("manual edit\n");
+    await expect.element(editor).toHaveTextContent("manual edit\n");
     expect(writeFile).toHaveBeenCalledTimes(1);
   } finally {
     restoreNativeApi();
@@ -206,7 +206,7 @@ it("revalidates on file events without overwriting a dirty edit buffer", async (
     );
 
     const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
-    await expect.element(editor).toHaveValue("export const value = 1;\n");
+    await expect.element(editor).toHaveTextContent("export const value = 1;\n");
     await editor.fill("manual edit\n");
     await vi.waitFor(() => expect(onFileChange).toHaveBeenCalledTimes(1));
 
@@ -217,7 +217,7 @@ it("revalidates on file events without overwriting a dirty edit buffer", async (
     });
 
     await vi.waitFor(() => expect(readFile).toHaveBeenCalledTimes(2));
-    await expect.element(editor).toHaveValue("manual edit\n");
+    await expect.element(editor).toHaveTextContent("manual edit\n");
     await expect
       .element(page.getByText("This file changed on disk. Your unsaved edits are preserved."))
       .toBeVisible();
@@ -225,7 +225,7 @@ it("revalidates on file events without overwriting a dirty edit buffer", async (
     const reloadButton = document.querySelector<HTMLButtonElement>('[role="alert"] button');
     expect(reloadButton).not.toBeNull();
     reloadButton?.click();
-    await expect.element(editor).toHaveValue("external edit\n");
+    await expect.element(editor).toHaveTextContent("external edit\n");
   } finally {
     restoreNativeApi();
   }
@@ -248,7 +248,7 @@ it("stops revalidation when a kept-mounted preview becomes hidden", async () => 
 
     await expect
       .element(page.getByRole("textbox", { name: `Edit ${FILE_PATH}` }))
-      .toHaveValue("export const value = 1;\n");
+      .toHaveTextContent("export const value = 1;\n");
     await vi.waitFor(() => expect(onFileChange).toHaveBeenCalledTimes(1));
 
     await screen.rerender(
@@ -285,7 +285,7 @@ it("switches the watcher to a workspace path resolved by the file read", async (
 
     await expect
       .element(page.getByRole("textbox", { name: `Edit ${FILE_PATH}` }))
-      .toHaveValue("export const value = 1;\n");
+      .toHaveTextContent("export const value = 1;\n");
     await vi.waitFor(() =>
       expect(onFileChange).toHaveBeenLastCalledWith(
         { cwd: WORKSPACE_ROOT, relativePath: resolvedPath },
@@ -328,7 +328,7 @@ it("preserves dirty edits when reloading the changed disk version fails", async 
     );
 
     const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
-    await expect.element(editor).toHaveValue("export const value = 1;\n");
+    await expect.element(editor).toHaveTextContent("export const value = 1;\n");
     await editor.fill("manual edit\n");
     await vi.waitFor(() => expect(onFileChange).toHaveBeenCalledTimes(1));
     fileChangeSubscription.listener?.({
@@ -342,7 +342,7 @@ it("preserves dirty edits when reloading the changed disk version fails", async 
     await reloadButton.click();
 
     await vi.waitFor(() => expect(readFile).toHaveBeenCalledTimes(3));
-    await expect.element(editor).toHaveValue("manual edit\n");
+    await expect.element(editor).toHaveTextContent("manual edit\n");
     await expect.element(page.getByText("Transient read failure")).toBeVisible();
     await expect.element(page.getByRole("status", { name: "Unsaved changes" })).toBeVisible();
   } finally {
@@ -462,7 +462,7 @@ it("keeps a successful save when an older watcher read resolves afterwards", asy
       </QueryClientProvider>,
     );
     const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
-    await expect.element(editor).toHaveValue("export const value = 1;\n");
+    await expect.element(editor).toHaveTextContent("export const value = 1;\n");
     await vi.waitFor(() => expect(onFileChange).toHaveBeenCalledTimes(1));
     subscription.listener?.({ type: "changed", relativePath: FILE_PATH, mtimeMs: 1 });
     await vi.waitFor(() => expect(readFile).toHaveBeenCalledTimes(2));
@@ -475,7 +475,7 @@ it("keeps a successful save when an older watcher read resolves afterwards", asy
     completeRead(loadedFile());
     await pendingRead;
     await vi.waitFor(() => expect(queryClient.isFetching()).toBe(0));
-    await expect.element(editor).toHaveValue("saved contents\n");
+    await expect.element(editor).toHaveTextContent("saved contents\n");
     await editor.fill("next saved contents\n");
     pressKeyboardSave(editor.element());
     await vi.waitFor(() =>

--- a/apps/web/src/components/WorkspaceFilePreview.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.tsx
@@ -11,6 +11,12 @@ import type {
   ProjectFileLineEnding,
   ProjectReadFileResult,
 } from "@synara/contracts";
+import type { FileContents as PierreFileContents } from "@pierre/diffs";
+import {
+  Editor as PierreEditor,
+  type EditorOptions as PierreEditorOptions,
+} from "@pierre/diffs/edit";
+import { EditProvider, File as PierreFile } from "@pierre/diffs/react";
 import {
   isSupportedLocalImagePath,
   isSupportedLocalPdfPath,
@@ -44,7 +50,11 @@ import {
   getSelectionWithin,
   type ChatFileReference,
 } from "~/lib/chatReferences";
-import { resolveDiffThemeName, type DiffThemeName } from "~/lib/diffRendering";
+import {
+  buildDiffPanelUnsafeCSS,
+  resolveDiffThemeName,
+  type DiffThemeName,
+} from "~/lib/diffRendering";
 import { extractEditorGutterChanges, type EditorGutterChangeRange } from "~/lib/editorGutterDiff";
 import { formatFileCommentRange, type FileCommentSelection } from "~/lib/fileComments";
 import { showFileReferenceContextMenu } from "~/lib/fileReferenceContextMenu";
@@ -258,6 +268,97 @@ function FileContentsView(props: { path: string; contents: string; themeName: Di
         />
       </Suspense>
     </FilePreviewHighlightErrorBoundary>
+  );
+}
+
+function createPierreEditor(options: PierreEditorOptions<undefined>) {
+  return new PierreEditor(options);
+}
+
+function PierreEditableFileContents(props: {
+  path: string;
+  initialContents: string;
+  cacheKey: string;
+  themeName: DiffThemeName;
+  theme: "light" | "dark";
+  saving: boolean;
+  invalid: boolean;
+  onContentsChange: (contents: string) => void;
+  onSave: () => void;
+}) {
+  const editorContainerRef = useRef<HTMLDivElement>(null);
+  const file = useMemo<PierreFileContents>(
+    () => ({
+      name: props.path,
+      contents: props.initialContents,
+      lang: getSyntaxLanguageForPath(props.path),
+      cacheKey: props.cacheKey,
+    }),
+    [props.cacheKey, props.initialContents, props.path],
+  );
+  const editorOptions = useMemo<PierreEditorOptions<undefined>>(
+    () => ({
+      onChange: (nextFile) => props.onContentsChange(nextFile.contents),
+    }),
+    [props.onContentsChange],
+  );
+
+  useEffect(() => {
+    const container = editorContainerRef.current;
+    if (!container) return;
+
+    let shadowObserver: MutationObserver | null = null;
+    const labelEditor = () => {
+      const host = container.querySelector("diffs-container");
+      const shadowRoot = host?.shadowRoot;
+      if (!shadowRoot) return;
+      const editor = shadowRoot.querySelector<HTMLElement>('[contenteditable="true"]');
+      if (!editor) {
+        shadowObserver ??= new MutationObserver(labelEditor);
+        shadowObserver.observe(shadowRoot, { childList: true, subtree: true });
+        return;
+      }
+      editor.setAttribute("aria-label", `Edit ${props.path}`);
+      editor.setAttribute("spellcheck", "false");
+    };
+
+    const containerObserver = new MutationObserver(labelEditor);
+    containerObserver.observe(container, { childList: true, subtree: true });
+    labelEditor();
+    return () => {
+      containerObserver.disconnect();
+      shadowObserver?.disconnect();
+    };
+  }, [props.path]);
+
+  return (
+    <div
+      ref={editorContainerRef}
+      className="editor-file-editor__pierre"
+      aria-busy={props.saving}
+      aria-invalid={props.invalid ? "true" : undefined}
+      onKeyDown={(event) => {
+        if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
+          event.preventDefault();
+          props.onSave();
+        }
+      }}
+    >
+      <EditProvider createEditor={createPierreEditor}>
+        <PierreFile
+          file={file}
+          edit
+          editorOptions={editorOptions}
+          options={{
+            disableFileHeader: true,
+            overflow: "scroll",
+            preferredHighlighter: "shiki-js",
+            theme: props.themeName,
+            unsafeCSS: buildDiffPanelUnsafeCSS(props.theme),
+          }}
+        />
+      </EditProvider>
+    </div>
   );
 }
 
@@ -1111,21 +1212,18 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
       ) : !hasFileContents ? (
         <FilePreviewLoadingState />
       ) : activeEditBuffer && editableDocument && !showMarkdownPreview ? (
-        <textarea
-          className="editor-file-editor"
-          aria-label={`Edit ${filePath}`}
-          aria-busy={activeEditBuffer.saving}
-          aria-invalid={activeEditBuffer.error ? "true" : undefined}
-          value={activeEditBuffer.contents}
-          spellCheck={false}
-          autoCapitalize="off"
-          autoCorrect="off"
-          onChange={(event) => handleEditBufferChange(event.currentTarget.value)}
-          onKeyDown={(event) => {
-            if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
-              event.preventDefault();
-              void handleEditBufferSave();
-            }
+        <PierreEditableFileContents
+          key={`${activeEditBuffer.key}:${activeEditBuffer.version}`}
+          path={filePath}
+          initialContents={activeEditBuffer.savedContents}
+          cacheKey={`${activeEditBuffer.key}:${activeEditBuffer.version}`}
+          themeName={diffThemeName}
+          theme={resolvedTheme}
+          saving={activeEditBuffer.saving}
+          invalid={activeEditBuffer.error !== null}
+          onContentsChange={handleEditBufferChange}
+          onSave={() => {
+            void handleEditBufferSave();
           }}
         />
       ) : (

--- a/apps/web/src/components/WorkspaceFilePreview.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.tsx
@@ -37,6 +37,8 @@ import {
   use,
   useCallback,
   useEffect,
+  useInsertionEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -277,8 +279,9 @@ function createPierreEditor(options: PierreEditorOptions<undefined>) {
 
 function PierreEditableFileContents(props: {
   path: string;
-  initialContents: string;
+  contents: string;
   cacheKey: string;
+  hidden: boolean;
   themeName: DiffThemeName;
   theme: "light" | "dark";
   saving: boolean;
@@ -287,54 +290,66 @@ function PierreEditableFileContents(props: {
   onSave: () => void;
 }) {
   const editorContainerRef = useRef<HTMLDivElement>(null);
+  const editorId = useId();
+  const labelEditor = useCallback(() => {
+    editorContainerRef.current
+      ?.querySelector("diffs-container")
+      ?.shadowRoot?.querySelector<HTMLElement>('[contenteditable="true"]')
+      ?.setAttribute("aria-label", `Edit ${props.path}`);
+  }, [props.path]);
+  const editorObserverRef = useRef<MutationObserver | null>(null);
+  const attachEditor = useCallback(() => {
+    const shadowRoot = editorContainerRef.current?.querySelector("diffs-container")?.shadowRoot;
+    if (!shadowRoot) return;
+    labelEditor();
+    if (editorObserverRef.current === null) {
+      editorObserverRef.current = new MutationObserver(labelEditor);
+    }
+    editorObserverRef.current.observe(shadowRoot, { childList: true, subtree: true });
+  }, [labelEditor]);
+  useEffect(() => {
+    attachEditor();
+    return () => {
+      editorObserverRef.current?.disconnect();
+      editorObserverRef.current = null;
+    };
+  }, [attachEditor]);
+  // Local typing updates this snapshot in the same batch as the parent draft.
+  // Only a different incoming document (reload/watcher) resets Pierre's history.
+  const [document, setDocument] = useState({ contents: props.contents, revision: 0 });
+  if (document.contents !== props.contents) {
+    setDocument({ contents: props.contents, revision: document.revision + 1 });
+  }
+  const onContentsChangeRef = useRef(props.onContentsChange);
+  useInsertionEffect(() => {
+    onContentsChangeRef.current = props.onContentsChange;
+  });
   const file = useMemo<PierreFileContents>(
     () => ({
       name: props.path,
-      contents: props.initialContents,
+      contents: document.contents,
       lang: getSyntaxLanguageForPath(props.path),
-      cacheKey: props.cacheKey,
+      cacheKey: `${props.cacheKey}:${editorId}:${document.revision}`,
     }),
-    [props.cacheKey, props.initialContents, props.path],
+    [document.contents, document.revision, editorId, props.cacheKey, props.path],
   );
   const editorOptions = useMemo<PierreEditorOptions<undefined>>(
     () => ({
-      onChange: (nextFile) => props.onContentsChange(nextFile.contents),
+      onAttach: attachEditor,
+      onChange: (nextFile) => {
+        const contents = nextFile.contents;
+        setDocument((current) => ({ ...current, contents }));
+        onContentsChangeRef.current(contents);
+      },
     }),
-    [props.onContentsChange],
+    [attachEditor],
   );
-
-  useEffect(() => {
-    const container = editorContainerRef.current;
-    if (!container) return;
-
-    let shadowObserver: MutationObserver | null = null;
-    const labelEditor = () => {
-      const host = container.querySelector("diffs-container");
-      const shadowRoot = host?.shadowRoot;
-      if (!shadowRoot) return;
-      const editor = shadowRoot.querySelector<HTMLElement>('[contenteditable="true"]');
-      if (!editor) {
-        shadowObserver ??= new MutationObserver(labelEditor);
-        shadowObserver.observe(shadowRoot, { childList: true, subtree: true });
-        return;
-      }
-      editor.setAttribute("aria-label", `Edit ${props.path}`);
-      editor.setAttribute("spellcheck", "false");
-    };
-
-    const containerObserver = new MutationObserver(labelEditor);
-    containerObserver.observe(container, { childList: true, subtree: true });
-    labelEditor();
-    return () => {
-      containerObserver.disconnect();
-      shadowObserver?.disconnect();
-    };
-  }, [props.path]);
 
   return (
     <div
       ref={editorContainerRef}
       className="editor-file-editor__pierre"
+      hidden={props.hidden}
       aria-busy={props.saving}
       aria-invalid={props.invalid ? "true" : undefined}
       onKeyDown={(event) => {
@@ -1211,115 +1226,125 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
         </PanelStateMessage>
       ) : !hasFileContents ? (
         <FilePreviewLoadingState />
-      ) : activeEditBuffer && editableDocument && !showMarkdownPreview ? (
-        <PierreEditableFileContents
-          key={`${activeEditBuffer.key}:${activeEditBuffer.version}`}
-          path={filePath}
-          initialContents={activeEditBuffer.savedContents}
-          cacheKey={`${activeEditBuffer.key}:${activeEditBuffer.version}`}
-          themeName={diffThemeName}
-          theme={resolvedTheme}
-          saving={activeEditBuffer.saving}
-          invalid={activeEditBuffer.error !== null}
-          onContentsChange={handleEditBufferChange}
-          onSave={() => {
-            void handleEditBufferSave();
-          }}
-        />
       ) : (
-        <div
-          ref={contentsRef}
-          className={cn(
-            "editor-file-viewer min-h-0 flex-1 overflow-auto",
-            showMarkdownPreview && "editor-file-viewer--markdown-preview",
-          )}
-          onContextMenu={handleContentsContextMenu}
-          onMouseUp={previewSelectionAction.onContainerMouseUp}
-          onMouseMove={lineCommenting.onContainerMouseMove}
-          onMouseLeave={lineCommenting.onContainerMouseLeave}
-        >
-          {showMarkdownPreview ? (
-            <div className="editor-markdown-preview">
-              <ChatMarkdown
-                text={displayedFileContents}
-                cwd={markdownPreviewCwd(props.workspaceRoot, filePath)}
-                wikiLinkRoot={props.workspaceRoot ?? undefined}
-                isStreaming={false}
-                className="editor-markdown-preview__body text-sm leading-relaxed"
-                {...(canToggleTasks ? { onTaskToggle: handleTaskToggle } : {})}
-              />
-            </div>
-          ) : (
-            <FileContentsView path={filePath} contents={fileContents} themeName={diffThemeName} />
-          )}
-          {!showMarkdownPreview && changeRanges.length > 0 ? (
-            <FilePreviewChangeGutter ranges={changeRanges} subtle={changeGutterSubtle} />
-          ) : null}
-          {!showMarkdownPreview && lineCount > 0 ? (
-            <span className="sr-only">{lineCount} lines</span>
-          ) : null}
-          {previewSelectionAction.pendingAction ? (
-            <TranscriptSelectionAction
-              left={previewSelectionAction.pendingAction.left}
-              top={previewSelectionAction.pendingAction.top}
-              placement={previewSelectionAction.pendingAction.placement}
-              onAddToChat={previewSelectionAction.commit}
+        <>
+          {activeEditBuffer && editableDocument ? (
+            <PierreEditableFileContents
+              key={activeEditBuffer.key}
+              path={filePath}
+              contents={activeEditBuffer.contents}
+              cacheKey={activeEditBuffer.key}
+              hidden={showMarkdownPreview}
+              themeName={diffThemeName}
+              theme={resolvedTheme}
+              saving={activeEditBuffer.saving}
+              invalid={activeEditBuffer.error !== null}
+              onContentsChange={handleEditBufferChange}
+              onSave={() => {
+                void handleEditBufferSave();
+              }}
             />
           ) : null}
-          {lineCommentingEnabled && hoveredCommentLine && !activeCommentLine ? (
-            <button
-              type="button"
-              className="editor-file-viewer__comment-add"
-              style={{
-                top: hoveredCommentLine.top,
-                left: hoveredCommentLine.left,
-                height: hoveredCommentLine.height,
-              }}
-              aria-label={`Comment on line ${hoveredCommentLine.lineNumber}`}
-              title="Comment"
-              onMouseDown={(event) => event.preventDefault()}
-              onClick={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                lineCommenting.openComment(hoveredCommentLine);
-              }}
+          {!activeEditBuffer || !editableDocument || showMarkdownPreview ? (
+            <div
+              ref={contentsRef}
+              className={cn(
+                "editor-file-viewer min-h-0 flex-1 overflow-auto",
+                showMarkdownPreview && "editor-file-viewer--markdown-preview",
+              )}
+              onContextMenu={handleContentsContextMenu}
+              onMouseUp={previewSelectionAction.onContainerMouseUp}
+              onMouseMove={lineCommenting.onContainerMouseMove}
+              onMouseLeave={lineCommenting.onContainerMouseLeave}
             >
-              <span className="editor-file-viewer__comment-add-glyph">
-                <PlusIcon className="size-3.5" />
-              </span>
-            </button>
+              {showMarkdownPreview ? (
+                <div className="editor-markdown-preview">
+                  <ChatMarkdown
+                    text={displayedFileContents}
+                    cwd={markdownPreviewCwd(props.workspaceRoot, filePath)}
+                    wikiLinkRoot={props.workspaceRoot ?? undefined}
+                    isStreaming={false}
+                    className="editor-markdown-preview__body text-sm leading-relaxed"
+                    {...(canToggleTasks ? { onTaskToggle: handleTaskToggle } : {})}
+                  />
+                </div>
+              ) : (
+                <FileContentsView
+                  path={filePath}
+                  contents={fileContents}
+                  themeName={diffThemeName}
+                />
+              )}
+              {!showMarkdownPreview && changeRanges.length > 0 ? (
+                <FilePreviewChangeGutter ranges={changeRanges} subtle={changeGutterSubtle} />
+              ) : null}
+              {!showMarkdownPreview && lineCount > 0 ? (
+                <span className="sr-only">{lineCount} lines</span>
+              ) : null}
+              {previewSelectionAction.pendingAction ? (
+                <TranscriptSelectionAction
+                  left={previewSelectionAction.pendingAction.left}
+                  top={previewSelectionAction.pendingAction.top}
+                  placement={previewSelectionAction.pendingAction.placement}
+                  onAddToChat={previewSelectionAction.commit}
+                />
+              ) : null}
+              {lineCommentingEnabled && hoveredCommentLine && !activeCommentLine ? (
+                <button
+                  type="button"
+                  className="editor-file-viewer__comment-add"
+                  style={{
+                    top: hoveredCommentLine.top,
+                    left: hoveredCommentLine.left,
+                    height: hoveredCommentLine.height,
+                  }}
+                  aria-label={`Comment on line ${hoveredCommentLine.lineNumber}`}
+                  title="Comment"
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    lineCommenting.openComment(hoveredCommentLine);
+                  }}
+                >
+                  <span className="editor-file-viewer__comment-add-glyph">
+                    <PlusIcon className="size-3.5" />
+                  </span>
+                </button>
+              ) : null}
+              {lineCommentingEnabled && activeCommentLine ? (
+                <>
+                  <div
+                    className="editor-file-viewer__comment-line-highlight"
+                    style={{ top: activeCommentLine.top, height: activeCommentLine.height }}
+                    aria-hidden="true"
+                  />
+                  <FileLineCommentBox
+                    lineLabel={formatFileCommentRange({
+                      startLine: activeCommentLine.lineNumber,
+                      endLine: activeCommentLine.lineNumber,
+                    })}
+                    top={activeCommentLine.top + activeCommentLine.height}
+                    left={activeCommentLine.left}
+                    width={Math.max(
+                      240,
+                      Math.min(440, activeCommentLine.containerWidth - activeCommentLine.left - 16),
+                    )}
+                    onCancel={lineCommenting.closeComment}
+                    onSubmit={(text) => {
+                      commitLineComment({
+                        startLine: activeCommentLine.lineNumber,
+                        endLine: activeCommentLine.lineNumber,
+                        text,
+                      });
+                      lineCommenting.closeComment();
+                    }}
+                  />
+                </>
+              ) : null}
+            </div>
           ) : null}
-          {lineCommentingEnabled && activeCommentLine ? (
-            <>
-              <div
-                className="editor-file-viewer__comment-line-highlight"
-                style={{ top: activeCommentLine.top, height: activeCommentLine.height }}
-                aria-hidden="true"
-              />
-              <FileLineCommentBox
-                lineLabel={formatFileCommentRange({
-                  startLine: activeCommentLine.lineNumber,
-                  endLine: activeCommentLine.lineNumber,
-                })}
-                top={activeCommentLine.top + activeCommentLine.height}
-                left={activeCommentLine.left}
-                width={Math.max(
-                  240,
-                  Math.min(440, activeCommentLine.containerWidth - activeCommentLine.left - 16),
-                )}
-                onCancel={lineCommenting.closeComment}
-                onSubmit={(text) => {
-                  commitLineComment({
-                    startLine: activeCommentLine.lineNumber,
-                    endLine: activeCommentLine.lineNumber,
-                    text,
-                  });
-                  lineCommenting.closeComment();
-                }}
-              />
-            </>
-          ) : null}
-        </div>
+        </>
       )}
     </div>
   );

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -364,7 +364,8 @@ describe("MessagesTimeline", () => {
     );
     expect(markup).toContain("rounded-[var(--radius-user-message)]");
     expect(markup).toContain("chat-user-message-bubble");
-    expect(markup).toContain("py-2");
+    const bubbleClassName = markup.match(/class="([^"]*chat-user-message-bubble[^"]*)"/)?.[1];
+    expect(bubbleClassName?.split(" ")).toContain("py-3");
     expect(markup).toContain("group-hover:opacity-100");
   });
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1163,6 +1163,24 @@ label:has(> select#reasoning-effort) select {
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ring) 45%, transparent);
 }
 
+.editor-file-editor__pierre {
+  min-height: 0;
+  flex: 1;
+  overflow: auto;
+  background: transparent;
+  color: color-mix(in srgb, var(--foreground) 88%, transparent);
+  font-family: var(--font-chat-code-family);
+  font-size: var(--app-font-size-chat-code, 12px);
+  line-height: 1.65;
+}
+
+.editor-file-editor__pierre > diffs-container {
+  display: block;
+  min-height: 100%;
+  min-width: 100%;
+  width: max-content;
+}
+
 /* Line-number gutter for the read-only file preview. Rendered via CSS counters
    on the per-line spans (Shiki and the plain fallback both emit .line), so the
    numbers stay out of text selection, clipboard copies, and the selection


### PR DESCRIPTION
## Summary
- replace editable workspace file textarea with Pierre editor
- preserve syntax highlighting, dirty state, guarded saves, reloads, and Ctrl/Cmd+S
- update browser editor assertions for contenteditable behavior

## Verification
- `bun run --cwd apps/web test`
- `bun run --cwd apps/web typecheck`
- `git diff --check`
