### PR TITLE
Add slider-based composer effort control

### DIFF
--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -328,7 +328,7 @@ export const AppSettingsSchema = Schema.Struct({
   enableAssistantStreaming: Schema.Boolean.pipe(withDefaults(() => true)),
   // Started threads: show reasoning effort as a stepped slider card in the composer's
   // model menu instead of radio rows. New chats keep the split model/effort pickers.
-  composerEffortSlider: Schema.Boolean.pipe(withDefaults(() => false)),
+  composerEffortSlider: Schema.Boolean.pipe(withDefaults(() => true)),
   autoOpenDevicePane: Schema.Boolean.pipe(withDefaults(() => true)),
   enableProviderUpdateChecks: Schema.Boolean.pipe(withDefaults(() => true)),
   enableNativeFontSmoothing: Schema.Boolean.pipe(withDefaults(getDefaultNativeFontSmoothing)),

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -326,6 +326,9 @@ export const AppSettingsSchema = Schema.Struct({
   showEnvironmentNotepad: Schema.Boolean.pipe(withDefaults(() => false)),
   followUpBehavior: FollowUpBehavior.pipe(withDefaults(() => DEFAULT_FOLLOW_UP_BEHAVIOR)),
   enableAssistantStreaming: Schema.Boolean.pipe(withDefaults(() => true)),
+  // Started threads: show reasoning effort as a stepped slider card in the composer's
+  // model menu instead of radio rows. New chats keep the split model/effort pickers.
+  composerEffortSlider: Schema.Boolean.pipe(withDefaults(() => false)),
   autoOpenDevicePane: Schema.Boolean.pipe(withDefaults(() => true)),
   enableProviderUpdateChecks: Schema.Boolean.pipe(withDefaults(() => true)),
   enableNativeFontSmoothing: Schema.Boolean.pipe(withDefaults(getDefaultNativeFontSmoothing)),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -10239,6 +10239,7 @@ export default function ChatView({
       compact={isComposerFooterCompact}
       hideModelLabel={!composerFooterControlsPlan.showModelLabel}
       hideStatusLabel={!composerFooterControlsPlan.showTraitsLabel}
+      effortControl={settings.composerEffortSlider ? "slider" : "menu"}
       provider={selectedProvider}
       model={selectedModelForPickerWithCustomFallback}
       lockedProvider={lockedProvider}

--- a/apps/web/src/components/SpaceSwitcher.tsx
+++ b/apps/web/src/components/SpaceSwitcher.tsx
@@ -33,7 +33,7 @@ import {
   type VoidSpacePresentation,
 } from "~/lib/spaceGrouping";
 import { cn } from "~/lib/utils";
-import { PencilIcon, PlusIcon, RotateCcwIcon, Trash2 } from "~/lib/icons";
+import { PencilIcon, PlusIcon, ResetIcon, Trash2 } from "~/lib/icons";
 import { SIDEBAR_SECTION_LABEL_CLASS_NAME } from "~/sidebarRowStyles";
 import { SpaceIcon, type SpaceIconValue } from "./SpaceIcon";
 import { ComposerPickerMenuPopup } from "./chat/ComposerPickerMenuPopup";
@@ -683,7 +683,7 @@ function SpaceSwitcherStrip(props: SpaceSwitcherProps) {
                     props.onResetVoid();
                   }}
                 >
-                  <SidebarContextMenuIcon icon={RotateCcwIcon} />
+                  <SidebarContextMenuIcon icon={ResetIcon} />
                   <span>Reset to {DEFAULT_VOID_SPACE.name}</span>
                 </MenuItem>
               ) : null}

--- a/apps/web/src/components/chat/ComposerEffortSliderCard.tsx
+++ b/apps/web/src/components/chat/ComposerEffortSliderCard.tsx
@@ -1,0 +1,171 @@
+// FILE: ComposerEffortSliderCard.tsx
+// Purpose: Slider-style effort control for the combined composer picker (fast toggle,
+//   stacked effort/model label that opens the model list, reset, and a stepped slider).
+// Layer: Chat composer presentation
+// Depends on: shared trait resolution + effort-change planning, the trait commit hook,
+//   the shared Slider primitive, and menu submenu primitives for the model list.
+
+import type { ProviderKind, ProviderModelDescriptor, ThreadId } from "@synara/contracts";
+import type { ReactNode } from "react";
+
+import { ChevronRightIcon, ResetIcon } from "~/lib/icons";
+import { cn } from "~/lib/utils";
+import type { ProviderOptions } from "../../providerModelOptions";
+import { MenuSub, MenuSubTriggerBase } from "../ui/menu";
+import { Slider } from "../ui/slider";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import {
+  getComposerTraitSelection,
+  planComposerEffortChange,
+  resolveComposerEffortLadderIndex,
+  resolveComposerTraitStatusLabel,
+  supportsComposerFastModeControl,
+} from "./composerTraits";
+import { FastModeToggle } from "./TraitsPicker";
+import { useComposerTraitCommit } from "./useComposerTraitCommit";
+
+type ComposerEffortSliderCardProps = {
+  provider: ProviderKind;
+  threadId: ThreadId;
+  model: string | null | undefined;
+  modelLabel: string;
+  runtimeModel?: ProviderModelDescriptor | undefined;
+  modelOptions: ProviderOptions | null | undefined;
+  prompt: string;
+  onPromptChange: (prompt: string) => void;
+  // The model-list submenu popup. Rendered inside this card's MenuSub so the
+  // stacked "effort / model" label is its trigger.
+  modelSubmenuPopup: ReactNode;
+};
+
+const CARD_ICON_BUTTON_CLASS_NAME =
+  "flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-lg transition-colors hover:bg-[color-mix(in_srgb,var(--foreground)_6%,transparent)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--color-border-focus)]/60 disabled:pointer-events-none disabled:opacity-35";
+
+// Effort ladder as a stepped slider. Every level the model exposes is one stop
+// (including prompt-injected ones such as Ultrathink), so the ladder matches the
+// radio menu exactly; changes commit immediately and keep the menu open so the
+// label and thumb update in place.
+export function ComposerEffortSliderCard(props: ComposerEffortSliderCardProps) {
+  const { provider, threadId, model, modelOptions, prompt, onPromptChange } = props;
+  const selection = getComposerTraitSelection(
+    provider,
+    model,
+    prompt,
+    modelOptions,
+    props.runtimeModel,
+  );
+  const { effortLevels, defaultEffort, effort, fastModeEnabled, ultrathinkPromptControlled } =
+    selection;
+  const supportsFastMode = supportsComposerFastModeControl(selection);
+  const commitTrait = useComposerTraitCommit({ threadId, provider, model, modelOptions });
+
+  const ladderIndex = resolveComposerEffortLadderIndex(selection);
+  const activeLevel = effortLevels[ladderIndex];
+  const statusLabel = resolveComposerTraitStatusLabel(selection) ?? activeLevel?.label ?? "Effort";
+  const effortIsDefault = ultrathinkPromptControlled || effort === defaultEffort;
+  const canReset = fastModeEnabled || !effortIsDefault;
+
+  const handleSliderChange = (nextIndex: number) => {
+    if (nextIndex === ladderIndex) return;
+    const nextLevel = effortLevels[nextIndex];
+    if (!nextLevel) return;
+    const plan = planComposerEffortChange({ provider, selection, prompt, value: nextLevel.value });
+    if (!plan) return;
+    if (plan.kind === "prompt") {
+      onPromptChange(plan.prompt);
+      return;
+    }
+    commitTrait(plan.patch);
+  };
+
+  const handleReset = () => {
+    const effortPlan =
+      defaultEffort && !effortIsDefault
+        ? planComposerEffortChange({ provider, selection, prompt, value: defaultEffort })
+        : null;
+    commitTrait({
+      ...(effortPlan?.kind === "options" ? effortPlan.patch : {}),
+      ...(fastModeEnabled ? { fastMode: false } : {}),
+    });
+  };
+
+  return (
+    <div className="px-1 pt-0.5 pb-1.5" data-slot="effort-slider-card">
+      <div className="grid grid-cols-[1.5rem_minmax(0,1fr)_1.5rem] items-center gap-1">
+        {supportsFastMode ? (
+          <FastModeToggle
+            tone="accent"
+            enabled={fastModeEnabled}
+            onToggle={() => commitTrait({ fastMode: !fastModeEnabled })}
+          />
+        ) : (
+          <span aria-hidden="true" className="size-6" />
+        )}
+        <MenuSub>
+          <MenuSubTriggerBase
+            openOnHover={false}
+            className="flex min-w-0 cursor-default select-none flex-col items-center justify-center rounded-lg px-2 py-0.5 text-center leading-snug outline-none transition-colors data-highlighted:bg-[var(--color-background-button-secondary-hover)] data-popup-open:bg-[var(--color-background-button-secondary-hover)]"
+          >
+            {/* The chevron hangs off the label's right edge so the effort text itself is
+                centered over the model name instead of being pushed left by the glyph. */}
+            <span className="relative inline-block whitespace-nowrap font-medium text-[length:var(--app-font-size-ui,12px)] text-[var(--color-text-accent)]">
+              {statusLabel}
+              <ChevronRightIcon
+                aria-hidden="true"
+                className="absolute top-1/2 left-full ml-0.5 size-3.5 -translate-y-1/2 text-muted-foreground"
+              />
+            </span>
+            <span className="max-w-full truncate text-[length:var(--app-font-size-ui-sm,11px)] text-muted-foreground">
+              {props.modelLabel}
+            </span>
+          </MenuSubTriggerBase>
+          {props.modelSubmenuPopup}
+        </MenuSub>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                aria-label="Reset effort and speed"
+                disabled={!canReset}
+                className={cn(
+                  CARD_ICON_BUTTON_CLASS_NAME,
+                  "text-muted-foreground/70 hover:text-[var(--color-text-foreground)]",
+                )}
+                onClick={handleReset}
+              />
+            }
+          >
+            <ResetIcon aria-hidden="true" className="size-3.5" />
+          </TooltipTrigger>
+          <TooltipPopup side="top" variant="picker">
+            Reset to defaults
+          </TooltipPopup>
+        </Tooltip>
+      </div>
+      <div className="mt-1 px-0.5">
+        <Slider
+          value={ladderIndex}
+          min={0}
+          max={Math.max(effortLevels.length - 1, 0)}
+          step={1}
+          size="large"
+          showStepMarks
+          disabled={ultrathinkPromptControlled}
+          aria-label="Reasoning effort"
+          getAriaValueText={(index) => effortLevels[index]?.label ?? String(index)}
+          onValueChange={handleSliderChange}
+        />
+      </div>
+      {ultrathinkPromptControlled ? (
+        <div className="px-1 pt-1 text-muted-foreground/80 text-xs">
+          Remove Ultrathink from the prompt to change effort.
+        </div>
+      ) : activeLevel?.description ? (
+        <div className="px-1 pt-1 text-center text-muted-foreground/70 text-xs">
+          {activeLevel.description}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/ComposerModelEffortPicker.browser.tsx
+++ b/apps/web/src/components/chat/ComposerModelEffortPicker.browser.tsx
@@ -1,14 +1,205 @@
 import "../../index.css";
 
-import { type ModelSlug, ThreadId } from "@synara/contracts";
-import { page } from "vitest/browser";
-import { describe, expect, it, vi } from "vitest";
+import {
+  type CodexModelOptions,
+  type ModelSlug,
+  type ProviderKind,
+  ThreadId,
+} from "@synara/contracts";
+import { page, userEvent } from "vitest/browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
 
+import {
+  COMPOSER_DRAFT_STORAGE_KEY,
+  type ComposerThreadDraftState,
+  useComposerDraftStore,
+  useComposerThreadDraft,
+  useEffectiveComposerModelState,
+} from "../../composerDraftStore";
+import { type ProviderModelOption } from "../../providerModelOptions";
 import { ComposerModelEffortPicker } from "./ComposerModelEffortPicker";
 
 const THREAD_ID = ThreadId.makeUnsafe("thread-grok-model-effort-picker");
 const GROK_4_6 = "grok-4.6" as ModelSlug;
+
+const EMPTY_MODEL_OPTIONS_BY_PROVIDER: Record<ProviderKind, ReadonlyArray<ProviderModelOption>> = {
+  claudeAgent: [],
+  codex: [],
+  cursor: [],
+  devin: [],
+  antigravity: [],
+  grok: [],
+  droid: [],
+  opencode: [],
+  pi: [],
+};
+
+const EMPTY_CUSTOM_MODELS_BY_PROVIDER: Record<ProviderKind, never[]> = {
+  claudeAgent: [],
+  codex: [],
+  cursor: [],
+  devin: [],
+  antigravity: [],
+  grok: [],
+  droid: [],
+  opencode: [],
+  pi: [],
+};
+
+// ── Slider layout (store-backed) ──────────────────────────────────────
+
+const CODEX_THREAD_ID = ThreadId.makeUnsafe("thread-codex-effort-slider");
+const GPT_5_5 = "gpt-5.5" as ModelSlug;
+
+function CodexSliderHarness() {
+  const prompt = useComposerThreadDraft(CODEX_THREAD_ID).prompt;
+  const setPrompt = useComposerDraftStore((store) => store.setPrompt);
+  const { modelOptions, selectedModel } = useEffectiveComposerModelState({
+    threadId: CODEX_THREAD_ID,
+    selectedProvider: "codex",
+    threadModelSelection: null,
+    projectModelSelection: null,
+    customModelsByProvider: EMPTY_CUSTOM_MODELS_BY_PROVIDER,
+  });
+  return (
+    <ComposerModelEffortPicker
+      provider="codex"
+      model={(selectedModel ?? GPT_5_5) as ModelSlug}
+      // Started threads pin their provider, which also gives the model submenu a
+      // flat model list instead of one submenu per provider.
+      lockedProvider="codex"
+      modelOptionsByProvider={{
+        ...EMPTY_MODEL_OPTIONS_BY_PROVIDER,
+        codex: [{ slug: GPT_5_5, name: "GPT-5.5" }],
+      }}
+      effortControl="slider"
+      onProviderModelChange={vi.fn()}
+      threadId={CODEX_THREAD_ID}
+      modelOptions={modelOptions?.codex}
+      prompt={prompt}
+      onPromptChange={(next) => setPrompt(CODEX_THREAD_ID, next)}
+    />
+  );
+}
+
+async function mountCodexSlider(options?: CodexModelOptions) {
+  const draftsByThreadId: Record<ThreadId, ComposerThreadDraftState> = {
+    [CODEX_THREAD_ID]: {
+      prompt: "",
+      promptHistorySavedDraft: null,
+      images: [],
+      files: [],
+      nonPersistedImageIds: [],
+      persistedAttachments: [],
+      assistantSelections: [],
+      browserAnnotations: [],
+      terminalContexts: [],
+      fileComments: [],
+      pastedTexts: [],
+      pullRequestContexts: [],
+      skills: [],
+      mentions: [],
+      queuedTurns: [],
+      modelSelectionByProvider: {
+        codex: {
+          provider: "codex",
+          model: GPT_5_5,
+          ...(options ? { options } : {}),
+        },
+      },
+      activeProvider: "codex",
+      runtimeMode: null,
+      interactionMode: null,
+    },
+  };
+  useComposerDraftStore.setState({
+    draftsByThreadId,
+    draftThreadsByThreadId: {},
+    projectDraftThreadIdByProjectId: {},
+  });
+  const screen = await render(<CodexSliderHarness />);
+  return {
+    cleanup: async () => {
+      await screen.unmount();
+    },
+  };
+}
+
+describe("ComposerModelEffortPicker (effort slider)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    localStorage.removeItem(COMPOSER_DRAFT_STORAGE_KEY);
+    useComposerDraftStore.setState({
+      draftsByThreadId: {},
+      draftThreadsByThreadId: {},
+      projectDraftThreadIdByProjectId: {},
+      stickyModelSelectionByProvider: {},
+    });
+  });
+
+  it("renders the effort ladder as a slider and commits keyboard steps", async () => {
+    const { cleanup } = await mountCodexSlider({ reasoningEffort: "medium" });
+    try {
+      await page.getByRole("button", { name: "Change model and reasoning" }).click();
+
+      const slider = page.getByRole("slider", { name: "Reasoning effort" });
+      await expect.element(slider).toHaveAttribute("aria-valuetext", "Medium");
+      // Base UI backs the thumb with a native range input: one stop per effort level.
+      await expect.element(slider).toHaveAttribute("max", "3");
+      // Radio rows are gone: the slider owns the ladder.
+      expect(document.body.querySelector('[role="menuitemradio"]')).toBeNull();
+
+      await slider.element().focus();
+      await userEvent.keyboard("{ArrowRight}");
+
+      await expect.element(slider).toHaveAttribute("aria-valuetext", "High");
+      expect(useComposerDraftStore.getState().stickyModelSelectionByProvider.codex).toMatchObject({
+        provider: "codex",
+        options: { reasoningEffort: "high" },
+      });
+      // The stacked label follows the thumb and the menu stays open.
+      await expect.element(page.getByRole("menuitem", { name: /^High/u })).toBeVisible();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("toggles fast mode and resets both controls from the card", async () => {
+    const { cleanup } = await mountCodexSlider({ reasoningEffort: "xhigh" });
+    try {
+      await page.getByRole("button", { name: "Change model and reasoning" }).click();
+
+      const fastToggle = page.getByRole("button", { name: "Fast mode" });
+      await expect.element(fastToggle).toHaveAttribute("aria-pressed", "false");
+      await fastToggle.click();
+      await expect.element(fastToggle).toHaveAttribute("aria-pressed", "true");
+
+      const reset = page.getByRole("button", { name: "Reset effort and speed" });
+      await reset.click();
+
+      const slider = page.getByRole("slider", { name: "Reasoning effort" });
+      await expect.element(slider).toHaveAttribute("aria-valuetext", "Medium");
+      await expect.element(fastToggle).toHaveAttribute("aria-pressed", "false");
+      await expect.element(reset).toBeDisabled();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("opens the model list from the stacked effort/model label", async () => {
+    const { cleanup } = await mountCodexSlider(undefined);
+    try {
+      await page.getByRole("button", { name: "Change model and reasoning" }).click();
+      // The stacked "effort / model" label is the submenu trigger for the model list.
+      await page.getByRole("menuitem", { name: /GPT-5\.5/u }).click();
+
+      await expect.element(page.getByRole("menuitemradio", { name: "GPT-5.5" })).toBeVisible();
+    } finally {
+      await cleanup();
+    }
+  });
+});
 
 describe("ComposerModelEffortPicker", () => {
   it("keeps Grok 4.6 effort visible in compact layouts before runtime discovery", async () => {
@@ -18,15 +209,8 @@ describe("ComposerModelEffortPicker", () => {
         model={GROK_4_6}
         lockedProvider={null}
         modelOptionsByProvider={{
-          claudeAgent: [],
-          codex: [],
-          cursor: [],
-          devin: [],
-          antigravity: [],
+          ...EMPTY_MODEL_OPTIONS_BY_PROVIDER,
           grok: [{ slug: GROK_4_6, name: "Grok 4.6" }],
-          droid: [],
-          opencode: [],
-          pi: [],
         }}
         hideStatusLabel
         onProviderModelChange={vi.fn()}

--- a/apps/web/src/components/chat/ComposerModelEffortPicker.tsx
+++ b/apps/web/src/components/chat/ComposerModelEffortPicker.tsx
@@ -28,6 +28,7 @@ import {
   COMPOSER_PICKER_MODEL_SUBMENU_HEIGHT_CLASS_NAME,
   COMPOSER_PICKER_TRIGGER_TEXT_CLASS_NAME,
 } from "./composerPickerStyles";
+import { ComposerEffortSliderCard } from "./ComposerEffortSliderCard";
 import { ComposerPickerMenuPopup, ComposerPickerMenuSubPopup } from "./ComposerPickerMenuPopup";
 import {
   getComposerTraitSelection,
@@ -40,7 +41,9 @@ import {
   ProviderModelMenuItems,
   resolveProviderModelLabel,
 } from "./ProviderModelPicker";
-import { TraitsMenuContent } from "./TraitsPicker";
+import { hasComposerAgentControls, TraitsMenuContent } from "./TraitsPicker";
+
+export type ComposerEffortControl = "menu" | "slider";
 
 type ComposerModelEffortPickerProps = {
   // Model picker data.
@@ -59,6 +62,10 @@ type ComposerModelEffortPickerProps = {
   hideModelLabel?: boolean;
   hideStatusLabel?: boolean;
   disabled?: boolean;
+  // "menu" (default) lists effort levels as radio rows; "slider" renders the
+  // effort ladder as a stepped slider card with the model list behind its label.
+  // Models without an effort ladder always fall back to the menu layout.
+  effortControl?: ComposerEffortControl;
   onProviderModelChange: (provider: ProviderKind, model: ModelSlug) => void;
   onSelectionCommitted?: () => void;
 
@@ -111,6 +118,16 @@ export function ComposerModelEffortPicker(props: ComposerModelEffortPickerProps)
   );
 
   const hasTraitsTopSection = hasVisibleComposerTraitControls(traitSelection);
+  const usesEffortSlider =
+    props.effortControl === "slider" && traitSelection.effortLevels.length > 0;
+  // Trait sections the slider card does not own (thinking, context window, agent).
+  const hasSliderCompanionTraits =
+    usesEffortSlider &&
+    (hasVisibleComposerTraitControls(traitSelection, {
+      includeEffort: false,
+      includeFastMode: false,
+    }) ||
+      hasComposerAgentControls(props.provider, props.runtimeAgents));
 
   const triggerStatusLabel = resolveComposerTraitStatusLabel(traitSelection);
   const showsFastBadge = showsComposerFastModeBadge(traitSelection);
@@ -186,6 +203,45 @@ export function ComposerModelEffortPicker(props: ComposerModelEffortPickerProps)
     </span>
   );
 
+  // Shared between the radio and slider layouts so both reach the same model list.
+  const modelSubmenuPopup = (
+    <ComposerPickerMenuSubPopup
+      fixedWidth
+      className={COMPOSER_PICKER_MODEL_SUBMENU_HEIGHT_CLASS_NAME}
+    >
+      <ProviderModelMenuItems
+        provider={props.provider}
+        model={props.model}
+        lockedProvider={props.lockedProvider}
+        {...(props.providers ? { providers: props.providers } : {})}
+        modelOptionsByProvider={props.modelOptionsByProvider}
+        {...(props.loadingModelProviders
+          ? { loadingModelProviders: props.loadingModelProviders }
+          : {})}
+        {...(props.discoveryErrorsByProvider
+          ? { discoveryErrorsByProvider: props.discoveryErrorsByProvider }
+          : {})}
+        {...(props.hiddenProviders ? { hiddenProviders: props.hiddenProviders } : {})}
+        {...(props.providerOrder ? { providerOrder: props.providerOrder } : {})}
+        {...(props.disabled !== undefined ? { disabled: props.disabled } : {})}
+        onProviderModelChange={props.onProviderModelChange}
+        onAfterSelection={handleAfterModelSelection}
+      />
+    </ComposerPickerMenuSubPopup>
+  );
+
+  const traitsMenuContentProps = {
+    provider: props.provider,
+    threadId: props.threadId,
+    model: props.model,
+    ...(props.runtimeModel ? { runtimeModel: props.runtimeModel } : {}),
+    ...(props.runtimeModels !== undefined ? { runtimeModels: props.runtimeModels } : {}),
+    ...(props.runtimeAgents !== undefined ? { runtimeAgents: props.runtimeAgents } : {}),
+    modelOptions: props.modelOptions,
+    prompt: props.prompt,
+    onPromptChange: props.onPromptChange,
+  };
+
   return (
     <Menu
       open={isMenuOpen}
@@ -217,56 +273,61 @@ export function ComposerModelEffortPicker(props: ComposerModelEffortPickerProps)
       ) : (
         <MenuTrigger render={triggerButton}>{triggerContent}</MenuTrigger>
       )}
-      <ComposerPickerMenuPopup align="end" side="top" fixedWidth>
-        {hasTraitsTopSection ? (
-          <TraitsMenuContent
-            provider={props.provider}
-            threadId={props.threadId}
-            model={props.model}
-            {...(props.runtimeModel ? { runtimeModel: props.runtimeModel } : {})}
-            {...(props.runtimeModels !== undefined ? { runtimeModels: props.runtimeModels } : {})}
-            {...(props.runtimeAgents !== undefined ? { runtimeAgents: props.runtimeAgents } : {})}
-            modelOptions={props.modelOptions}
-            prompt={props.prompt}
-            onPromptChange={props.onPromptChange}
-            onSelectionComplete={handleAfterTraitsSelection}
-          />
-        ) : null}
-
-        {hasTraitsTopSection ? <MenuSeparator /> : null}
-
-        <MenuSub>
-          <MenuSubTrigger>
-            <ProviderIcon
-              aria-hidden="true"
-              className={cn("size-3 shrink-0", getProviderIconClassName(activeProvider))}
-            />
-            <span className="truncate">{modelLabel}</span>
-          </MenuSubTrigger>
-          <ComposerPickerMenuSubPopup
-            fixedWidth
-            className={COMPOSER_PICKER_MODEL_SUBMENU_HEIGHT_CLASS_NAME}
-          >
-            <ProviderModelMenuItems
+      <ComposerPickerMenuPopup
+        align="end"
+        side="top"
+        {...(usesEffortSlider
+          ? // Standard picker width; rounder shell so the slider reads as a card, not a menu.
+            { fixedWidth: true, className: "rounded-[1.25rem]" }
+          : { fixedWidth: true })}
+      >
+        {usesEffortSlider ? (
+          <>
+            <ComposerEffortSliderCard
               provider={props.provider}
+              threadId={props.threadId}
               model={props.model}
-              lockedProvider={props.lockedProvider}
-              {...(props.providers ? { providers: props.providers } : {})}
-              modelOptionsByProvider={props.modelOptionsByProvider}
-              {...(props.loadingModelProviders
-                ? { loadingModelProviders: props.loadingModelProviders }
-                : {})}
-              {...(props.discoveryErrorsByProvider
-                ? { discoveryErrorsByProvider: props.discoveryErrorsByProvider }
-                : {})}
-              {...(props.hiddenProviders ? { hiddenProviders: props.hiddenProviders } : {})}
-              {...(props.providerOrder ? { providerOrder: props.providerOrder } : {})}
-              {...(props.disabled !== undefined ? { disabled: props.disabled } : {})}
-              onProviderModelChange={props.onProviderModelChange}
-              onAfterSelection={handleAfterModelSelection}
+              modelLabel={modelLabel}
+              {...(props.runtimeModel ? { runtimeModel: props.runtimeModel } : {})}
+              modelOptions={props.modelOptions}
+              prompt={props.prompt}
+              onPromptChange={props.onPromptChange}
+              modelSubmenuPopup={modelSubmenuPopup}
             />
-          </ComposerPickerMenuSubPopup>
-        </MenuSub>
+            {hasSliderCompanionTraits ? (
+              <>
+                <MenuSeparator />
+                <TraitsMenuContent
+                  {...traitsMenuContentProps}
+                  excludeEffort
+                  onSelectionComplete={handleAfterTraitsSelection}
+                />
+              </>
+            ) : null}
+          </>
+        ) : (
+          <>
+            {hasTraitsTopSection ? (
+              <TraitsMenuContent
+                {...traitsMenuContentProps}
+                onSelectionComplete={handleAfterTraitsSelection}
+              />
+            ) : null}
+
+            {hasTraitsTopSection ? <MenuSeparator /> : null}
+
+            <MenuSub>
+              <MenuSubTrigger>
+                <ProviderIcon
+                  aria-hidden="true"
+                  className={cn("size-3 shrink-0", getProviderIconClassName(activeProvider))}
+                />
+                <span className="truncate">{modelLabel}</span>
+              </MenuSubTrigger>
+              {modelSubmenuPopup}
+            </MenuSub>
+          </>
+        )}
       </ComposerPickerMenuPopup>
     </Menu>
   );

--- a/apps/web/src/components/chat/GitPanel.tsx
+++ b/apps/web/src/components/chat/GitPanel.tsx
@@ -28,7 +28,7 @@ import {
   gitUnstageFilesMutationOptions,
   gitWorkingTreeDiffQueryOptions,
 } from "~/lib/gitReactQuery";
-import { PlusIcon, RefreshCwIcon, RotateCcwIcon } from "~/lib/icons";
+import { PlusIcon, RefreshCwIcon, ResetIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
 import { useStore } from "~/store";
 import { createProjectSelector, createThreadSelector } from "~/storeSelectors";
@@ -109,7 +109,7 @@ function GitFileRow(props: {
         {props.actionIcon === "stage" ? (
           <PlusIcon className="size-3.5" />
         ) : (
-          <RotateCcwIcon className="size-3.5" />
+          <ResetIcon className="size-3.5" />
         )}
       </IconButton>
     </div>

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -364,7 +364,8 @@ describe("MessagesTimeline", () => {
     );
     expect(markup).toContain("rounded-[var(--radius-user-message)]");
     expect(markup).toContain("chat-user-message-bubble");
-    expect(markup).toContain("py-2");
+    const bubbleClassName = markup.match(/class="([^"]*chat-user-message-bubble[^"]*)"/)?.[1];
+    expect(bubbleClassName?.split(" ")).toContain("py-3");
     expect(markup).toContain("group-hover:opacity-100");
   });
 

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -10,7 +10,6 @@ import {
   type ProviderModelDescriptor,
   type ThreadId,
 } from "@synara/contracts";
-import { applyClaudePromptEffortPrefix } from "@synara/shared/model";
 import { memo, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { ChevronDownIcon, FastModeIcon, FastModeOutlineIcon, SettingsIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
@@ -24,25 +23,20 @@ import {
   MenuSeparator as MenuDivider,
   MenuTrigger,
 } from "../ui/menu";
-import { useComposerDraftStore } from "../../composerDraftStore";
-import {
-  buildNextProviderOptions,
-  buildProviderOptionPatch,
-  type ProviderOptions,
-} from "../../providerModelOptions";
+import { type ProviderOptions } from "../../providerModelOptions";
 import { COMPOSER_PICKER_TRIGGER_TEXT_CLASS_NAME } from "./composerPickerStyles";
 import { ComposerPickerMenuPopup } from "./ComposerPickerMenuPopup";
 import {
   getComposerTraitSelection,
   hasVisibleComposerTraitControls,
+  planComposerEffortChange,
   resolveComposerTraitStatusLabel,
   showsComposerFastModeBadge,
   supportsComposerFastModeControl,
 } from "./composerTraits";
+import { useComposerTraitCommit } from "./useComposerTraitCommit";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { ShortcutKbd } from "../ui/shortcut-kbd";
-
-const ULTRATHINK_PROMPT_PREFIX = "Ultrathink:\n";
 
 function defaultAgentForProvider(provider: ProviderKind): string | null {
   if (provider === "opencode") return "build";
@@ -65,6 +59,18 @@ function getSelectedAgentValue(
   if (!defaultAgent) return null;
   const selectedAgent = (modelOptions as OpenCodeModelOptions | undefined)?.agent?.trim();
   return selectedAgent && selectedAgent.length > 0 ? selectedAgent : defaultAgent;
+}
+
+// Whether the Agent radio section renders for this provider/runtime pair; lets
+// hosts decide on separators before TraitsMenuContent mounts.
+export function hasComposerAgentControls(
+  provider: ProviderKind,
+  runtimeAgents: ReadonlyArray<ProviderAgentDescriptor> | null | undefined,
+): boolean {
+  return (
+    getAgentOptions(provider, runtimeAgents).length > 0 &&
+    defaultAgentForProvider(provider) !== null
+  );
 }
 
 function findAgentLabel(
@@ -142,11 +148,21 @@ export function resolveTraitsTriggerSummary(options: {
   };
 }
 
-// Compact icon toggle for fast mode, docked at the far right of the Effort
-// section header. Outline zap (Central reversed set) = default speed, filled
-// zap (Central fill set) = fast mode on. Toggling keeps the menu open so the
-// state flip is visible in place.
-function FastModeToggle({ enabled, onToggle }: { enabled: boolean; onToggle: () => void }) {
+// Compact icon toggle for fast mode. Outline zap (Central reversed set) = default
+// speed, filled zap (Central fill set) = fast mode on. Toggling keeps the menu
+// open so the state flip is visible in place. `tone="muted"` docks at the far
+// right of the Effort section header; `tone="accent"` is the slider card's
+// larger, accent-colored variant.
+export function FastModeToggle({
+  enabled,
+  onToggle,
+  tone: toneProp,
+}: {
+  enabled: boolean;
+  onToggle: () => void;
+  tone?: "muted" | "accent";
+}) {
+  const tone = toneProp ?? "muted";
   const Icon = enabled ? FastModeIcon : FastModeOutlineIcon;
   return (
     <Tooltip>
@@ -156,7 +172,10 @@ function FastModeToggle({ enabled, onToggle }: { enabled: boolean; onToggle: () 
             type="button"
             aria-label="Fast mode"
             aria-pressed={enabled}
-            className="-my-1 flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors hover:bg-[color-mix(in_srgb,var(--foreground)_6%,transparent)]"
+            className={cn(
+              "flex shrink-0 cursor-pointer items-center justify-center transition-colors hover:bg-[color-mix(in_srgb,var(--foreground)_6%,transparent)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--color-border-focus)]/60",
+              tone === "accent" ? "size-6 rounded-lg" : "-my-1 size-5 rounded-md",
+            )}
             onClick={onToggle}
           />
         }
@@ -165,7 +184,11 @@ function FastModeToggle({ enabled, onToggle }: { enabled: boolean; onToggle: () 
           aria-hidden="true"
           className={cn(
             "size-3.5",
-            enabled ? "text-[hsl(var(--chart-4))]" : "text-muted-foreground/70",
+            enabled
+              ? tone === "accent"
+                ? "text-[var(--color-text-accent)]"
+                : "text-[hsl(var(--chart-4))]"
+              : "text-muted-foreground/70",
           )}
         />
       </TooltipTrigger>
@@ -261,6 +284,9 @@ export interface TraitsMenuContentProps {
   prompt: string;
   onPromptChange: (prompt: string) => void;
   includeFastMode?: boolean;
+  // Drop the Effort ladder and the Speed section; the slider card renders both
+  // itself and only needs the remaining trait sections (thinking, context, agent).
+  excludeEffort?: boolean;
   modelOptions?: ProviderOptions | null | undefined;
   onSelectionComplete?: () => void;
 }
@@ -274,16 +300,17 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
   prompt,
   onPromptChange,
   includeFastMode: includeFastModeProp,
+  excludeEffort: excludeEffortProp,
   modelOptions,
   onSelectionComplete,
 }: TraitsMenuContentProps) {
-  const includeFastMode = includeFastModeProp ?? true;
-  const setProviderModelOptions = useComposerDraftStore((store) => store.setProviderModelOptions);
+  const excludeEffort = excludeEffortProp ?? false;
+  const includeFastMode = (includeFastModeProp ?? true) && !excludeEffort;
+  const selection = getComposerTraitSelection(provider, model, prompt, modelOptions, runtimeModel);
   const {
     caps,
     defaultEffort,
     effort,
-    effortLevels,
     thinkingEnabled,
     fastModeEnabled,
     contextWindowOptions,
@@ -291,10 +318,9 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
     defaultContextWindow,
     contextWindowDescriptor,
     ultrathinkPromptControlled,
-    primarySelectDescriptor,
     fastModeDescriptor,
-    promptInjectedValues,
-  } = getComposerTraitSelection(provider, model, prompt, modelOptions, runtimeModel);
+  } = selection;
+  const effortLevels = excludeEffort ? [] : selection.effortLevels;
   const hasVisibleControls = hasVisibleComposerTraitControls(
     { caps, effortLevels, thinkingEnabled, contextWindowOptions, fastModeDescriptor },
     { includeFastMode },
@@ -310,31 +336,24 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
   const selectedAgent = getSelectedAgentValue(provider, modelOptions);
   const hasAgentControls = agentOptions.length > 0 && defaultAgent !== null;
   const hasPriorContextWindowSection = thinkingEnabled !== null;
-  // Both descriptor ids are resolved up here rather than inline. React Compiler cannot lower a `??`
-  // in an object-key position, and it cannot match an optional-chained expression in a dependency
-  // list to its own inferred scope — either one makes it skip this component entirely.
+  // Resolved up here rather than inline. React Compiler cannot lower a `??` in an object-key
+  // position, which would make it skip this component entirely.
   const contextWindowTraitId = contextWindowDescriptor?.id ?? "contextWindow";
-  const primarySelectDescriptorId = primarySelectDescriptor?.id;
   const hasPriorEffortSection = thinkingEnabled !== null || contextWindowOptions.length > 1;
   const hasPriorFastModeSection =
     thinkingEnabled !== null || effortLevels.length > 0 || contextWindowOptions.length > 1;
 
-  // Single home for committing a trait change: merge the patch into the provider
-  // options, persist it as sticky, and close the menu. Every section funnels here.
-  // The fast-mode header toggle passes `keepMenuOpen` so its state flip stays visible.
+  const commitTraitOptions = useComposerTraitCommit({ threadId, provider, model, modelOptions });
+  // Commit a trait change and close the menu. Every section funnels here; the
+  // fast-mode header toggle passes `keepMenuOpen` so its state flip stays visible.
   const commitTrait = useCallback(
     (patch: Record<string, unknown>, options?: { keepMenuOpen?: boolean }) => {
-      setProviderModelOptions(
-        threadId,
-        provider,
-        buildNextProviderOptions(provider, modelOptions, patch),
-        { ...(model !== undefined ? { model } : {}), persistSticky: true },
-      );
+      commitTraitOptions(patch);
       if (!options?.keepMenuOpen) {
         onSelectionComplete?.();
       }
     },
-    [threadId, provider, modelOptions, model, setProviderModelOptions, onSelectionComplete],
+    [commitTraitOptions, onSelectionComplete],
   );
 
   // Deliberately not wrapped in `useCallback`: its inputs all come out of one
@@ -342,29 +361,14 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
   // hand-written dependency list can match it and the validator refuses to compile the component at
   // all. Letting the compiler own this memoization is what gets the whole file optimized.
   const handleEffortChange = (value: string) => {
-    if (ultrathinkPromptControlled) return;
-    if (!value) return;
-    const nextOption = effortLevels.find((option) => option.value === value);
-    if (!nextOption) return;
-    if (promptInjectedValues.includes(nextOption.value)) {
-      const nextPrompt =
-        prompt.trim().length === 0
-          ? ULTRATHINK_PROMPT_PREFIX
-          : applyClaudePromptEffortPrefix(prompt, "ultrathink");
-      onPromptChange(nextPrompt);
+    const plan = planComposerEffortChange({ provider, selection, prompt, value });
+    if (!plan) return;
+    if (plan.kind === "prompt") {
+      onPromptChange(plan.prompt);
       onSelectionComplete?.();
       return;
     }
-    const optionId =
-      primarySelectDescriptorId ??
-      (provider === "opencode"
-        ? "variant"
-        : provider === "pi"
-          ? "thinkingLevel"
-          : provider === "claudeAgent"
-            ? "effort"
-            : "reasoningEffort");
-    commitTrait(buildProviderOptionPatch(provider, optionId, nextOption.value));
+    commitTrait(plan.patch);
   };
 
   if (!hasVisibleControls && !hasAgentControls) {

--- a/apps/web/src/components/chat/WorkspaceFileEditorChrome.tsx
+++ b/apps/web/src/components/chat/WorkspaceFileEditorChrome.tsx
@@ -4,7 +4,7 @@ import { basenameOfPath } from "~/file-icons";
 import {
   ChevronRightIcon,
   Redo2Icon,
-  RotateCcwIcon,
+  ResetIcon,
   TriangleAlertIcon,
   Undo2Icon,
   XIcon,
@@ -81,7 +81,7 @@ export function WorkspaceFileEditorHistoryActions(props: WorkspaceFileEditorHist
         disabled={!props.canRevert}
         onClick={props.onRevert}
       >
-        <RotateCcwIcon aria-hidden="true" className="size-3.5" />
+        <ResetIcon aria-hidden="true" className="size-3.5" />
       </ChatHeaderIconButton>
     </>
   );

--- a/apps/web/src/components/chat/chatTypography.ts
+++ b/apps/web/src/components/chat/chatTypography.ts
@@ -9,7 +9,7 @@ import { DEFAULT_CHAT_FONT_SIZE_PX, normalizeChatFontSizePx } from "../../appSet
 // index.css shares composer corner smoothing; keep the radius as the browser fallback.
 export const USER_MESSAGE_BUBBLE_RADIUS_CLASS_NAME =
   "chat-user-message-bubble rounded-[var(--radius-user-message)]";
-export const USER_MESSAGE_BUBBLE_SHELL_PADDING_CLASS_NAME = "py-2";
+export const USER_MESSAGE_BUBBLE_SHELL_PADDING_CLASS_NAME = "py-3";
 export const USER_MESSAGE_BUBBLE_SHELL_HORIZONTAL_PADDING_CLASS_NAME = "px-4";
 export const USER_MESSAGE_BUBBLE_SHELL_CHROME_CLASS_NAME = [
   USER_MESSAGE_BUBBLE_SHELL_HORIZONTAL_PADDING_CLASS_NAME,

--- a/apps/web/src/components/chat/composerTraits.test.ts
+++ b/apps/web/src/components/chat/composerTraits.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getComposerTraitSelection,
+  planComposerEffortChange,
+  resolveComposerEffortLadderIndex,
+} from "./composerTraits";
+
+describe("planComposerEffortChange", () => {
+  it("patches the provider's effort option for plain ladder levels", () => {
+    const selection = getComposerTraitSelection("codex", "gpt-5.5", "", {
+      reasoningEffort: "medium",
+    });
+
+    expect(
+      planComposerEffortChange({ provider: "codex", selection, prompt: "", value: "xhigh" }),
+    ).toEqual({ kind: "options", patch: { reasoningEffort: "xhigh" } });
+    expect(
+      planComposerEffortChange({
+        provider: "claudeAgent",
+        selection: getComposerTraitSelection("claudeAgent", "claude-opus-5", "", undefined),
+        prompt: "",
+        value: "max",
+      }),
+    ).toEqual({ kind: "options", patch: { effort: "max" } });
+  });
+
+  it("rewrites the prompt for prompt-injected levels", () => {
+    const selection = getComposerTraitSelection("claudeAgent", "claude-opus-4-8", "", undefined);
+
+    expect(
+      planComposerEffortChange({
+        provider: "claudeAgent",
+        selection,
+        prompt: "",
+        value: "ultrathink",
+      }),
+    ).toEqual({ kind: "prompt", prompt: "Ultrathink:\n" });
+    expect(
+      planComposerEffortChange({
+        provider: "claudeAgent",
+        selection,
+        prompt: "Fix the flaky test",
+        value: "ultrathink",
+      }),
+    ).toEqual({ kind: "prompt", prompt: "Ultrathink:\nFix the flaky test" });
+  });
+
+  it("ignores changes while Ultrathink pins the effort and for unknown values", () => {
+    const pinned = getComposerTraitSelection(
+      "claudeAgent",
+      "claude-opus-4-8",
+      "Ultrathink:\nGo",
+      undefined,
+    );
+    expect(
+      planComposerEffortChange({
+        provider: "claudeAgent",
+        selection: pinned,
+        prompt: "Ultrathink:\nGo",
+        value: "low",
+      }),
+    ).toBeNull();
+
+    const free = getComposerTraitSelection("codex", "gpt-5.5", "", undefined);
+    expect(
+      planComposerEffortChange({ provider: "codex", selection: free, prompt: "", value: "turbo" }),
+    ).toBeNull();
+    expect(
+      planComposerEffortChange({ provider: "codex", selection: free, prompt: "", value: "" }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveComposerEffortLadderIndex", () => {
+  it("follows the selected effort and falls back to the first stop", () => {
+    const selection = getComposerTraitSelection("codex", "gpt-5.5", "", {
+      reasoningEffort: "high",
+    });
+    expect(resolveComposerEffortLadderIndex(selection)).toBe(
+      selection.effortLevels.findIndex((level) => level.value === "high"),
+    );
+    expect(resolveComposerEffortLadderIndex({ ...selection, effort: "unknown" })).toBe(0);
+  });
+
+  it("rests on the prompt-injected stop while Ultrathink pins the ladder", () => {
+    const selection = getComposerTraitSelection(
+      "claudeAgent",
+      "claude-opus-4-8",
+      "Ultrathink:\nGo",
+      undefined,
+    );
+    expect(selection.ultrathinkPromptControlled).toBe(true);
+    expect(resolveComposerEffortLadderIndex(selection)).toBe(
+      selection.effortLevels.findIndex((level) => level.value === "ultrathink"),
+    );
+  });
+});

--- a/apps/web/src/components/chat/composerTraits.ts
+++ b/apps/web/src/components/chat/composerTraits.ts
@@ -9,14 +9,17 @@ import {
   type ProviderModelDescriptor,
 } from "@synara/contracts";
 import {
+  applyClaudePromptEffortPrefix,
   getProviderOptionCurrentValue,
   getProviderOptionDescriptors,
   isClaudeUltrathinkPrompt,
   trimOrNull,
 } from "@synara/shared/model";
 
-import type { ProviderOptions } from "../../providerModelOptions";
+import { buildProviderOptionPatch, type ProviderOptions } from "../../providerModelOptions";
 import { getRuntimeAwareModelCapabilities } from "./runtimeModelCapabilities";
+
+const ULTRATHINK_PROMPT_PREFIX = "Ultrathink:\n";
 
 function getCursorBooleanModelParameter(
   model: string | null | undefined,
@@ -228,12 +231,80 @@ export function hasVisibleComposerTraitControls(
   >,
   options?: {
     includeFastMode?: boolean;
+    // Off when another surface (the effort slider card) already owns the effort ladder.
+    includeEffort?: boolean;
   },
 ): boolean {
   return (
-    selection.effortLevels.length > 0 ||
+    ((options?.includeEffort ?? true) && selection.effortLevels.length > 0) ||
     selection.thinkingEnabled !== null ||
     selection.contextWindowOptions.length > 1 ||
     ((options?.includeFastMode ?? true) && supportsComposerFastModeControl(selection))
   );
+}
+
+// Persisted option key for the primary effort ladder when the descriptor is missing.
+function fallbackEffortOptionId(provider: ProviderKind): string {
+  if (provider === "opencode") return "variant";
+  if (provider === "pi") return "thinkingLevel";
+  if (provider === "claudeAgent") return "effort";
+  return "reasoningEffort";
+}
+
+export type ComposerEffortChangePlan =
+  // Prompt-injected levels (Claude Ultrathink) rewrite the prompt instead of the options.
+  | { readonly kind: "prompt"; readonly prompt: string }
+  | { readonly kind: "options"; readonly patch: Record<string, unknown> };
+
+// Single decision point for "the user picked effort X": every effort surface
+// (radio menu, slider) turns its choice into the same prompt rewrite or option
+// patch here, so ultrathink handling and option ids can never drift apart.
+// Returns null when the change must be ignored (locked by the prompt, unknown value).
+export function planComposerEffortChange(input: {
+  provider: ProviderKind;
+  selection: Pick<
+    ReturnType<typeof getComposerTraitSelection>,
+    | "effortLevels"
+    | "promptInjectedValues"
+    | "primarySelectDescriptor"
+    | "ultrathinkPromptControlled"
+  >;
+  prompt: string;
+  value: string;
+}): ComposerEffortChangePlan | null {
+  const { provider, selection, prompt, value } = input;
+  if (selection.ultrathinkPromptControlled) return null;
+  if (!value) return null;
+  const nextOption = selection.effortLevels.find((option) => option.value === value);
+  if (!nextOption) return null;
+  if (selection.promptInjectedValues.includes(nextOption.value)) {
+    return {
+      kind: "prompt",
+      prompt:
+        prompt.trim().length === 0
+          ? ULTRATHINK_PROMPT_PREFIX
+          : applyClaudePromptEffortPrefix(prompt, "ultrathink"),
+    };
+  }
+  const optionId = selection.primarySelectDescriptor?.id ?? fallbackEffortOptionId(provider);
+  return { kind: "options", patch: buildProviderOptionPatch(provider, optionId, nextOption.value) };
+}
+
+// Index of the effort the slider thumb should rest on. While Ultrathink is
+// pinned by the prompt the resolved `effort` falls back to the default, so the
+// thumb follows the prompt-injected level instead when the ladder exposes it.
+export function resolveComposerEffortLadderIndex(
+  selection: Pick<
+    ReturnType<typeof getComposerTraitSelection>,
+    "effort" | "effortLevels" | "promptInjectedValues" | "ultrathinkPromptControlled"
+  >,
+): number {
+  if (selection.ultrathinkPromptControlled) {
+    const injectedIndex = selection.effortLevels.findIndex((level) =>
+      selection.promptInjectedValues.includes(level.value),
+    );
+    if (injectedIndex >= 0) return injectedIndex;
+  }
+  const index = selection.effortLevels.findIndex((level) => level.value === selection.effort);
+  return index >= 0 ? index : 0;
 }

--- a/apps/web/src/components/chat/useComposerTraitCommit.ts
+++ b/apps/web/src/components/chat/useComposerTraitCommit.ts
@@ -1,0 +1,34 @@
+// FILE: useComposerTraitCommit.ts
+// Purpose: One store write path for composer trait changes (effort, fast mode, thinking, context).
+// Layer: Chat composer state hook
+// Depends on: composer draft store and provider option patch helpers.
+
+import type { ProviderKind, ThreadId } from "@synara/contracts";
+import { useCallback } from "react";
+
+import { useComposerDraftStore } from "../../composerDraftStore";
+import { buildNextProviderOptions, type ProviderOptions } from "../../providerModelOptions";
+
+// Merges a trait patch into the thread's provider options and persists it as the
+// sticky choice for the model. Every trait surface (radio menu, slider card,
+// keyboard shortcuts) funnels through here so persistence semantics stay identical.
+export function useComposerTraitCommit(input: {
+  threadId: ThreadId;
+  provider: ProviderKind;
+  model: string | null | undefined;
+  modelOptions: ProviderOptions | null | undefined;
+}): (patch: Record<string, unknown>) => void {
+  const { threadId, provider, model, modelOptions } = input;
+  const setProviderModelOptions = useComposerDraftStore((store) => store.setProviderModelOptions);
+  return useCallback(
+    (patch: Record<string, unknown>) => {
+      setProviderModelOptions(
+        threadId,
+        provider,
+        buildNextProviderOptions(provider, modelOptions, patch),
+        { ...(model !== undefined ? { model } : {}), persistSticky: true },
+      );
+    },
+    [threadId, provider, modelOptions, model, setProviderModelOptions],
+  );
+}

--- a/apps/web/src/components/settings/SettingControls.tsx
+++ b/apps/web/src/components/settings/SettingControls.tsx
@@ -10,7 +10,7 @@ import { Button } from "~/components/ui/button";
 import { Select, SelectTrigger, SelectValue } from "~/components/ui/select";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { useRadioGroupKeyboardNav } from "~/hooks/useRadioGroupKeyboardNav";
-import { Undo2Icon } from "~/lib/icons";
+import { ResetIcon } from "~/lib/icons";
 import { SETTINGS_CONTROL_RADIUS_CLASS_NAME } from "~/settingsPanelStyles";
 import { SettingsSelectPopup } from "./SettingsPanelPrimitives";
 
@@ -40,7 +40,7 @@ export function SettingResetButton({ label, onClick }: { label: string; onClick:
               onClick();
             }}
           >
-            <Undo2Icon className="size-3" />
+            <ResetIcon className="size-3" />
           </Button>
         }
       />

--- a/apps/web/src/components/ui/menu.tsx
+++ b/apps/web/src/components/ui/menu.tsx
@@ -109,8 +109,9 @@ function MenuPopupBase({
           className={cn(
             "relative flex origin-(--transform-origin) text-[var(--color-text-foreground)] outline-none focus:outline-none",
             isComposerSurface ? "min-w-0 max-w-[92vw]" : "w-full min-w-full",
-            isComposerSurface ? className : null,
             popupSurfaceClassName,
+            // Last so a caller's className can override surface tokens (e.g. a rounder radius).
+            isComposerSurface ? className : null,
           )}
           data-slot="menu-popup"
           {...props}
@@ -401,6 +402,12 @@ function MenuSub({ keepOpenOnFocusOut: keepOpenOnFocusOutProp, ...props }: MenuS
   );
 }
 
+/** Unstyled submenu trigger for bespoke layouts (e.g. the effort slider card's stacked
+ *  model label). Prefer `MenuSubTrigger` for regular option rows. */
+function MenuSubTriggerBase(props: MenuPrimitive.SubmenuTrigger.Props) {
+  return <MenuPrimitive.SubmenuTrigger data-slot="menu-sub-trigger-base" {...props} />;
+}
+
 function MenuSubTrigger({
   className,
   inset,
@@ -483,5 +490,6 @@ export {
   MenuShortcut,
   MenuSub,
   MenuSubTrigger,
+  MenuSubTriggerBase,
   MenuSubPopup,
 };

--- a/apps/web/src/components/ui/notificationSurface.ts
+++ b/apps/web/src/components/ui/notificationSurface.ts
@@ -5,22 +5,21 @@
 
 import { cn } from "~/lib/utils";
 
-// `--notification-fg` keeps the text/icon/control color readable against the
-// accent-tinted surface. It tracks the theme's own foreground token, so it is
-// near-black in light themes and near-white in dark themes automatically —
-// without depending on the `.dark` class. Children reference it via
-// `text-[var(--notification-fg)]` so the contrast fix lives in one place for
-// both toasts and inline notification banners.
-const NOTIFICATION_FOREGROUND_CLASS_NAME =
-  "text-[var(--notification-fg)] [--notification-fg:var(--color-text-foreground)]";
-
+// Every notification card shares the same neutral popover chrome; only the
+// error tone tints the surface. Children reference `--notification-fg` via
+// `text-[var(--notification-fg)]` so text/icon/control color lives in one place
+// for both toasts and inline notification banners.
+//
 // `[-webkit-app-region:no-drag]` keeps the card (and every control inside it,
 // notably the dismiss "X") clickable in the desktop app. Toasts render at the
 // top edge over Electron's draggable titlebar region; without this the OS
 // captures clicks in that band for window dragging and the X stops working.
-export const COMPACT_NOTIFICATION_SURFACE_CLASS_NAME = `w-max max-w-[min(calc(100vw-2rem),28rem)] rounded-xl border border-border bg-popover/94 [--notification-fg:var(--popover-foreground)] text-[var(--notification-fg)] shadow-lg/10 backdrop-blur-xl before:hidden [-webkit-app-region:no-drag] dark:shadow-lg/15`;
+const NOTIFICATION_SURFACE_BASE_CLASS_NAME =
+  "border border-border bg-popover/94 [--notification-fg:var(--popover-foreground)] text-[var(--notification-fg)] shadow-lg/10 backdrop-blur-xl before:hidden [-webkit-app-region:no-drag] dark:shadow-lg/15";
 
-export const EXPANDED_NOTIFICATION_SURFACE_CLASS_NAME = `w-full rounded-2xl border border-[color-mix(in_srgb,var(--color-text-accent)_14%,transparent)] bg-[color-mix(in_srgb,var(--color-text-accent)_10%,transparent)] ${NOTIFICATION_FOREGROUND_CLASS_NAME} shadow-lg/10 backdrop-blur-xl before:hidden [-webkit-app-region:no-drag] dark:border-[color-mix(in_srgb,var(--color-text-accent)_10%,transparent)] dark:bg-[color-mix(in_srgb,var(--color-text-accent)_10%,transparent)] dark:shadow-lg/15`;
+export const COMPACT_NOTIFICATION_SURFACE_CLASS_NAME = `w-max max-w-[min(calc(100vw-2rem),28rem)] rounded-xl ${NOTIFICATION_SURFACE_BASE_CLASS_NAME}`;
+
+export const EXPANDED_NOTIFICATION_SURFACE_CLASS_NAME = `w-full rounded-2xl ${NOTIFICATION_SURFACE_BASE_CLASS_NAME}`;
 
 // The icon carries the tone color while the copy stays on the neutral
 // `--notification-fg`, so tones only need to set `--notification-icon-fg`.
@@ -29,8 +28,8 @@ export const NOTIFICATION_ICON_CLASS_NAME =
 
 export type NotificationTone = "default" | "error";
 
-// Error notifications keep the same card geometry and swap the accent tint for a
-// light destructive wash. The copy deliberately keeps the theme foreground
+// Error notifications keep the same card geometry and swap the neutral popover for
+// a light destructive wash. The copy deliberately keeps the theme foreground
 // (near-white in dark themes, near-black in light ones) instead of the destructive
 // role color, which reads muddy against the tint; the icon carries the red instead.
 const ERROR_NOTIFICATION_TONE_CLASS_NAME =

--- a/apps/web/src/components/ui/slider.tsx
+++ b/apps/web/src/components/ui/slider.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+// FILE: slider.tsx
+// Purpose: Shared accent-colored single-value slider primitive with optional step marks.
+// Layer: Base UI component
+// Exports: Slider
+
+import { Slider as SliderPrimitive } from "@base-ui/react/slider";
+
+import { cn } from "~/lib/utils";
+
+type SliderProps = {
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  disabled?: boolean;
+  /** `default` is a settings-row slider; `large` is the chunky iOS-style control
+   *  (thumb nearly flush with a tall track) used by the composer effort card. */
+  size?: "default" | "large";
+  /** Draw one dot per step so discrete scales (effort levels, sizes) read as a ladder. */
+  showStepMarks?: boolean;
+  className?: string;
+  "aria-label": string;
+  /** Spoken value for assistive tech; defaults to the numeric value. */
+  getAriaValueText?: (value: number) => string;
+  onValueChange: (value: number) => void;
+};
+
+function stepMarkPercents(min: number, max: number, step: number): number[] {
+  if (!(max > min) || !(step > 0)) return [];
+  const marks: number[] = [];
+  for (let value = min; value <= max + Number.EPSILON; value += step) {
+    marks.push(((value - min) / (max - min)) * 100);
+  }
+  return marks;
+}
+
+/**
+ * Single-thumb slider on the app accent. The thumb is edge-aligned so it never
+ * overhangs the track; step marks live in a matching inset rail so every dot
+ * sits exactly under the thumb centre at that value.
+ */
+function Slider({
+  value,
+  min,
+  max,
+  step: stepProp,
+  disabled,
+  size: sizeProp,
+  showStepMarks: showStepMarksProp,
+  className,
+  "aria-label": ariaLabel,
+  getAriaValueText,
+  onValueChange,
+}: SliderProps) {
+  const step = stepProp ?? 1;
+  const size = sizeProp ?? "default";
+  const showStepMarks = showStepMarksProp ?? false;
+  const marks = showStepMarks ? stepMarkPercents(min, max, step) : [];
+  const valuePercent = max > min ? ((value - min) / (max - min)) * 100 : 0;
+
+  return (
+    <SliderPrimitive.Root
+      value={value}
+      min={min}
+      max={max}
+      step={step}
+      {...(disabled ? { disabled: true } : {})}
+      thumbAlignment="edge"
+      onValueChange={(nextValue) => {
+        if (typeof nextValue === "number") onValueChange(nextValue);
+      }}
+      className={cn(
+        "relative flex w-full touch-none select-none items-center data-disabled:cursor-not-allowed data-disabled:opacity-64",
+        size === "large"
+          ? "[--slider-mark-size:--spacing(1)] [--slider-thumb-size:--spacing(6)] [--slider-track-size:--spacing(5)]"
+          : "[--slider-mark-size:--spacing(1)] [--slider-thumb-size:--spacing(5)] [--slider-track-size:--spacing(3)]",
+        className,
+      )}
+      data-slot="slider"
+    >
+      <SliderPrimitive.Control className="flex w-full cursor-pointer items-center py-0.5 data-disabled:cursor-not-allowed">
+        <SliderPrimitive.Track
+          className="relative h-[var(--slider-track-size)] w-full overflow-visible rounded-full bg-[color-mix(in_srgb,var(--color-text-foreground)_14%,transparent)]"
+          data-slot="slider-track"
+        >
+          <SliderPrimitive.Indicator
+            className="rounded-full bg-[var(--color-text-accent)]"
+            data-slot="slider-indicator"
+          />
+          {marks.length > 0 ? (
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-y-0 left-[calc(var(--slider-thumb-size)/2)] right-[calc(var(--slider-thumb-size)/2)]"
+            >
+              {marks.map((percent) => (
+                <span
+                  key={percent}
+                  className={cn(
+                    "absolute top-1/2 size-[var(--slider-mark-size)] -translate-x-1/2 -translate-y-1/2 rounded-full",
+                    percent <= valuePercent + Number.EPSILON
+                      ? "bg-white/55"
+                      : "bg-[color-mix(in_srgb,var(--color-text-foreground)_28%,transparent)]",
+                  )}
+                  style={{ left: `${percent}%` }}
+                />
+              ))}
+            </span>
+          ) : null}
+          <SliderPrimitive.Thumb
+            aria-label={ariaLabel}
+            {...(getAriaValueText
+              ? { getAriaValueText: (_formatted: string, next: number) => getAriaValueText(next) }
+              : {})}
+            className="size-[var(--slider-thumb-size)] rounded-full bg-white shadow-[0_1px_3px_rgba(0,0,0,0.35),0_0_0_1px_rgba(0,0,0,0.06)] outline-none transition-[scale] duration-100 has-focus-visible:ring-2 has-focus-visible:ring-[color:var(--color-border-focus)]/60 has-focus-visible:ring-offset-1 has-focus-visible:ring-offset-background data-dragging:scale-105"
+            data-slot="slider-thumb"
+          />
+        </SliderPrimitive.Track>
+      </SliderPrimitive.Control>
+    </SliderPrimitive.Root>
+  );
+}
+
+export { Slider };

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -381,7 +381,7 @@
 :root {
   color-scheme: light;
   --radius: 0.625rem;
-  --radius-user-message: 0.8rem;
+  --radius-user-message: 1rem;
   --font-ui-family: var(
     --theme-font-ui-family,
     -apple-system,

--- a/apps/web/src/lib/icons.tsx
+++ b/apps/web/src/lib/icons.tsx
@@ -296,6 +296,10 @@ export const TextWrapIcon = adaptIcon(IconTextWrap);
 export const Trash2 = adaptIcon(IconTrash);
 export const TriangleAlertIcon = adaptIcon(IconAlertTriangle);
 export const Undo2Icon = adaptIcon(IconArrowBackUp);
+// Single source for every "reset / restore default / revert" affordance (settings
+// row resets, Restore defaults, effort-slider reset, space reset, file revert):
+// the Central reversed counter-clockwise arrow, never a Tabler/Lucide rotate glyph.
+export const ResetIcon: LucideIcon = centralIconWrapper("arrow-rotate-counter-clockwise");
 export const Redo2Icon = adaptIcon(IconArrowForwardUp);
 export const WorktreeIcon = centralIconWrapper("arrow-split-right");
 export const XIcon = adaptIcon(IconX);

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -91,7 +91,7 @@ import { useTheme } from "../hooks/useTheme";
 import { isUiDensity } from "../lib/appDensity";
 import { isChatWidthMode, type ChatWidthMode } from "../lib/chatWidth";
 import { isElectron } from "../env";
-import { RotateCcwIcon } from "../lib/icons";
+import { ResetIcon } from "../lib/icons";
 import {
   cn,
   getNavigatorPlatform,
@@ -342,6 +342,7 @@ function SettingsRouteView() {
     ...(settings.enableAssistantStreaming !== defaults.enableAssistantStreaming
       ? ["Assistant output"]
       : []),
+    ...(settings.composerEffortSlider !== defaults.composerEffortSlider ? ["Effort slider"] : []),
     ...(settings.followUpBehavior !== defaults.followUpBehavior ? ["Follow-up behavior"] : []),
     ...(settings.autoOpenDevicePane !== defaults.autoOpenDevicePane
       ? ["Automatically open simulator"]
@@ -1166,6 +1167,15 @@ function SettingsRouteView() {
         })}
 
         {renderBooleanSettingRow({
+          settingKey: "composerEffortSlider",
+          title: "Effort slider",
+          description:
+            "Once a chat has started, show reasoning effort as a slider in the composer's model menu, with fast mode and the model list alongside it. New chats keep the separate model and effort pickers.",
+          resetLabel: "effort slider",
+          ariaLabel: "Show effort slider in the composer",
+        })}
+
+        {renderBooleanSettingRow({
           settingKey: "autoOpenDevicePane",
           title: "Automatically open simulator",
           description:
@@ -1299,7 +1309,7 @@ function SettingsRouteView() {
                     disabled={changedSettingLabels.length === 0}
                     onClick={() => void restoreDefaults()}
                   >
-                    <RotateCcwIcon className="size-3.5" />
+                    <ResetIcon className="size-3.5" />
                     Restore defaults
                   </Button>
                 </div>

--- a/apps/web/src/settingsSearchIndex.ts
+++ b/apps/web/src/settingsSearchIndex.ts
@@ -295,6 +295,13 @@ export const SETTINGS_SEARCH_ENTRIES: readonly SettingsSearchEntry[] = [
     keywords: "Show token-by-token output while a response is in progress. streaming",
   },
   {
+    id: "behavior:effort-slider",
+    section: "behavior",
+    title: "Effort slider",
+    keywords:
+      "Show reasoning effort as a slider in the composer model menu once a chat has started. fast mode reasoning thinking level picker",
+  },
+  {
     id: "behavior:auto-open-simulator",
     section: "behavior",
     title: "Automatically open simulator",


### PR DESCRIPTION
## What changes

Adds a stepped effort slider to the combined model/reasoning picker in started-thread composers. The slider is enabled by default through the Composer effort slider setting; disabling that setting restores the radio-based menu. Models without an effort ladder retain the menu layout.

The slider card shows the selected model and effort, explains each effort level, and provides supported fast-mode and reset controls. Model selection remains available from the card. Shared effort-planning and trait-persistence helpers preserve provider-specific options, Claude prompt-controlled Ultrathink, and companion traits such as thinking and context size.

The PR also introduces a shared slider primitive and ResetIcon, updates reset glyphs, and adjusts notification chrome and user-message bubble styling.

## Verification

- Focused unit coverage checks provider effort patches, Claude prompt injection, pinned Ultrathink, invalid values, and slider stop selection.
- Browser coverage checks keyboard effort changes, fast-mode toggling, reset, and model-menu navigation.
- Local final-head verification: 61 unit tests and 4 browser tests passed, including the user-bubble metadata/padding regression.
- Corrected the stale bubble-padding assertion to inspect the actual user bubble and require its current `py-3` padding.
- Current-head CI and Cursor results must be checked after the final repair commit is published; earlier green checks do not certify that commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches composer model-option persistence and effort/Ultrathink behavior across providers; mistakes could mis-save reasoning settings, though radio fallback and unit/browser tests reduce drift risk.
> 
> **Overview**
> Adds a **composer effort slider** path for the combined model/traits menu (started-thread layout): when `composerEffortSlider` is on (default), reasoning effort is a **stepped slider card** with fast mode, reset, and the model list behind the stacked effort/model label instead of radio rows. New chats that still use the **split** model + traits pickers are unchanged.
> 
> Introduces `ComposerEffortSliderCard`, a shared `Slider` primitive, and centralized **`planComposerEffortChange`** / **`useComposerTraitCommit`** so the slider and radio menu stay aligned (including Ultrathink prompt injection). Settings and search index expose a toggle to fall back to the menu layout.
> 
> Smaller UI polish in the same PR: **`ResetIcon`** replaces assorted rotate/undo reset glyphs, user message bubbles get **taller padding and a larger corner radius**, and expanded notifications use **neutral popover chrome** instead of accent tinting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0775dc1d98722561963c1f1b453749bdbb30732d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

