### PR TITLE
Harden provider delivery against slow checkpoint capture

### DIFF
--- a/apps/server/src/checkpointing/Layers/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.test.ts
@@ -4,7 +4,7 @@
 // Exports: Vitest coverage for CheckpointStoreLive.
 import { mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Effect, Fiber, Layer, ManagedRuntime, Option } from "effect";
@@ -15,6 +15,9 @@ import { CheckpointStore } from "../Services/CheckpointStore.ts";
 import { GitCore, type GitCoreShape } from "../../git/Services/GitCore.ts";
 import { GitCommandError } from "../../git/Errors.ts";
 import { CheckpointRef } from "@synara/contracts";
+
+const CHECKPOINT_ADD_COMMAND = "add --no-warn-embedded-repo -A -- .";
+const UNSEEDED_CAPTURE_PREFLIGHT_COMMAND = "ls-files --cached --others --exclude-standard -z";
 
 async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
   const started = Date.now();
@@ -48,7 +51,10 @@ describe("CheckpointStoreLive", () => {
       if (args === "rev-parse --verify HEAD") {
         return Effect.succeed({ code: 1, stdout: "", stderr: "" });
       }
-      if (args === "add -A -- .") {
+      if (args === UNSEEDED_CAPTURE_PREFLIGHT_COMMAND) {
+        return Effect.succeed({ code: 0, stdout: "", stderr: "" });
+      }
+      if (args === CHECKPOINT_ADD_COMMAND) {
         return Effect.promise(() => addGate).pipe(Effect.as({ code: 0, stdout: "", stderr: "" }));
       }
       if (args === "write-tree") {
@@ -78,13 +84,15 @@ describe("CheckpointStoreLive", () => {
 
         const first = yield* store.captureCheckpoint(input).pipe(Effect.forkChild);
         yield* Effect.promise(() =>
-          waitFor(() => execute.mock.calls.some(([call]) => call.args.join(" ") === "add -A -- .")),
+          waitFor(() =>
+            execute.mock.calls.some(([call]) => call.args.join(" ") === CHECKPOINT_ADD_COMMAND),
+          ),
         );
         const second = yield* store.captureCheckpoint(input).pipe(Effect.forkChild);
         yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 25)));
 
         expect(
-          execute.mock.calls.filter(([call]) => call.args.join(" ") === "add -A -- ."),
+          execute.mock.calls.filter(([call]) => call.args.join(" ") === CHECKPOINT_ADD_COMMAND),
         ).toHaveLength(1);
 
         releaseAdd?.();
@@ -102,6 +110,7 @@ describe("CheckpointStoreLive", () => {
     utimesSync(workingIndexPath, workingIndexTime, workingIndexTime);
     let capturedSeed = "";
     let capturedIndexMtimeMs = 0;
+    let capturedAddInput: Parameters<GitCoreShape["execute"]>[0] | undefined;
 
     const execute = vi.fn<GitCoreShape["execute"]>((input) => {
       const args = input.args.join(" ");
@@ -114,7 +123,8 @@ describe("CheckpointStoreLive", () => {
         utimesSync(captureIndexPath, refreshTime, refreshTime);
         return Effect.succeed({ code: 1, stdout: "", stderr: "README.md: needs update\n" });
       }
-      if (args === "add -A -- .") {
+      if (args === CHECKPOINT_ADD_COMMAND) {
+        capturedAddInput = input;
         const captureIndexPath = input.env?.GIT_INDEX_FILE ?? "";
         capturedSeed = readFileSync(captureIndexPath, "utf8");
         capturedIndexMtimeMs = statSync(captureIndexPath).mtimeMs;
@@ -155,11 +165,288 @@ describe("CheckpointStoreLive", () => {
           ([call]) => call.args.join(" ") === "update-index --really-refresh",
         ),
       ).toBe(true);
+      expect(capturedAddInput).toMatchObject({
+        args: ["add", "--no-warn-embedded-repo", "-A", "--", "."],
+        maxOutputBytes: 64 * 1_024,
+        outputMode: "truncate",
+      });
+      expect(capturedAddInput?.env?.GIT_INDEX_FILE).not.toBe(workingIndexPath);
+      expect(readFileSync(workingIndexPath, "utf8")).toBe("working-index-stat-cache");
+      expect(statSync(workingIndexPath).mtimeMs).toBe(workingIndexTime.getTime());
       expect(
         execute.mock.calls.some(([call]) => call.args.join(" ") === "rev-parse --verify HEAD"),
       ).toBe(false);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("bounds an unseeded workspace scan and cools down retries before git add", async () => {
+    let preflightInput: Parameters<GitCoreShape["execute"]>[0] | undefined;
+    const execute = vi.fn<GitCoreShape["execute"]>((input) => {
+      const args = input.args.join(" ");
+      if (args === "rev-parse --git-path index") {
+        return Effect.succeed({ code: 0, stdout: "/repo/.git/index\n", stderr: "" });
+      }
+      if (args === "rev-parse --verify HEAD") {
+        return Effect.succeed({ code: 1, stdout: "", stderr: "" });
+      }
+      if (args === UNSEEDED_CAPTURE_PREFLIGHT_COMMAND) {
+        preflightInput = input;
+        return Effect.fail(
+          new GitCommandError({
+            operation: input.operation,
+            command: "git ls-files --cached --others --exclude-standard -z",
+            cwd: input.cwd,
+            detail: "workspace listing exceeded the configured output limit",
+            reason: "output-limit",
+          }),
+        );
+      }
+      throw new Error(`Unexpected git args: ${args}`);
+    });
+    const layer = CheckpointStoreLive.pipe(
+      Layer.provide(Layer.succeed(GitCore, { execute } as unknown as GitCoreShape)),
+      Layer.provide(NodeServices.layer),
+    );
+    runtime = ManagedRuntime.make(layer);
+
+    const results = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CheckpointStore;
+        return yield* Effect.forEach(
+          ["first", "second"],
+          (suffix) =>
+            store
+              .captureCheckpoint({
+                cwd: "/repo",
+                checkpointRef: CheckpointRef.makeUnsafe(`refs/synara-checkpoints/thread/${suffix}`),
+              })
+              .pipe(
+                Effect.map(() => "success"),
+                Effect.catch((error) => Effect.succeed(error.message)),
+              ),
+          { concurrency: 1 },
+        );
+      }),
+    );
+
+    expect(results[0]).toContain("safe scan budget");
+    expect(results[1]).toContain("temporarily paused");
+    expect(preflightInput).toMatchObject({
+      timeoutMs: 5_000,
+      maxOutputBytes: 1_000_000,
+    });
+    expect(
+      execute.mock.calls.filter(
+        ([call]) => call.args.join(" ") === UNSEEDED_CAPTURE_PREFLIGHT_COMMAND,
+      ),
+    ).toHaveLength(1);
+    expect(
+      execute.mock.calls.some(([call]) => call.args.join(" ") === CHECKPOINT_ADD_COMMAND),
+    ).toBe(false);
+  });
+
+  it("serializes different checkpoint refs for one workspace and shares failure cooldown", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "synara-checkpoint-lane-test-"));
+    const workingIndexPath = join(tempDir, "index");
+    writeFileSync(workingIndexPath, "working-index-stat-cache");
+    let releaseFirstAdd: (() => void) | undefined;
+    const firstAddGate = new Promise<void>((resolve) => {
+      releaseFirstAdd = resolve;
+    });
+    let addCalls = 0;
+    const execute = vi.fn<GitCoreShape["execute"]>((input) => {
+      const args = input.args.join(" ");
+      if (args === "rev-parse --git-path index") {
+        return Effect.succeed({ code: 0, stdout: `${workingIndexPath}\n`, stderr: "" });
+      }
+      if (args === "update-index --really-refresh") {
+        return Effect.succeed({ code: 0, stdout: "", stderr: "" });
+      }
+      if (args === CHECKPOINT_ADD_COMMAND) {
+        addCalls += 1;
+        return Effect.promise(() => firstAddGate).pipe(
+          Effect.flatMap(() =>
+            Effect.fail(
+              new GitCommandError({
+                operation: input.operation,
+                command: "git add",
+                cwd: input.cwd,
+                detail: "git add timed out during simulated expensive capture",
+                reason: "timeout",
+              }),
+            ),
+          ),
+        );
+      }
+      throw new Error(`Unexpected git args: ${args}`);
+    });
+    const layer = CheckpointStoreLive.pipe(
+      Layer.provide(Layer.succeed(GitCore, { execute } as unknown as GitCoreShape)),
+      Layer.provide(NodeServices.layer),
+    );
+    runtime = ManagedRuntime.make(layer);
+
+    try {
+      const results = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* CheckpointStore;
+          const capture = (suffix: string, cwd = tempDir) =>
+            store
+              .captureCheckpoint({
+                cwd,
+                checkpointRef: CheckpointRef.makeUnsafe(`refs/synara-checkpoints/thread/${suffix}`),
+              })
+              .pipe(
+                Effect.map(() => "success"),
+                Effect.catch((error) => Effect.succeed(error.message)),
+              );
+
+          const first = yield* capture("first").pipe(Effect.forkChild);
+          yield* Effect.promise(() => waitFor(() => addCalls === 1));
+          const workspaceAlias =
+            process.platform === "win32" ? `${tempDir.toUpperCase()}${sep}` : `${tempDir}${sep}`;
+          const second = yield* capture("second", workspaceAlias).pipe(Effect.forkChild);
+          yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 25)));
+          expect(addCalls).toBe(1);
+
+          releaseFirstAdd?.();
+          return yield* Effect.all([Fiber.join(first), Fiber.join(second)]);
+        }),
+      );
+
+      expect(results[0]).toContain("simulated expensive capture");
+      expect(results[1]).toContain("temporarily paused");
+      expect(addCalls).toBe(1);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not cool down ordinary Git failures from an unseeded preflight", async () => {
+    const execute = vi.fn<GitCoreShape["execute"]>((input) => {
+      const args = input.args.join(" ");
+      if (args === "rev-parse --git-path index") {
+        return Effect.succeed({ code: 0, stdout: "/repo/.git/index\n", stderr: "" });
+      }
+      if (args === "rev-parse --verify HEAD") {
+        return Effect.succeed({ code: 1, stdout: "", stderr: "" });
+      }
+      if (args === UNSEEDED_CAPTURE_PREFLIGHT_COMMAND) {
+        return Effect.fail(
+          new GitCommandError({
+            operation: input.operation,
+            command: "git ls-files --cached --others --exclude-standard -z",
+            cwd: input.cwd,
+            detail: "fatal: hook said timed out but exited non-zero",
+            reason: "non-zero-exit",
+          }),
+        );
+      }
+      throw new Error(`Unexpected git args: ${args}`);
+    });
+    const layer = CheckpointStoreLive.pipe(
+      Layer.provide(Layer.succeed(GitCore, { execute } as unknown as GitCoreShape)),
+      Layer.provide(NodeServices.layer),
+    );
+    runtime = ManagedRuntime.make(layer);
+
+    const results = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CheckpointStore;
+        return yield* Effect.forEach(
+          ["first", "second"],
+          (suffix) =>
+            store
+              .captureCheckpoint({
+                cwd: "/repo",
+                checkpointRef: CheckpointRef.makeUnsafe(`refs/synara-checkpoints/thread/${suffix}`),
+              })
+              .pipe(Effect.result),
+          { concurrency: 1 },
+        );
+      }),
+    );
+
+    expect(results).toHaveLength(2);
+    for (const result of results) {
+      expect(result._tag).toBe("Failure");
+      if (result._tag === "Failure") {
+        expect(result.failure).toMatchObject({
+          _tag: "GitCommandError",
+          reason: "non-zero-exit",
+          detail: "fatal: hook said timed out but exited non-zero",
+        });
+      }
+    }
+    expect(
+      execute.mock.calls.filter(
+        ([call]) => call.args.join(" ") === UNSEEDED_CAPTURE_PREFLIGHT_COMMAND,
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("bounds remembered capture failures and evicts the oldest workspace deterministically", async () => {
+    let preflightCalls = 0;
+    const execute = vi.fn<GitCoreShape["execute"]>((input) => {
+      const args = input.args.join(" ");
+      if (args === "rev-parse --git-path index") {
+        return Effect.succeed({ code: 0, stdout: `${input.cwd}/.git/index\n`, stderr: "" });
+      }
+      if (args === "rev-parse --verify HEAD") {
+        return Effect.succeed({ code: 1, stdout: "", stderr: "" });
+      }
+      if (args === UNSEEDED_CAPTURE_PREFLIGHT_COMMAND) {
+        preflightCalls += 1;
+        return Effect.fail(
+          new GitCommandError({
+            operation: input.operation,
+            command: "git ls-files --cached --others --exclude-standard -z",
+            cwd: input.cwd,
+            detail: "synthetic output overflow",
+            reason: "output-limit",
+          }),
+        );
+      }
+      throw new Error(`Unexpected git args: ${args}`);
+    });
+    const layer = CheckpointStoreLive.pipe(
+      Layer.provide(Layer.succeed(GitCore, { execute } as unknown as GitCoreShape)),
+      Layer.provide(NodeServices.layer),
+    );
+    runtime = ManagedRuntime.make(layer);
+
+    const { oldestRetry, newestRetry } = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CheckpointStore;
+        const cwdFor = (index: number) => join(tmpdir(), `synara-checkpoint-failure-${index}`);
+        const capture = (cwd: string, suffix: string) =>
+          store
+            .captureCheckpoint({
+              cwd,
+              checkpointRef: CheckpointRef.makeUnsafe(`refs/synara-checkpoints/thread/${suffix}`),
+            })
+            .pipe(Effect.result);
+
+        for (let index = 0; index < 65; index += 1) {
+          yield* capture(cwdFor(index), `initial-${index}`);
+        }
+        return {
+          oldestRetry: yield* capture(cwdFor(0), "oldest-retry"),
+          newestRetry: yield* capture(cwdFor(64), "newest-retry"),
+        };
+      }),
+    );
+
+    expect(preflightCalls).toBe(66);
+    expect(oldestRetry._tag).toBe("Failure");
+    if (oldestRetry._tag === "Failure") {
+      expect(oldestRetry.failure.message).toContain("safe scan budget");
+    }
+    expect(newestRetry._tag).toBe("Failure");
+    if (newestRetry._tag === "Failure") {
+      expect(newestRetry.failure.message).toContain("temporarily paused");
     }
   });
 
