### PR TITLE
Render Cursor ACP Task calls as active subagent runs

### DIFF
--- a/apps/server/src/provider/acp/AcpAdapterSupport.test.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSupport.test.ts
@@ -15,10 +15,9 @@ import {
 describe("AcpAdapterSupport", () => {
   it("maps every ACP tool kind to its canonical runtime item type", () => {
     expect(
-      ["execute", "edit", "delete", "move", "fetch", "search", "read", undefined].map((kind) => [
-        kind,
-        canonicalItemTypeFromAcpToolKind(kind),
-      ]),
+      ["execute", "edit", "delete", "move", "fetch", "search", "read", "agent", undefined].map(
+        (kind) => [kind, canonicalItemTypeFromAcpToolKind(kind)],
+      ),
     ).toEqual([
       ["execute", "command_execution"],
       ["edit", "file_change"],
@@ -27,6 +26,7 @@ describe("AcpAdapterSupport", () => {
       ["fetch", "web_search"],
       ["search", "dynamic_tool_call"],
       ["read", "dynamic_tool_call"],
+      ["agent", "collab_agent_tool_call"],
       [undefined, "dynamic_tool_call"],
     ]);
   });

--- a/apps/server/src/provider/acp/AcpAdapterSupport.ts
+++ b/apps/server/src/provider/acp/AcpAdapterSupport.ts
@@ -16,8 +16,16 @@ import * as AcpErrors from "./AcpErrors.ts";
 
 import { ProviderAdapterRequestError, type ProviderAdapterError } from "../Errors.ts";
 
+// Synara-internal ACP tool kind for provider-native subagent runs. ACP's ToolKind has
+// no subagent variant (Cursor sends `kind: "other"` + `rawInput._toolName: "task"`), so
+// the runtime model tags detected subagent calls with this kind to reach the shared
+// collab_agent_tool_call presentation (agent icon, prompt preview, subagent live meta).
+export const ACP_SUBAGENT_TOOL_KIND = "agent";
+
 export function canonicalItemTypeFromAcpToolKind(kind: string | undefined): ToolLifecycleItemType {
   switch (kind) {
+    case ACP_SUBAGENT_TOOL_KIND:
+      return "collab_agent_tool_call";
     case "execute":
       return "command_execution";
     case "edit":

--- a/apps/server/src/provider/acp/AcpRuntimeModel.test.ts
+++ b/apps/server/src/provider/acp/AcpRuntimeModel.test.ts
@@ -368,6 +368,69 @@ describe("AcpRuntimeModel", () => {
     }
   });
 
+  it("projects Cursor subagent Task tool calls as collab agent runs titled by description", () => {
+    const started = parseSessionUpdateEvent({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "toolu_task",
+        title: "Task: Explore composer model/effort UI",
+        kind: "other",
+        status: "pending",
+        rawInput: {
+          _toolName: "task",
+          prompt: "Explore the composer and report back with file paths.",
+          description: "Explore composer model/effort UI",
+          subagentType: { unspecified: {} },
+        },
+      },
+    } satisfies Acp.SessionNotification);
+    const startedEvent = started.events[0];
+    expect(startedEvent?._tag).toBe("ToolCallUpdated");
+    if (startedEvent?._tag !== "ToolCallUpdated") return;
+    expect(startedEvent.toolCall).toEqual({
+      toolCallId: "toolu_task",
+      kind: "agent",
+      title: "Explore composer model/effort UI",
+      status: "pending",
+      data: {
+        toolCallId: "toolu_task",
+        kind: "agent",
+        tool: "task",
+        prompt: "Explore the composer and report back with file paths.",
+        rawInput: {
+          _toolName: "task",
+          prompt: "Explore the composer and report back with file paths.",
+          description: "Explore composer model/effort UI",
+          subagentType: { unspecified: {} },
+        },
+      },
+    });
+
+    // Cursor's completion update carries only bookkeeping output; the merged state
+    // must keep the subagent kind/title and not surface that output as detail.
+    const completed = parseSessionUpdateEvent({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "toolu_task",
+        status: "completed",
+        rawOutput: { durationMs: 328175, isBackground: false },
+      },
+    } satisfies Acp.SessionNotification);
+    const completedEvent = completed.events[0];
+    if (completedEvent?._tag !== "ToolCallUpdated") return;
+    const merged = mergeToolCallState(startedEvent.toolCall, completedEvent.toolCall);
+    expect(merged).toMatchObject({
+      toolCallId: "toolu_task",
+      kind: "agent",
+      status: "completed",
+      title: "Explore composer model/effort UI",
+      data: { tool: "task", kind: "agent" },
+    });
+    expect(merged.detail).toBeUndefined();
+  });
+
   it("trims padded current mode updates before emitting a mode change", () => {
     const result = parseSessionUpdateEvent({
       sessionId: "session-1",

--- a/apps/server/src/provider/acp/AcpRuntimeModel.ts
+++ b/apps/server/src/provider/acp/AcpRuntimeModel.ts
@@ -7,7 +7,7 @@ import type {
 import { summarizeToolRawOutput } from "@synara/shared/toolOutputSummary";
 
 import { computeUsagePercent, nonNegativeInteger, positiveInteger } from "../tokenUsage.ts";
-import { canonicalItemTypeFromAcpToolKind } from "./AcpAdapterSupport.ts";
+import { ACP_SUBAGENT_TOOL_KIND, canonicalItemTypeFromAcpToolKind } from "./AcpAdapterSupport.ts";
 
 type AcpTextStreamKind = Extract<RuntimeContentStreamKind, "assistant_text" | "reasoning_text">;
 
@@ -352,6 +352,36 @@ function inferToolKindFromProviderTitle(title: string | undefined): string | und
   }
 }
 
+interface AcpSubagentToolInput {
+  readonly description?: string;
+  readonly prompt?: string;
+}
+
+const ACP_SUBAGENT_TOOL_NAMES: ReadonlySet<string> = new Set(["task", "agent", "subagent"]);
+
+// Cursor's ACP bridge surfaces its `Task` subagent tool as a generic `other` tool call
+// whose rawInput carries the native tool name plus the task description/prompt. The
+// subagent streams nothing back over ACP until it finishes (only `cursor/task`, a
+// completion-only notification), so this detection is what lets the client render it
+// as a subagent run instead of an idle-looking generic tool.
+function parseSubagentToolInput(rawInput: unknown): AcpSubagentToolInput | undefined {
+  if (!isRecord(rawInput)) {
+    return undefined;
+  }
+  const toolName =
+    typeof rawInput._toolName === "string" ? rawInput._toolName.trim().toLowerCase() : undefined;
+  if (!toolName || !ACP_SUBAGENT_TOOL_NAMES.has(toolName)) {
+    return undefined;
+  }
+  const description =
+    typeof rawInput.description === "string" ? trimNonEmpty(rawInput.description) : undefined;
+  const prompt = typeof rawInput.prompt === "string" ? trimNonEmpty(rawInput.prompt) : undefined;
+  return {
+    ...(description !== undefined ? { description } : {}),
+    ...(prompt !== undefined ? { prompt } : {}),
+  };
+}
+
 function deriveGenericToolActionTitle(
   kind: string | undefined,
   status: "pending" | "inProgress" | "completed" | "failed" | undefined,
@@ -408,14 +438,19 @@ function makeToolCallState(
   if (!toolCallId) {
     return undefined;
   }
-  const title = input.title?.trim() || undefined;
-  const command = extractToolCallCommand(input.rawInput, title);
+  const subagent = parseSubagentToolInput(input.rawInput);
+  // A subagent's own description ("Explore composer UI") is the row heading; the
+  // provider title ("Task: Explore composer UI") is only the fallback.
+  const title = subagent?.description ?? (input.title?.trim() || undefined);
+  const command = subagent ? undefined : extractToolCallCommand(input.rawInput, title);
   const textContent = extractTextContentFromToolCallContent(input.content);
   const structuredContent = summarizeToolCallContent(input.content);
   const locationDetail = summarizeToolCallLocations(input.locations);
   const outputDetail = summarizeToolRawOutput(input.rawOutput);
   const status = normalizeToolCallStatus(input.status, options?.fallbackStatus);
-  const kind = normalizeToolKind(input.kind) ?? inferToolKindFromProviderTitle(title);
+  const kind = subagent
+    ? ACP_SUBAGENT_TOOL_KIND
+    : (normalizeToolKind(input.kind) ?? inferToolKindFromProviderTitle(title));
   const normalizedTitle =
     title && title.toLowerCase() !== "terminal" && title.toLowerCase() !== "tool call"
       ? title
@@ -423,6 +458,13 @@ function makeToolCallState(
   const data: Record<string, unknown> = { toolCallId };
   if (kind) {
     data.kind = kind;
+  }
+  if (subagent) {
+    // Shape read by the web collab-action extractor (`item.tool` / `item.prompt`).
+    data.tool = "task";
+    if (subagent.prompt) {
+      data.prompt = subagent.prompt;
+    }
   }
   if (command) {
     data.command = command;
@@ -440,20 +482,24 @@ function makeToolCallState(
     data.locations = input.locations;
   }
   const kindSpecificTitleIsGeneric = isProviderGenericToolTitle(title, kind);
+  // A healthy subagent row previews its prompt (from data), not a restated title or
+  // the bookkeeping rawOutput ({ durationMs, isBackground }); failures keep the detail.
   const fallbackDetail =
-    status === "failed"
-      ? (textContent ??
-        outputDetail ??
-        command ??
-        locationDetail ??
-        structuredContent ??
-        (kindSpecificTitleIsGeneric ? undefined : normalizedTitle))
-      : (command ??
-        locationDetail ??
-        structuredContent ??
-        outputDetail ??
-        (kindSpecificTitleIsGeneric ? undefined : normalizedTitle) ??
-        textContent);
+    subagent && status !== "failed"
+      ? undefined
+      : status === "failed"
+        ? (textContent ??
+          outputDetail ??
+          command ??
+          locationDetail ??
+          structuredContent ??
+          (kindSpecificTitleIsGeneric ? undefined : normalizedTitle))
+        : (command ??
+          locationDetail ??
+          structuredContent ??
+          outputDetail ??
+          (kindSpecificTitleIsGeneric ? undefined : normalizedTitle) ??
+          textContent);
   const actionTitle = deriveGenericToolActionTitle(kind, status);
   const hasPresentationSeed =
     title !== undefined ||
@@ -469,7 +515,13 @@ function makeToolCallState(
     ? deriveToolActivityPresentation({
         itemType,
         data,
-        fallbackSummary: actionTitle ?? (itemType === "command_execution" ? "Ran command" : "Tool"),
+        fallbackSummary:
+          actionTitle ??
+          (itemType === "command_execution"
+            ? "Ran command"
+            : itemType === "collab_agent_tool_call"
+              ? "Subagent task"
+              : "Tool"),
         ...(normalizedTitle !== undefined && !kindSpecificTitleIsGeneric
           ? { title: normalizedTitle }
           : actionTitle !== undefined

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -364,7 +364,8 @@ describe("MessagesTimeline", () => {
     );
     expect(markup).toContain("rounded-[var(--radius-user-message)]");
     expect(markup).toContain("chat-user-message-bubble");
-    expect(markup).toContain("py-2");
+    const bubbleClassName = markup.match(/class="([^"]*chat-user-message-bubble[^"]*)"/)?.[1];
+    expect(bubbleClassName?.split(" ")).toContain("py-3");
     expect(markup).toContain("group-hover:opacity-100");
   });
 

--- a/apps/web/src/components/chat/MessagesTimeline.toolDetails.browser.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.toolDetails.browser.tsx
@@ -306,7 +306,7 @@ describe("MessagesTimeline tool details", () => {
       expect(onOpenAgentActivity).toHaveBeenCalledWith("agent-live-activity");
       expect(document.querySelector("[data-tool-details-inline='true']")).toBeNull();
       expect(document.body.textContent ?? "").toContain("Agent task");
-      expect(document.body.textContent ?? "").toContain("Active");
+      expect(document.body.textContent ?? "").toContain("Subagent working");
     } finally {
       await screen.unmount();
       host.remove();

--- a/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
+++ b/apps/web/src/components/chat/TimelineWorkEntryRow.tsx
@@ -557,7 +557,9 @@ export const TimelineWorkEntryRow = memo(function TimelineWorkEntryRow(props: {
   );
   const liveActivityNowMs = useLiveActivityNow(workEntry.liveActivity);
   const liveActivityMetaText = workEntry.liveActivity
-    ? formatLiveActivityMeta(workEntry.liveActivity, liveActivityNowMs)
+    ? formatLiveActivityMeta(workEntry.liveActivity, liveActivityNowMs, {
+        subagent: workEntry.itemType === "collab_agent_tool_call",
+      })
     : null;
 
   // A created-automation row renders as its own card instead of a tool-call line.

--- a/apps/web/src/lib/liveActivityPresentation.test.ts
+++ b/apps/web/src/lib/liveActivityPresentation.test.ts
@@ -43,6 +43,32 @@ describe("live activity presentation", () => {
     ).toBe("No activity for 30s · 2m 14s elapsed");
   });
 
+  it("never reports a quiet subagent as idle while it is still running", () => {
+    const quietSubagent: WorkLogLiveActivity = {
+      state: "running_tool",
+      label: "Explore composer model/effort UI",
+      startedAt: STARTED_AT,
+      lastActivityAt: "2026-07-26T14:00:00.100Z",
+    };
+    const nowMs = Date.parse("2026-07-26T14:04:55.000Z");
+
+    expect(formatLiveActivityMeta(quietSubagent, nowMs, { subagent: true })).toBe(
+      "Subagent working · 4m 55s elapsed",
+    );
+    // Same activity without the subagent hint keeps the generic idle wording.
+    expect(formatLiveActivityMeta(quietSubagent, nowMs)).toBe(
+      "No activity for 4m 54s · 4m 55s elapsed",
+    );
+    // Terminal states are unaffected by the hint.
+    expect(
+      formatLiveActivityMeta(
+        { ...quietSubagent, state: "failed", lastActivityAt: "2026-07-26T14:04:55.000Z" },
+        nowMs,
+        { subagent: true },
+      ),
+    ).toBe("Failed · 4m 55s elapsed");
+  });
+
   it("keeps progress and terminal states provider-agnostic", () => {
     const completed = runningActivity({
       state: "completed",

--- a/apps/web/src/lib/liveActivityPresentation.ts
+++ b/apps/web/src/lib/liveActivityPresentation.ts
@@ -131,6 +131,12 @@ export function formatLiveActivityElapsed(
   return elapsedMs === null ? null : formatClockDuration(elapsedMs);
 }
 
+export interface LiveActivityMetaOptions {
+  // Subagent rows (Cursor/Claude `Task`, Codex collab) only hear back from the child
+  // agent when it finishes, so quiet time is the expected state — never idleness.
+  readonly subagent?: boolean;
+}
+
 // Live meta only exists to explain work the row can't state on its own: how long
 // something in flight has been running, or that it ended badly. A tool call that
 // simply succeeded already reads as a finished sentence ("Searched for foo in
@@ -138,6 +144,7 @@ export function formatLiveActivityElapsed(
 export function formatLiveActivityMeta(
   activity: WorkLogLiveActivity,
   nowMs: number,
+  options?: LiveActivityMetaOptions,
 ): string | null {
   if (activity.state === "completed") {
     return null;
@@ -148,7 +155,9 @@ export function formatLiveActivityMeta(
   const lastActivityAtMs = parseTimestamp(activity.lastActivityAt);
 
   if (isLiveActivityInProgress(activity)) {
-    if (lastActivityAtMs !== null) {
+    if (options?.subagent) {
+      parts.push("Subagent working");
+    } else if (lastActivityAtMs !== null) {
       const idleMs = Math.max(0, nowMs - lastActivityAtMs);
       parts.push(
         idleMs >= NO_ACTIVITY_THRESHOLD_MS

--- a/apps/web/src/workLog.test.ts
+++ b/apps/web/src/workLog.test.ts
@@ -3504,6 +3504,50 @@ describe("deriveWorkLogEntries", () => {
     expect(deriveWorkLogEntries(activities, undefined)[0]?.detail).toBeUndefined();
   });
 
+  it("renders Cursor ACP subagent task rows with the description heading and prompt", () => {
+    // Shape emitted by AcpRuntimeModel for Cursor's `Task` tool (kind "agent").
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "cursor-task-start",
+        createdAt: "2026-09-10T21:26:57.180Z",
+        kind: "tool.started",
+        summary: "Explore composer model/effort UI",
+        payload: {
+          itemType: "collab_agent_tool_call",
+          status: "inProgress",
+          title: "Explore composer model/effort UI",
+          data: {
+            toolCallId: "toolu_012fsSN5hrdndPjxoWQjZswu",
+            kind: "agent",
+            tool: "task",
+            prompt: "Explore the Synara web app and report back with file paths.",
+            rawInput: {
+              _toolName: "task",
+              description: "Explore composer model/effort UI",
+              prompt: "Explore the Synara web app and report back with file paths.",
+            },
+          },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+    expect(entries).toEqual([
+      expect.objectContaining({
+        itemType: "collab_agent_tool_call",
+        toolCallId: "toolu_012fsSN5hrdndPjxoWQjZswu",
+        toolTitle: "Explore composer model/effort UI",
+        subagentAction: expect.objectContaining({
+          tool: "task",
+          prompt: "Explore the Synara web app and report back with file paths.",
+        }),
+        liveActivity: expect.objectContaining({ state: "running_tool" }),
+      }),
+    ]);
+    expect(entries[0]?.subagents).toBeUndefined();
+    expect(entries[0]?.detail).toBeUndefined();
+  });
+
   it("uses completed generic agent task output instead of truncated task wrapper text", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({


### PR DESCRIPTION
## What Changed

- Detect Cursor ACP `Task`, `agent`, and `subagent` tool calls from their raw input.
- Project them as `collab_agent_tool_call` items with the task description as the title and the prompt as preview data.
- Preserve subagent metadata when completion updates contain only bookkeeping output.
- Display quiet in-progress subagents as “Subagent working” instead of reporting them as idle.
- Add regression coverage for ACP mapping, runtime projection, work-log entries, and live activity presentation.

## Why

Cursor reports subagent tasks through generic ACP tool calls and may provide no intermediate activity until the child agent completes. These calls previously appeared as generic or inactive work, making active subagent runs look stalled. This change maps them into the existing shared subagent presentation and keeps their status accurate during quiet periods.

## UI Changes

- Updated work-log rows for Cursor ACP subagent tasks to use the subagent presentation, including the description heading, prompt preview, and active “Subagent working” status.
- No screenshots or video were provided.

## Verification

- Added focused regression tests covering Cursor ACP task-call parsing and merging.
- Added focused tests covering work-log projection and live activity metadata.
- Test execution was not reported in the provided change context.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ACP tool-call classification and merge rules for Cursor subagents, which could mislabel non-subagent `other` tools if detection heuristics are too broad; UI impact is limited to work-log/live-activity presentation.
> 
> **Overview**
> Cursor’s ACP bridge exposes **Task** / subagent runs as generic `other` tool calls with little or no mid-run activity. This PR **detects** those calls from `rawInput` (`_toolName`: `task`, `agent`, `subagent`) and **reclassifies** them as Synara’s internal **`agent`** kind → **`collab_agent_tool_call`**, using the task **description** as the row title and **prompt** in tool data for the existing subagent UI.
> 
> On the server, completion updates that only carry bookkeeping `rawOutput` no longer overwrite subagent presentation or leak that output as row detail. On the web, in-progress **`collab_agent_tool_call`** rows show **“Subagent working”** (with elapsed time) instead of idle “no activity” copy when the child agent is quiet.
> 
> Regression tests cover ACP kind mapping, runtime parse/merge, work-log projection, and live-activity formatting. A small user-bubble test assertion was updated to expect **`py-3`** padding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d08c1ced55a229f983ec8c04b9bbf39464f2f19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->