@@ -173,7 +460,10 @@ describe("CheckpointStoreLive", () => {
       if (args === "rev-parse --verify HEAD") {
         return Effect.succeed({ code: 1, stdout: "", stderr: "" });
       }
-      if (args === "add -A -- .") {
+      if (args === UNSEEDED_CAPTURE_PREFLIGHT_COMMAND) {
+        return Effect.succeed({ code: 0, stdout: "", stderr: "" });
+      }
+      if (args === CHECKPOINT_ADD_COMMAND) {
         addCalls += 1;
         if (addCalls === 1) {
           return Effect.never;
@@ -246,7 +536,10 @@ describe("CheckpointStoreLive", () => {
       if (args === "rev-parse --verify HEAD") {
         return Effect.succeed({ code: 1, stdout: "", stderr: "" });
       }
-      if (args === "add -A -- .") {
+      if (args === UNSEEDED_CAPTURE_PREFLIGHT_COMMAND) {
+        return Effect.succeed({ code: 0, stdout: "", stderr: "" });
+      }
+      if (args === CHECKPOINT_ADD_COMMAND) {
         return Effect.succeed({ code: 0, stdout: "", stderr: "" });
       }
       if (args === "write-tree") {
@@ -277,14 +570,14 @@ describe("CheckpointStoreLive", () => {
           checkpointRef: CheckpointRef.makeUnsafe(existingRef),
           skipIfExists: true,
         });
-        expect(captureArgs("add -A -- .")).toHaveLength(0);
+        expect(captureArgs(CHECKPOINT_ADD_COMMAND)).toHaveLength(0);
 
         yield* store.captureCheckpoint({
           cwd: "/repo",
           checkpointRef: CheckpointRef.makeUnsafe(missingRef),
           skipIfExists: true,
         });
-        expect(captureArgs("add -A -- .")).toHaveLength(1);
+        expect(captureArgs(CHECKPOINT_ADD_COMMAND)).toHaveLength(1);
         expect(captureArgs(`update-ref ${missingRef} commit-oid`)).toHaveLength(1);
       }),
     );

--- a/apps/server/src/checkpointing/Layers/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.ts
@@ -11,15 +11,42 @@
  */
 import { randomUUID } from "node:crypto";
 
-import { Cause, Deferred, Effect, Exit, Layer, FileSystem, Option, Path, Semaphore } from "effect";
+import {
+  Cause,
+  Clock,
+  Deferred,
+  Effect,
+  Exit,
+  Layer,
+  FileSystem,
+  Option,
+  Path,
+  Semaphore,
+} from "effect";
 
 import { CheckpointInvariantError, type CheckpointStoreError } from "../Errors.ts";
 import { GitCommandError } from "../../git/Errors.ts";
 import { GitCore } from "../../git/Services/GitCore.ts";
 import { CheckpointStore, type CheckpointStoreShape } from "../Services/CheckpointStore.ts";
 import { CheckpointRef } from "@synara/contracts";
+import { localPathComparisonKey } from "@synara/shared/path";
 
 const CHECKPOINT_DIFF_MAX_OUTPUT_BYTES = 10_000_000;
+
+// Without a working index Git has no stat cache to reuse, so `git add -A`
+// must discover and hash the workspace from scratch. Bound that cold path
+// before it can saturate the server on an accidentally broad repository root.
+const CHECKPOINT_UNSEEDED_LIST_MAX_OUTPUT_BYTES = 1_000_000;
+const CHECKPOINT_UNSEEDED_LIST_TIMEOUT_MS = 5_000;
+const CHECKPOINT_UNSEEDED_BUDGET_DETAIL =
+  "Checkpoint capture was skipped because this repository has no reusable Git index and its workspace could not be enumerated within the safe scan budget.";
+
+// A failed capture used to be retried independently by every domain/runtime
+// event. Keep the failure local to checkpointing and let provider delivery
+// continue without repeatedly launching the same expensive Git scan.
+const CHECKPOINT_CAPTURE_FAILURE_COOLDOWN_MS = 60_000;
+const CHECKPOINT_RECENT_FAILURE_MAX_ENTRIES = 64;
+const CHECKPOINT_ADD_MAX_OUTPUT_BYTES = 64 * 1_024;
 
 // Individual git commands are already bounded by GitCore's default timeout;
 // this aggregate cap exists to unstick the shared in-flight capture slot if a
@@ -28,17 +55,71 @@ const CHECKPOINT_DIFF_MAX_OUTPUT_BYTES = 10_000_000;
 // per-command timeouts would allow.
 const CHECKPOINT_CAPTURE_TIMEOUT_MS = 180_000;
 
+function shouldCoolDownCapture(error: CheckpointStoreError): boolean {
+  return (
+    (error._tag === "CheckpointInvariantError" &&
+      (error.detail === CHECKPOINT_UNSEEDED_BUDGET_DETAIL ||
+        error.detail.startsWith("Checkpoint capture timed out"))) ||
+    (error._tag === "GitCommandError" &&
+      (error.reason === "output-limit" || error.reason === "timeout"))
+  );
+}
+
+function captureKey(cwdKey: string, checkpointRef: CheckpointRef): string {
+  return `${cwdKey}\0${checkpointRef}`;
+}
+
 const makeCheckpointStore = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const git = yield* GitCore;
   const captureLock = yield* Semaphore.make(1);
   const inFlightCaptures = new Map<string, Deferred.Deferred<void, CheckpointStoreError>>();
+  const captureLanes = new Map<
+    string,
+    { readonly semaphore: Semaphore.Semaphore; users: number }
+  >();
+  const recentCaptureFailures = new Map<
+    string,
+    { readonly retryAtMillis: number; readonly error: CheckpointStoreError }
+  >();
 
-  // Normalize the cwd so captures for the same repo reached via differently
-  // written paths (trailing slash, relative segments) share one in-flight slot.
-  const captureKey = (input: { readonly cwd: string; readonly checkpointRef: CheckpointRef }) =>
-    `${path.resolve(input.cwd)}\0${input.checkpointRef}`;
+  // Resolve filesystem aliases when possible, then apply the same Windows
+  // separator/case rules used by the shared local-path helpers. A safe lexical
+  // fallback keeps synthetic/nonexistent test paths deterministic.
+  const resolveCaptureCwdKey = (cwd: string) => {
+    const resolved = path.resolve(cwd);
+    return fs.realPath(resolved).pipe(
+      Effect.catch(() => Effect.succeed(resolved)),
+      Effect.map(localPathComparisonKey),
+    );
+  };
+
+  const pruneRecentCaptureFailures = (nowMillis: number) => {
+    for (const [key, failure] of recentCaptureFailures) {
+      if (failure.retryAtMillis <= nowMillis) {
+        recentCaptureFailures.delete(key);
+      }
+    }
+  };
+
+  const rememberRecentCaptureFailure = (
+    cwdKey: string,
+    error: CheckpointStoreError,
+    failedAtMillis: number,
+  ) => {
+    pruneRecentCaptureFailures(failedAtMillis);
+    recentCaptureFailures.delete(cwdKey);
+    recentCaptureFailures.set(cwdKey, {
+      retryAtMillis: failedAtMillis + CHECKPOINT_CAPTURE_FAILURE_COOLDOWN_MS,
+      error,
+    });
+    while (recentCaptureFailures.size > CHECKPOINT_RECENT_FAILURE_MAX_ENTRIES) {
+      const oldestKey = recentCaptureFailures.keys().next().value;
+      if (oldestKey === undefined) break;
+      recentCaptureFailures.delete(oldestKey);
+    }
+  };
 
   const resolveHeadCommit = (cwd: string): Effect.Effect<string | null, GitCommandError> =>
     git
@@ -96,6 +177,28 @@ const makeCheckpointStore = Effect.gen(function* () {
       yield* fs.copyFile(indexPath, tempIndexPath);
       return indexInfo;
     });
+
+  const preflightUnseededCapture = (cwd: string): Effect.Effect<void, CheckpointStoreError> =>
+    git
+      .execute({
+        operation: "CheckpointStore.preflightUnseededCapture",
+        cwd,
+        args: ["ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+        timeoutMs: CHECKPOINT_UNSEEDED_LIST_TIMEOUT_MS,
+        maxOutputBytes: CHECKPOINT_UNSEEDED_LIST_MAX_OUTPUT_BYTES,
+      })
+      .pipe(
+        Effect.asVoid,
+        Effect.mapError((error) =>
+          error.reason === "timeout" || error.reason === "output-limit"
+            ? new CheckpointInvariantError({
+                operation: "CheckpointStore.captureCheckpoint",
+                detail: CHECKPOINT_UNSEEDED_BUDGET_DETAIL,
+                cause: error,
+              })
+            : error,
+        ),
+      );
 
   const resolveCheckpointCommit = (
     cwd: string,
@@ -160,13 +263,17 @@ const makeCheckpointStore = Effect.gen(function* () {
             };
 
             const workingIndexInfo = yield* seedCheckpointIndex(input.cwd, tempIndexPath);
-            if (workingIndexInfo === null && (yield* hasHeadCommit(input.cwd))) {
-              yield* git.execute({
-                operation,
-                cwd: input.cwd,
-                args: ["read-tree", "HEAD"],
-                env: commitEnv,
-              });
+            if (workingIndexInfo === null) {
+              const headExists = yield* hasHeadCommit(input.cwd);
+              yield* preflightUnseededCapture(input.cwd);
+              if (headExists) {
+                yield* git.execute({
+                  operation,
+                  cwd: input.cwd,
+                  args: ["read-tree", "HEAD"],
+                  env: commitEnv,
+                });
+              }
             }
             if (workingIndexInfo !== null) {
               // A copied index can describe a rapid same-size rewrite as clean
@@ -200,8 +307,10 @@ const makeCheckpointStore = Effect.gen(function* () {
             yield* git.execute({
               operation,
               cwd: input.cwd,
-              args: ["add", "-A", "--", "."],
+              args: ["add", "--no-warn-embedded-repo", "-A", "--", "."],
               env: commitEnv,
+              maxOutputBytes: CHECKPOINT_ADD_MAX_OUTPUT_BYTES,
+              outputMode: "truncate",
             });
 
             const writeTreeResult = yield* git.execute({
@@ -260,7 +369,8 @@ const makeCheckpointStore = Effect.gen(function* () {
 
   const captureCheckpoint: CheckpointStoreShape["captureCheckpoint"] = (input) =>
     Effect.gen(function* () {
-      const key = captureKey(input);
+      const cwdKey = yield* resolveCaptureCwdKey(input.cwd);
+      const key = captureKey(cwdKey, input.checkpointRef);
       const registration = yield* captureLock.withPermits(1)(
         Effect.gen(function* () {
           const existing = inFlightCaptures.get(key);
@@ -269,7 +379,13 @@ const makeCheckpointStore = Effect.gen(function* () {
           }
           const deferred = yield* Deferred.make<void, CheckpointStoreError>();
           inFlightCaptures.set(key, deferred);
-          return { owner: true as const, deferred };
+          let lane = captureLanes.get(cwdKey);
+          if (!lane) {
+            lane = { semaphore: yield* Semaphore.make(1), users: 0 };
+            captureLanes.set(cwdKey, lane);
+          }
+          lane.users += 1;
+          return { owner: true as const, deferred, lane };
         }),
       );
 
@@ -283,18 +399,50 @@ const makeCheckpointStore = Effect.gen(function* () {
         Effect.gen(function* () {
           const exit = yield* Effect.exit(
             restore(
-              captureCheckpointOnce(input).pipe(
-                Effect.timeoutOption(CHECKPOINT_CAPTURE_TIMEOUT_MS),
-                Effect.flatMap((completed) =>
-                  Option.isSome(completed)
-                    ? Effect.void
-                    : Effect.fail(
-                        new CheckpointInvariantError({
-                          operation: "CheckpointStore.captureCheckpoint",
-                          detail: `Checkpoint capture timed out after ${CHECKPOINT_CAPTURE_TIMEOUT_MS}ms.`,
-                        }),
-                      ),
-                ),
+              registration.lane.semaphore.withPermits(1)(
+                Effect.gen(function* () {
+                  const now = yield* Clock.currentTimeMillis;
+                  pruneRecentCaptureFailures(now);
+                  const recentFailure = recentCaptureFailures.get(cwdKey);
+                  if (recentFailure && recentFailure.retryAtMillis > now) {
+                    rememberRecentCaptureFailure(cwdKey, recentFailure.error, now);
+                    return yield* new CheckpointInvariantError({
+                      operation: "CheckpointStore.captureCheckpoint",
+                      detail: `Checkpoint capture is temporarily paused for this workspace after a recent failure (${CHECKPOINT_CAPTURE_FAILURE_COOLDOWN_MS}ms remaining): ${recentFailure.error.message}`,
+                      cause: recentFailure.error,
+                    });
+                  }
+
+                  yield* captureCheckpointOnce(input).pipe(
+                    Effect.timeoutOption(CHECKPOINT_CAPTURE_TIMEOUT_MS),
+                    Effect.flatMap((completed) =>
+                      Option.isSome(completed)
+                        ? Effect.void
+                        : Effect.fail(
+                            new CheckpointInvariantError({
+                              operation: "CheckpointStore.captureCheckpoint",
+                              detail: `Checkpoint capture timed out after ${CHECKPOINT_CAPTURE_TIMEOUT_MS}ms.`,
+                            }),
+                          ),
+                    ),
+                    Effect.tap(() =>
+                      Effect.sync(() => {
+                        recentCaptureFailures.delete(cwdKey);
+                      }),
+                    ),
+                    Effect.tapError((error) =>
+                      shouldCoolDownCapture(error)
+                        ? Clock.currentTimeMillis.pipe(
+                            Effect.tap((failedAtMillis) =>
+                              Effect.sync(() => {
+                                rememberRecentCaptureFailure(cwdKey, error, failedAtMillis);
+                              }),
+                            ),
+                          )
+                        : Effect.void,
+                    ),
+                  );
+                }),
               ),
             ),
           );
@@ -311,7 +459,15 @@ const makeCheckpointStore = Effect.gen(function* () {
                 )
               : exit;
           yield* Deferred.done(registration.deferred, waiterExit);
-          yield* captureLock.withPermits(1)(Effect.sync(() => inFlightCaptures.delete(key)));
+          yield* captureLock.withPermits(1)(
+            Effect.sync(() => {
+              inFlightCaptures.delete(key);
+              registration.lane.users -= 1;
+              if (registration.lane.users === 0) {
+                captureLanes.delete(cwdKey);
+              }
+            }),
+          );
           if (Exit.isFailure(exit)) {
             return yield* Effect.failCause(exit.cause);
           }

--- a/apps/server/src/git/Errors.ts
+++ b/apps/server/src/git/Errors.ts
@@ -8,6 +8,9 @@ export class GitCommandError extends Schema.TaggedErrorClass<GitCommandError>()(
   command: Schema.String,
   cwd: Schema.String,
   detail: Schema.String,
+  reason: Schema.optional(
+    Schema.Literals(["timeout", "output-limit", "non-zero-exit", "spawn", "stream"]),
+  ),
   cause: Schema.optional(Schema.Defect),
 }) {
   override get message(): string {

--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -332,6 +332,25 @@ it.layer(TestLayer)("git integration", (it) => {
       }),
     );
 
+    it.effect("classifies output overflow without parsing the error message", () =>
+      Effect.gen(function* () {
+        const result = yield* Effect.result(
+          collectGitOutput(
+            { operation: "test output limit", cwd: process.cwd(), args: ["status"] },
+            Stream.make(new TextEncoder().encode("too much output")),
+            4,
+            undefined,
+            "error",
+          ),
+        );
+
+        expect(result._tag).toBe("Failure");
+        if (result._tag === "Failure") {
+          expect(result.failure.reason).toBe("output-limit");
+        }
+      }),
+    );
+
     it.effect("preserves NUL-delimited paths across byte chunks beyond the capture limit", () =>
       Effect.gen(function* () {
         const records = ["R100", "old\r\nname", "new é\tname"];

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -406,6 +406,7 @@ function parseStashEntries(input: string): StashEntry[] {
 function toGitCommandError(
   input: Pick<ExecuteGitInput, "operation" | "cwd" | "args">,
   detail: string,
+  reason?: GitCommandError["reason"],
 ) {
   return (cause: unknown) =>
     Schema.is(GitCommandError)(cause)
@@ -415,6 +416,7 @@ function toGitCommandError(
           command: commandLabel(input.args),
           cwd: input.cwd,
           detail: `${cause instanceof Error && cause.message.length > 0 ? cause.message : "Unknown error"} - ${detail}`,
+          ...(reason !== undefined ? { reason } : {}),
           ...(cause !== undefined ? { cause } : {}),
         });
 }
@@ -641,6 +643,7 @@ export const collectGitOutput = Effect.fn(function* <E>(
           command: commandLabel(input.args),
           cwd: input.cwd,
           detail: `${commandLabel(input.args)} output exceeded ${maxOutputBytes} bytes and was truncated.`,
+          reason: "output-limit",
         });
       }
       const decoded = decoder.decode(chunk, { stream: true });
@@ -653,7 +656,7 @@ export const collectGitOutput = Effect.fn(function* <E>(
         lineBuffer = lineBuffer.slice(-maxOutputBytes);
       }
     }),
-  ).pipe(Effect.mapError(toGitCommandError(input, "output stream failed.")));
+  ).pipe(Effect.mapError(toGitCommandError(input, "output stream failed.", "stream")));
 
   const remainder = decoder.decode();
   if (text.length < maxOutputBytes) {
@@ -726,7 +729,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
                 },
               }),
             )
-            .pipe(Effect.mapError(toGitCommandError(commandInput, "failed to spawn.")));
+            .pipe(Effect.mapError(toGitCommandError(commandInput, "failed to spawn.", "spawn")));
           // Keep cancellation ownership explicit even though spawn is already
           // Scope-bound: an RPC interruption closes this Scope and kills the child
           // before execute settles. The spawner's own finalizer safely handles the
@@ -752,7 +755,9 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
               ),
               child.exitCode.pipe(
                 Effect.map((value) => Number(value)),
-                Effect.mapError(toGitCommandError(commandInput, "failed to report exit code.")),
+                Effect.mapError(
+                  toGitCommandError(commandInput, "failed to report exit code.", "stream"),
+                ),
               ),
             ],
             { concurrency: "unbounded" },
@@ -769,6 +774,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
                 trimmedStderr.length > 0
                   ? `${commandLabel(commandInput.args)} failed: ${trimmedStderr}`
                   : `${commandLabel(commandInput.args)} failed with code ${exitCode}.`,
+              reason: "non-zero-exit",
             });
           }
 
@@ -787,6 +793,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
                     command: commandLabel(commandInput.args),
                     cwd: commandInput.cwd,
                     detail: `${commandLabel(commandInput.args)} timed out.`,
+                    reason: "timeout",
                   }),
                 ),
               onSome: Effect.succeed,

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -743,14 +743,15 @@ describe("OrchestrationEngine", () => {
     await system.dispose();
   });
 
-  it("keeps dispatch responsive and replays every event when a subscriber falls behind", async () => {
+  it("keeps session updates responsive and replays every event when a subscriber falls behind", async () => {
     const system = await createOrchestrationSystem();
     const { engine } = system;
     const projectId = asProjectId("project-slow-subscriber");
+    const threadId = ThreadId.makeUnsafe("thread-slow-subscriber");
     // Overflow by more than one durable replay page (500 events).
     const count = ORCHESTRATION_EVENT_PUBSUB_CAPACITY + 510;
     try {
-      const initial = await system.run(
+      await system.run(
         engine.dispatch({
           type: "project.create",
           commandId: CommandId.makeUnsafe("cmd-slow-subscriber-create"),
@@ -761,11 +762,29 @@ describe("OrchestrationEngine", () => {
           createdAt: now(),
         }),
       );
+      const initial = await system.run(
+        engine.dispatch({
+          type: "thread.create",
+          commandId: CommandId.makeUnsafe("cmd-slow-subscriber-thread-create"),
+          threadId,
+          projectId,
+          title: "Slow subscriber thread",
+          modelSelection: {
+            provider: "codex",
+            model: "gpt-5-codex",
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          branch: null,
+          worktreePath: null,
+          createdAt: now(),
+        }),
+      );
       const result = await system.run(
         Effect.gen(function* () {
           // Attach before loading/processing work, as startup and reactors do.
           const live = yield* engine.subscribeDomainEvents;
-          for (let i = 0; i < count; i++) {
+          for (let i = 0; i < count - 1; i++) {
             yield* engine.dispatch({
               type: "project.meta.update",
               commandId: CommandId.makeUnsafe(`cmd-slow-subscriber-${i}`),
@@ -773,6 +792,22 @@ describe("OrchestrationEngine", () => {
               title: `Update ${i}`,
             });
           }
+          const updatedAt = now();
+          yield* engine.dispatch({
+            type: "thread.session.set",
+            commandId: CommandId.makeUnsafe("cmd-slow-subscriber-session-set"),
+            threadId,
+            session: {
+              threadId,
+              status: "ready",
+              providerName: "codex",
+              runtimeMode: "approval-required",
+              activeTurnId: null,
+              lastError: null,
+              updatedAt,
+            },
+            createdAt: updatedAt,
+          });
           return Array.from(yield* Stream.runCollect(Stream.take(live, count)));
         }).pipe(Effect.scoped, Effect.timeoutOption("8 seconds")),
       );
@@ -781,7 +816,10 @@ describe("OrchestrationEngine", () => {
       expect(events.map((event) => event.sequence)).toEqual(
         Array.from({ length: count }, (_, i) => initial.sequence + i + 1),
       );
-      expect(events.at(-1)?.payload).toMatchObject({ title: `Update ${count - 1}` });
+      expect(events.at(-1)).toMatchObject({
+        type: "thread.session-set",
+        payload: { threadId, session: { status: "ready" } },
+      });
     } finally {
       await system.dispose();
     }

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -87,6 +87,7 @@ import {
   classifyProviderAttemptOutcome,
   isSafeLegacyProviderBlocker,
   makeProviderCommandReactorLive,
+  withProviderMessageStartCheckpointBudget,
 } from "./ProviderCommandReactor.ts";
 import {
   OrchestrationEngineService,
@@ -103,6 +104,7 @@ import { resolveProviderAttachmentPath } from "../../provider/providerAttachment
 import { PROVIDER_DEBUG_MODE_PROMPT_PREFIX } from "../../provider/debugMode.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { checkpointRefForThreadTurn } from "../../checkpointing/Utils.ts";
+import { CheckpointInvariantError } from "../../checkpointing/Errors.ts";
 import {
   CheckpointStore,
   type CheckpointStoreShape,
@@ -6226,6 +6228,39 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
+  it("interrupts checkpoint work that exceeds the provider-start budget", async () => {
+    let finalized = false;
+    const startedAt = Date.now();
+    const result = await Effect.runPromise(
+      withProviderMessageStartCheckpointBudget(
+        Effect.never.pipe(
+          Effect.ensuring(
+            Effect.sleep("100 millis").pipe(
+              Effect.andThen(
+                Effect.sync(() => {
+                  finalized = true;
+                }),
+              ),
+            ),
+          ),
+        ),
+        5,
+        10,
+      ).pipe(Effect.result),
+    );
+
+    expect(result._tag).toBe("Failure");
+    if (result._tag === "Failure") {
+      expect(result.failure).toMatchObject({
+        _tag: "CheckpointInvariantError",
+        detail: "Provider turn checkpoint exceeded its 5ms start budget.",
+      });
+    }
+    expect(Date.now() - startedAt).toBeLessThan(80);
+    expect(finalized).toBe(false);
+    await waitFor(() => finalized);
+  });
+
   it("waits for the message-start checkpoint before sending the provider turn", async () => {
     let releaseCapture: (() => void) | undefined;
     const captureGate = new Promise<void>((resolve) => {
@@ -6271,6 +6306,43 @@ describe("ProviderCommandReactor", () => {
       cwd: "/tmp/provider-project",
     });
     expect(captureCheckpoint.mock.calls[0]?.[0].checkpointRef).toContain("/message-start/");
+  });
+
+  it("continues provider delivery when the message-start checkpoint is safely skipped", async () => {
+    const captureCheckpoint = vi.fn<CheckpointStoreShape["captureCheckpoint"]>(() =>
+      Effect.fail(
+        new CheckpointInvariantError({
+          operation: "CheckpointStore.captureCheckpoint",
+          detail: "workspace exceeded the safe scan budget",
+        }),
+      ),
+    );
+    const harness = await createHarness({
+      checkpointStore: {
+        isGitRepository: vi.fn<CheckpointStoreShape["isGitRepository"]>(() => Effect.succeed(true)),
+        captureCheckpoint,
+      },
+    });
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-skipped-checkpoint"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-skipped-checkpoint"),
+          role: "user",
+          text: "continue despite an unsafe checkpoint scan",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: new Date().toISOString(),
+      }),
+    );
+
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    expect(captureCheckpoint).toHaveBeenCalledTimes(1);
   });
 
   it("waits for the Studio output baseline before sending the provider turn", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -36,6 +36,7 @@ import {
   Effect,
   Equal,
   Exit,
+  Fiber,
   Layer,
   Option,
   Queue,
@@ -69,6 +70,7 @@ import {
   checkpointRefForThreadTurn,
   resolveThreadWorkspaceCwd,
 } from "../../checkpointing/Utils.ts";
+import { CheckpointInvariantError } from "../../checkpointing/Errors.ts";
 import { CheckpointStore } from "../../checkpointing/Services/CheckpointStore.ts";
 import { AgentGatewayOperationRepository } from "../../agentGateway/Services/AgentGatewayOperationRepository.ts";
 import { GitCore } from "../../git/Services/GitCore.ts";
@@ -147,6 +149,42 @@ import { deriveTurnStartSession } from "../turnStartSession.ts";
 import { TurnCheckpointCoordinator } from "../Services/TurnCheckpointCoordinator.ts";
 import { resolveProviderSessionThread as resolveProviderSessionThreadFromProjection } from "../providerSessionThread.ts";
 import { isExpiredSidechat } from "../sidechatLifecycle.ts";
+
+const PROVIDER_MESSAGE_START_CHECKPOINT_TIMEOUT_MS = 10_000;
+const PROVIDER_MESSAGE_START_CHECKPOINT_CLEANUP_GRACE_MS = 1_000;
+
+export function withProviderMessageStartCheckpointBudget<E, R>(
+  capture: Effect.Effect<void, E, R>,
+  timeoutMs = PROVIDER_MESSAGE_START_CHECKPOINT_TIMEOUT_MS,
+  cleanupGraceMs = PROVIDER_MESSAGE_START_CHECKPOINT_CLEANUP_GRACE_MS,
+): Effect.Effect<void, E | CheckpointInvariantError, R> {
+  return Effect.gen(function* () {
+    // Detach the capture so a stuck resource finalizer cannot keep the provider
+    // command fiber beyond the explicit cleanup grace period. The timeout path
+    // still requests interruption immediately; cleanup may finish in the
+    // global scope after provider delivery resumes.
+    const captureFiber = yield* capture.pipe(Effect.forkDetach({ startImmediately: true }));
+    const requestInterrupt = Fiber.interrupt(captureFiber);
+    const completed = yield* Fiber.await(captureFiber).pipe(
+      Effect.timeoutOption(timeoutMs),
+      Effect.onInterrupt(() =>
+        requestInterrupt.pipe(Effect.forkDetach({ startImmediately: true }), Effect.asVoid),
+      ),
+    );
+    if (Option.isSome(completed)) {
+      if (Exit.isFailure(completed.value)) {
+        return yield* Effect.failCause(completed.value.cause);
+      }
+      return;
+    }
+
+    yield* requestInterrupt.pipe(Effect.timeoutOption(cleanupGraceMs));
+    return yield* new CheckpointInvariantError({
+      operation: "ProviderCommandReactor.captureMessageStartCheckpoint",
+      detail: `Provider turn checkpoint exceeded its ${timeoutMs}ms start budget.`,
+    });
+  });
+}
 
 type ProviderQueueDrainEvent = Extract<
   ProviderRuntimeEvent,
@@ -2379,33 +2417,35 @@ const make = Effect.gen(function* () {
         ...(messageText ? { input: messageText } : {}),
       });
 
-    const captureMessageStartCheckpoint = Effect.gen(function* () {
-      if ((input.dispatchMode ?? "queue") === "steer") {
-        return;
-      }
+    const captureMessageStartCheckpoint = withProviderMessageStartCheckpointBudget(
+      Effect.gen(function* () {
+        if ((input.dispatchMode ?? "queue") === "steer") {
+          return;
+        }
 
-      const currentThread = yield* resolveThread(input.threadId);
-      if (!currentThread) {
-        return;
-      }
+        const currentThread = yield* resolveThread(input.threadId);
+        if (!currentThread) {
+          return;
+        }
 
-      const cwd = yield* resolveProjectedThreadWorkspaceCwd(currentThread);
-      if (!cwd || !(yield* checkpointStore.isGitRepository(cwd))) {
-        return;
-      }
+        const cwd = yield* resolveProjectedThreadWorkspaceCwd(currentThread);
+        if (!cwd || !(yield* checkpointStore.isGitRepository(cwd))) {
+          return;
+        }
 
-      // Capture before provider dispatch so the later turn diff is bounded by
-      // the user's submit moment, not early provider edits. skipIfExists keeps
-      // a backup baseline from CheckpointReactor as the first-writer winner.
-      yield* checkpointStore.captureCheckpoint({
-        cwd,
-        checkpointRef: checkpointRefForThreadMessageStart(
-          input.threadId,
-          MessageId.makeUnsafe(input.messageId),
-        ),
-        skipIfExists: true,
-      });
-    }).pipe(
+        // Capture before provider dispatch so the later turn diff is bounded by
+        // the user's submit moment, not early provider edits. skipIfExists keeps
+        // a backup baseline from CheckpointReactor as the first-writer winner.
+        yield* checkpointStore.captureCheckpoint({
+          cwd,
+          checkpointRef: checkpointRefForThreadMessageStart(
+            input.threadId,
+            MessageId.makeUnsafe(input.messageId),
+          ),
+          skipIfExists: true,
+        });
+      }),
+    ).pipe(
       Effect.catchCause((cause) =>
         Effect.logWarning("failed to capture provider turn start checkpoint", {
           threadId: input.threadId,

--- a/apps/server/src/provider/providerModelDiscoveryCache.test.ts
+++ b/apps/server/src/provider/providerModelDiscoveryCache.test.ts
@@ -275,7 +275,7 @@ describe("makeProviderModelDiscoveryCache", () => {
     await Effect.runPromise(cache.lookup(KEY, discover));
     clock.advance(5_000);
     await Effect.runPromise(cache.lookup(KEY, discover));
-    await flush();
+    await expect.poll(() => cache.size(), { timeout: 5_000 }).toBe(0);
     const results = await Effect.runPromise(
       Effect.all([cache.lookup(KEY, discover), cache.lookup(KEY, discover)], {
         concurrency: "unbounded",

--- a/packages/shared/src/path.test.ts
+++ b/packages/shared/src/path.test.ts
@@ -4,8 +4,28 @@ import {
   isLocalAbsolutePath,
   isWorkspaceRelativePathSafe,
   joinWorkspaceRelativePath,
+  localPathComparisonKey,
+  localPathsEqual,
   workspaceRelativePathOf,
 } from "./path";
+
+describe("localPathComparisonKey", () => {
+  it("normalizes Windows drive and UNC aliases for map keys", () => {
+    expect(localPathComparisonKey("C:\\Repo\\App\\")).toBe("c:/repo/app");
+    expect(localPathComparisonKey("c:/repo/app")).toBe("c:/repo/app");
+    expect(localPathComparisonKey("\\\\Server\\Share\\Repo\\")).toBe("//server/share/repo");
+    expect(localPathsEqual("C:\\Repo\\App\\", "c:/repo/app")).toBe(true);
+  });
+
+  it("keeps POSIX keys case-sensitive", () => {
+    expect(localPathComparisonKey("/Repo/App/")).toBe("/Repo/App");
+    expect(localPathsEqual("/Repo/App", "/repo/app")).toBe(false);
+  });
+
+  it("does not apply absolute Windows casing rules to drive-relative paths", () => {
+    expect(localPathsEqual("C:/", "c:")).toBe(false);
+  });
+});
 
 describe("isWorkspaceRelativePathSafe", () => {
   it("accepts plain workspace-relative paths", () => {

--- a/packages/shared/src/path.ts
+++ b/packages/shared/src/path.ts
@@ -44,15 +44,24 @@ export function isNormalizedWindowsAbsolutePath(value: string): boolean {
   return isWindowsDrivePath(value) || value.startsWith("//");
 }
 
+export function localPathComparisonKey(value: string): string {
+  const normalized = normalizePathSeparators(value.trim());
+  const withoutTrailing = normalized.replace(/\/+$/, "");
+  return isNormalizedWindowsAbsolutePath(normalized)
+    ? withoutTrailing.toLowerCase()
+    : withoutTrailing;
+}
+
 export function localPathsEqual(left: string, right: string): boolean {
   const normalizedLeft = normalizePathSeparators(left.trim());
   const normalizedRight = normalizePathSeparators(right.trim());
-  const leftWithoutTrailing = normalizedLeft.replace(/\/+$/, "");
-  const rightWithoutTrailing = normalizedRight.replace(/\/+$/, "");
-  return isNormalizedWindowsAbsolutePath(normalizedLeft) &&
+  if (
+    isNormalizedWindowsAbsolutePath(normalizedLeft) &&
     isNormalizedWindowsAbsolutePath(normalizedRight)
-    ? leftWithoutTrailing.toLowerCase() === rightWithoutTrailing.toLowerCase()
-    : leftWithoutTrailing === rightWithoutTrailing;
+  ) {
+    return localPathComparisonKey(normalizedLeft) === localPathComparisonKey(normalizedRight);
+  }
+  return normalizedLeft.replace(/\/+$/, "") === normalizedRight.replace(/\/+$/, "");
 }
 
 function windowsRelativePathOf(targetPath: string, workspaceRoot: string): string | null {


### PR DESCRIPTION
## Summary
- bound checkpoint capture on unseeded or slow Git workspaces, serialize captures per canonical workspace, and cool down repeated budget failures
- keep provider turn delivery responsive with a hard checkpoint-start budget and detached cleanup
- classify Git command failures structurally and bound retained `git add` output without mutating the user's real index
- verify durable orchestration replay reaches `thread.session.set` after a slow subscriber exceeds the live event window

## Verification
- relevant Vitest suites: 282 assertions passed across CheckpointStore, ProviderCommandReactor, OrchestrationEngine, and shared path handling
- GitCore output-limit classification: 1 passed (137 filtered)
- slow-subscriber `thread.session.set` stress: 5/5 passes, 4.56-4.92s process wall time per run
- `bun run lint`: passed (baseline warnings only)
- `bun run typecheck`: 7/7 packages passed
- formatting: all 10 changed files passed in the Windows checkout; full 3,081-file check passed in an isolated LF checkout (the working checkout's full check reports baseline CRLF differences)
- `bun run build:desktop`: 4/4 build tasks passed
- `bun run release:smoke`: passed
- isolated Canary: backend started on loopback using task-owned Synara and Codex state, then the full Canary process tree was stopped

## Notes
- no Stable Synara Desktop data or live Codex state was modified
- the installed Stable build remains unchanged; this PR contains the source fix