### PR TITLE
Bound provider start checkpoint latency

### DIFF
--- a/apps/server/src/checkpointing/Errors.ts
+++ b/apps/server/src/checkpointing/Errors.ts
@@ -35,8 +35,29 @@ export class CheckpointInvariantError extends Schema.TaggedErrorClass<Checkpoint
   }
 }
 
+/**
+ * CheckpointCaptureBudgetExceededError - Advisory capture exceeded its resource policy.
+ *
+ * Intentionally excludes workspace paths and subprocess output so a skipped
+ * pre-turn checkpoint can be logged without exposing filenames.
+ */
+export class CheckpointCaptureBudgetExceededError extends Schema.TaggedErrorClass<CheckpointCaptureBudgetExceededError>()(
+  "CheckpointCaptureBudgetExceededError",
+  {
+    operation: Schema.String,
+    reason: Schema.Literals(["timeout", "unseeded-scan", "cooldown"]),
+    timeoutMs: Schema.Number,
+    detail: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Checkpoint capture skipped (${this.reason}): ${this.detail}`;
+  }
+}
+
 export type CheckpointStoreError =
   | GitCommandError
+  | CheckpointCaptureBudgetExceededError
   | CheckpointInvariantError
   | CheckpointUnavailableError;
 

--- a/apps/server/src/checkpointing/Layers/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.test.ts
@@ -25,6 +25,11 @@ async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<voi
   throw new Error("Timed out waiting for condition");
 }
 
+const makeGitCore = (
+  execute: GitCoreShape["execute"],
+  withMutation: GitCoreShape["withMutation"] = (_cwd, effect) => effect,
+): GitCoreShape => ({ execute, withMutation }) as unknown as GitCoreShape;
+
 describe("CheckpointStoreLive", () => {
   let runtime: ManagedRuntime.ManagedRuntime<CheckpointStore, unknown> | null = null;
 
@@ -63,7 +68,7 @@ describe("CheckpointStoreLive", () => {
       throw new Error(`Unexpected git args: ${args}`);
     });
     const layer = CheckpointStoreLive.pipe(
-      Layer.provide(Layer.succeed(GitCore, { execute } as unknown as GitCoreShape)),
+      Layer.provide(Layer.succeed(GitCore, makeGitCore(execute))),
       Layer.provide(NodeServices.layer),
     );
     runtime = ManagedRuntime.make(layer);
@@ -132,7 +137,7 @@ describe("CheckpointStoreLive", () => {
       throw new Error(`Unexpected git args: ${args}`);
     });
     const layer = CheckpointStoreLive.pipe(
-      Layer.provide(Layer.succeed(GitCore, { execute } as unknown as GitCoreShape)),
+      Layer.provide(Layer.succeed(GitCore, makeGitCore(execute))),
       Layer.provide(NodeServices.layer),
     );
     runtime = ManagedRuntime.make(layer);
@@ -192,7 +197,7 @@ describe("CheckpointStoreLive", () => {
       throw new Error(`Unexpected git args: ${args}`);
     });
     const layer = CheckpointStoreLive.pipe(
-      Layer.provide(Layer.succeed(GitCore, { execute } as unknown as GitCoreShape)),
+      Layer.provide(Layer.succeed(GitCore, makeGitCore(execute))),
       Layer.provide(NodeServices.layer),
     );
     runtime = ManagedRuntime.make(layer);
@@ -229,6 +234,135 @@ describe("CheckpointStoreLive", () => {
     );
   });
 
+  it("bounds an advisory capture instead of holding the provider start path", async () => {
+    const execute = vi.fn<GitCoreShape["execute"]>((input) => {
+      const args = input.args.join(" ");
+      if (args === "rev-parse --git-path index") {
+        return Effect.succeed({ code: 0, stdout: "/repo/.git/index\n", stderr: "" });
+      }
+      if (args === "rev-parse --verify HEAD") {
+        return Effect.succeed({ code: 1, stdout: "", stderr: "" });
+      }
+      if (args === "ls-files --cached --others --exclude-standard -z") {
+        return Effect.succeed({ code: 0, stdout: "", stderr: "" });
+      }
+      if (args === "add -A -- .") {
+        return Effect.never;
+      }
+      throw new Error(`Unexpected git args: ${args}`);
+    });
+    let mutationCalls = 0;
+    const withMutation: GitCoreShape["withMutation"] = (_cwd, effect) =>
+      Effect.sync(() => {
+        mutationCalls += 1;
+      }).pipe(Effect.andThen(effect));
+    const layer = CheckpointStoreLive.pipe(
+      Layer.provide(Layer.succeed(GitCore, makeGitCore(execute, withMutation))),
+      Layer.provide(NodeServices.layer),
+    );
+    runtime = ManagedRuntime.make(layer);
+
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CheckpointStore;
+        const input = {
+          cwd: "/repo",
+          checkpointRef: CheckpointRef.makeUnsafe("refs/synara-checkpoints/thread/advisory-budget"),
+          policy: {
+            timeoutMs: 25,
+            maxOutputBytes: 1_024,
+            unseededScanMaxOutputBytes: 4_096,
+            failureCooldownMs: 1_000,
+          },
+        };
+        const attempt = () =>
+          store.captureCheckpoint(input).pipe(
+            Effect.map(() => "completed" as const),
+            Effect.catch((error) =>
+              Effect.succeed({ tag: error._tag, reason: "reason" in error ? error.reason : null }),
+            ),
+            Effect.timeoutOption("250 millis"),
+            Effect.map(
+              Option.getOrElse(() => ({ tag: "external-timeout" as const, reason: null })),
+            ),
+          );
+        const first = yield* attempt();
+        const second = yield* attempt();
+        return { first, second };
+      }),
+    );
+
+    expect(result.first).toEqual({
+      tag: "CheckpointCaptureBudgetExceededError",
+      reason: "timeout",
+    });
+    expect(result.second).toEqual({
+      tag: "CheckpointCaptureBudgetExceededError",
+      reason: "cooldown",
+    });
+    expect(mutationCalls).toBe(1);
+    const addCalls = execute.mock.calls.filter(([call]) => call.args.join(" ") === "add -A -- .");
+    expect(addCalls).toHaveLength(1);
+    expect(addCalls[0]?.[0]).toMatchObject({
+      maxOutputBytes: 1_024,
+      outputMode: "truncate",
+    });
+  });
+
+  it("rejects an oversized unseeded scan before git add", async () => {
+    const execute = vi.fn<GitCoreShape["execute"]>((input) => {
+      const args = input.args.join(" ");
+      if (args === "rev-parse --git-path index") {
+        return Effect.succeed({ code: 0, stdout: "/repo/.git/index\n", stderr: "" });
+      }
+      if (args === "ls-files --cached --others --exclude-standard -z") {
+        return Effect.fail(
+          new GitCommandError({
+            operation: input.operation,
+            command: args,
+            cwd: input.cwd,
+            detail: "output exceeded limit and included a private path",
+          }),
+        );
+      }
+      throw new Error(`Unexpected git args: ${args}`);
+    });
+    const layer = CheckpointStoreLive.pipe(
+      Layer.provide(Layer.succeed(GitCore, makeGitCore(execute))),
+      Layer.provide(NodeServices.layer),
+    );
+    runtime = ManagedRuntime.make(layer);
+
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CheckpointStore;
+        return yield* store
+          .captureCheckpoint({
+            cwd: "/repo",
+            checkpointRef: CheckpointRef.makeUnsafe(
+              "refs/synara-checkpoints/thread/unseeded-budget",
+            ),
+            policy: {
+              timeoutMs: 100,
+              maxOutputBytes: 1_024,
+              unseededScanMaxOutputBytes: 4_096,
+            },
+          })
+          .pipe(
+            Effect.map(() => ({ tag: "completed", message: "" })),
+            Effect.catch((error) => Effect.succeed({ tag: error._tag, message: error.message })),
+          );
+      }),
+    );
+
+    expect(result).toEqual({
+      tag: "CheckpointCaptureBudgetExceededError",
+      message:
+        "Checkpoint capture skipped (unseeded-scan): The unseeded workspace scan exceeded its advisory budget.",
+    });
+    expect(execute.mock.calls.some(([call]) => call.args.join(" ") === "add -A -- .")).toBe(false);
+  });
+
   it("skips the capture when skipIfExists is set and the ref already exists", async () => {
     const existingRef = "refs/synara-checkpoints/thread/existing";
     const missingRef = "refs/synara-checkpoints/thread/missing";
@@ -261,7 +395,7 @@ describe("CheckpointStoreLive", () => {
       throw new Error(`Unexpected git args: ${args}`);
     });
     const layer = CheckpointStoreLive.pipe(
-      Layer.provide(Layer.succeed(GitCore, { execute } as unknown as GitCoreShape)),
+      Layer.provide(Layer.succeed(GitCore, makeGitCore(execute))),
       Layer.provide(NodeServices.layer),
     );
     runtime = ManagedRuntime.make(layer);
@@ -328,7 +462,7 @@ describe("CheckpointStoreLive", () => {
       throw new Error(`Unexpected git args: ${args}`);
     });
     const layer = CheckpointStoreLive.pipe(
-      Layer.provide(Layer.succeed(GitCore, { execute } as unknown as GitCoreShape)),
+      Layer.provide(Layer.succeed(GitCore, makeGitCore(execute))),
       Layer.provide(NodeServices.layer),
     );
     runtime = ManagedRuntime.make(layer);
@@ -368,7 +502,7 @@ describe("CheckpointStoreLive", () => {
       throw new Error(`Unexpected git args: ${args}`);
     });
     const layer = CheckpointStoreLive.pipe(
-      Layer.provide(Layer.succeed(GitCore, { execute } as unknown as GitCoreShape)),
+      Layer.provide(Layer.succeed(GitCore, makeGitCore(execute))),
       Layer.provide(NodeServices.layer),
     );
     runtime = ManagedRuntime.make(layer);
@@ -401,7 +535,7 @@ describe("CheckpointStoreLive", () => {
       Effect.succeed({ code: 0, stdout: "", stderr: "" }),
     );
     const layer = CheckpointStoreLive.pipe(
-      Layer.provide(Layer.succeed(GitCore, { execute } as unknown as GitCoreShape)),
+      Layer.provide(Layer.succeed(GitCore, makeGitCore(execute))),
       Layer.provide(NodeServices.layer),
     );
     runtime = ManagedRuntime.make(layer);

--- a/apps/server/src/checkpointing/Layers/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.ts
@@ -11,9 +11,24 @@
  */
 import { randomUUID } from "node:crypto";
 
-import { Cause, Deferred, Effect, Exit, Layer, FileSystem, Option, Path, Semaphore } from "effect";
+import {
+  Cause,
+  Clock,
+  Deferred,
+  Effect,
+  Exit,
+  Layer,
+  FileSystem,
+  Option,
+  Path,
+  Semaphore,
+} from "effect";
 
-import { CheckpointInvariantError, type CheckpointStoreError } from "../Errors.ts";
+import {
+  CheckpointCaptureBudgetExceededError,
+  CheckpointInvariantError,
+  type CheckpointStoreError,
+} from "../Errors.ts";
 import { GitCommandError } from "../../git/Errors.ts";
 import { GitCore } from "../../git/Services/GitCore.ts";
 import { CheckpointStore, type CheckpointStoreShape } from "../Services/CheckpointStore.ts";
@@ -27,6 +42,7 @@ const CHECKPOINT_DIFF_MAX_OUTPUT_BYTES = 10_000_000;
 // the worst per-command-capped chain, so it never truncates a capture the
 // per-command timeouts would allow.
 const CHECKPOINT_CAPTURE_TIMEOUT_MS = 180_000;
+const MAX_CAPTURE_COOLDOWNS = 128;
 
 const makeCheckpointStore = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem;
@@ -34,11 +50,32 @@ const makeCheckpointStore = Effect.gen(function* () {
   const git = yield* GitCore;
   const captureLock = yield* Semaphore.make(1);
   const inFlightCaptures = new Map<string, Deferred.Deferred<void, CheckpointStoreError>>();
+  const captureFailureCooldowns = new Map<string, number>();
 
   // Normalize the cwd so captures for the same repo reached via differently
   // written paths (trailing slash, relative segments) share one in-flight slot.
   const captureKey = (input: { readonly cwd: string; readonly checkpointRef: CheckpointRef }) =>
     `${path.resolve(input.cwd)}\0${input.checkpointRef}`;
+  const captureCooldownKey = (cwd: string) => path.resolve(cwd);
+
+  const pruneCaptureCooldowns = (now: number) => {
+    for (const [key, expiresAt] of captureFailureCooldowns) {
+      if (expiresAt <= now) {
+        captureFailureCooldowns.delete(key);
+      }
+    }
+  };
+
+  const recordCaptureCooldown = (key: string, now: number, cooldownMs: number) => {
+    pruneCaptureCooldowns(now);
+    captureFailureCooldowns.delete(key);
+    while (captureFailureCooldowns.size >= MAX_CAPTURE_COOLDOWNS) {
+      const oldestKey = captureFailureCooldowns.keys().next().value;
+      if (oldestKey === undefined) break;
+      captureFailureCooldowns.delete(oldestKey);
+    }
+    captureFailureCooldowns.set(key, now + cooldownMs);
+  };
 
   const resolveHeadCommit = (cwd: string): Effect.Effect<string | null, GitCommandError> =>
     git
@@ -160,6 +197,36 @@ const makeCheckpointStore = Effect.gen(function* () {
             };
 
             const workingIndexInfo = yield* seedCheckpointIndex(input.cwd, tempIndexPath);
+            const capturePolicy = input.policy;
+            if (
+              workingIndexInfo === null &&
+              capturePolicy?.unseededScanMaxOutputBytes !== undefined
+            ) {
+              // An unseeded index forces Git to enumerate every tracked and
+              // untracked path. Prove that enumeration fits the advisory
+              // budget before starting the more expensive add/hash pass.
+              yield* git
+                .execute({
+                  operation: "CheckpointStore.preflightUnseededCapture",
+                  cwd: input.cwd,
+                  args: ["ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+                  maxOutputBytes: capturePolicy.unseededScanMaxOutputBytes,
+                  outputMode: "error",
+                })
+                .pipe(
+                  Effect.asVoid,
+                  Effect.catch(() =>
+                    Effect.fail(
+                      new CheckpointCaptureBudgetExceededError({
+                        operation,
+                        reason: "unseeded-scan",
+                        timeoutMs: capturePolicy.timeoutMs,
+                        detail: "The unseeded workspace scan exceeded its advisory budget.",
+                      }),
+                    ),
+                  ),
+                );
+            }
             if (workingIndexInfo === null && (yield* hasHeadCommit(input.cwd))) {
               yield* git.execute({
                 operation,
@@ -202,6 +269,12 @@ const makeCheckpointStore = Effect.gen(function* () {
               cwd: input.cwd,
               args: ["add", "-A", "--", "."],
               env: commitEnv,
+              ...(input.policy
+                ? {
+                    maxOutputBytes: input.policy.maxOutputBytes,
+                    outputMode: "truncate" as const,
+                  }
+                : {}),
             });
 
             const writeTreeResult = yield* git.execute({
@@ -258,7 +331,7 @@ const makeCheckpointStore = Effect.gen(function* () {
       );
     });
 
-  const captureCheckpoint: CheckpointStoreShape["captureCheckpoint"] = (input) =>
+  const captureCheckpointShared: CheckpointStoreShape["captureCheckpoint"] = (input) =>
     Effect.gen(function* () {
       const key = captureKey(input);
       const registration = yield* captureLock.withPermits(1)(
@@ -282,21 +355,7 @@ const makeCheckpointStore = Effect.gen(function* () {
       return yield* Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
           const exit = yield* Effect.exit(
-            restore(
-              captureCheckpointOnce(input).pipe(
-                Effect.timeoutOption(CHECKPOINT_CAPTURE_TIMEOUT_MS),
-                Effect.flatMap((completed) =>
-                  Option.isSome(completed)
-                    ? Effect.void
-                    : Effect.fail(
-                        new CheckpointInvariantError({
-                          operation: "CheckpointStore.captureCheckpoint",
-                          detail: `Checkpoint capture timed out after ${CHECKPOINT_CAPTURE_TIMEOUT_MS}ms.`,
-                        }),
-                      ),
-                ),
-              ),
-            ),
+            restore(git.withMutation(input.cwd, captureCheckpointOnce(input))),
           );
           // Waiters joined an in-flight capture they do not control; replaying the
           // owner's raw interrupt cause would make callers treat it as their own
@@ -318,6 +377,64 @@ const makeCheckpointStore = Effect.gen(function* () {
         }),
       );
     });
+
+  const captureCheckpoint: CheckpointStoreShape["captureCheckpoint"] = (input) => {
+    const policy = input.policy;
+    const failureCooldownMs = policy?.failureCooldownMs;
+    const cooldownKey = captureCooldownKey(input.cwd);
+    const timeoutMs = policy?.timeoutMs ?? CHECKPOINT_CAPTURE_TIMEOUT_MS;
+
+    return Effect.gen(function* () {
+      if (failureCooldownMs !== undefined && failureCooldownMs > 0) {
+        const now = yield* Clock.currentTimeMillis;
+        pruneCaptureCooldowns(now);
+        const cooldownExpiresAt = captureFailureCooldowns.get(cooldownKey);
+        if (cooldownExpiresAt !== undefined && cooldownExpiresAt > now) {
+          return yield* new CheckpointCaptureBudgetExceededError({
+            operation: "CheckpointStore.captureCheckpoint",
+            reason: "cooldown",
+            timeoutMs,
+            detail:
+              "A recent advisory capture exceeded its budget; retry is temporarily suppressed.",
+          });
+        }
+      }
+
+      const completed = yield* captureCheckpointShared(input).pipe(Effect.timeoutOption(timeoutMs));
+      if (Option.isNone(completed)) {
+        if (policy) {
+          return yield* new CheckpointCaptureBudgetExceededError({
+            operation: "CheckpointStore.captureCheckpoint",
+            reason: "timeout",
+            timeoutMs,
+            detail: `The advisory capture exceeded its ${timeoutMs}ms deadline.`,
+          });
+        }
+        return yield* new CheckpointInvariantError({
+          operation: "CheckpointStore.captureCheckpoint",
+          detail: `Checkpoint capture timed out after ${CHECKPOINT_CAPTURE_TIMEOUT_MS}ms.`,
+        });
+      }
+
+      captureFailureCooldowns.delete(cooldownKey);
+    }).pipe(
+      Effect.tapError((error) => {
+        if (
+          failureCooldownMs === undefined ||
+          failureCooldownMs <= 0 ||
+          error._tag !== "CheckpointCaptureBudgetExceededError" ||
+          error.reason === "cooldown"
+        ) {
+          return Effect.void;
+        }
+        return Clock.currentTimeMillis.pipe(
+          Effect.flatMap((now) =>
+            Effect.sync(() => recordCaptureCooldown(cooldownKey, now, failureCooldownMs)),
+          ),
+        );
+      }),
+    );
+  };
 
   const hasCheckpointRef: CheckpointStoreShape["hasCheckpointRef"] = (input) =>
     resolveCheckpointCommit(input.cwd, input.checkpointRef).pipe(

--- a/apps/server/src/checkpointing/Services/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Services/CheckpointStore.ts
@@ -16,6 +16,20 @@ import type { Effect } from "effect";
 import type { CheckpointStoreError } from "../Errors.ts";
 import { CheckpointRef } from "@synara/contracts";
 
+/**
+ * Optional resource limits for advisory captures on latency-sensitive paths.
+ *
+ * Authoritative checkpoint flows omit this policy and retain the store's
+ * existing aggregate timeout. A policy bounds queueing plus capture work and
+ * may suppress repeated attempts briefly after a resource-budget failure.
+ */
+export interface CaptureCheckpointPolicy {
+  readonly timeoutMs: number;
+  readonly maxOutputBytes: number;
+  readonly unseededScanMaxOutputBytes?: number;
+  readonly failureCooldownMs?: number;
+}
+
 export interface CaptureCheckpointInput {
   readonly cwd: string;
   readonly checkpointRef: CheckpointRef;
@@ -27,6 +41,7 @@ export interface CaptureCheckpointInput {
    * working tree the agent may already have modified.
    */
   readonly skipIfExists?: boolean;
+  readonly policy?: CaptureCheckpointPolicy;
 }
 
 export interface CopyCheckpointRefInput {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -107,6 +107,7 @@ import {
   CheckpointStore,
   type CheckpointStoreShape,
 } from "../../checkpointing/Services/CheckpointStore.ts";
+import { CheckpointCaptureBudgetExceededError } from "../../checkpointing/Errors.ts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 
 const asProjectId = (value: string): ProjectId => ProjectId.makeUnsafe(value);
@@ -6269,8 +6270,54 @@ describe("ProviderCommandReactor", () => {
     expect(captureCheckpoint.mock.calls.length).toBe(1);
     expect(captureCheckpoint.mock.calls[0]?.[0]).toMatchObject({
       cwd: "/tmp/provider-project",
+      policy: {
+        timeoutMs: 5_000,
+        maxOutputBytes: 64 * 1_024,
+        unseededScanMaxOutputBytes: 1_000_000,
+        failureCooldownMs: 60_000,
+      },
     });
     expect(captureCheckpoint.mock.calls[0]?.[0].checkpointRef).toContain("/message-start/");
+  });
+
+  it("continues the provider turn when the message-start checkpoint exceeds its budget", async () => {
+    const captureCheckpoint = vi.fn<CheckpointStoreShape["captureCheckpoint"]>(() =>
+      Effect.fail(
+        new CheckpointCaptureBudgetExceededError({
+          operation: "CheckpointStore.captureCheckpoint",
+          reason: "timeout",
+          timeoutMs: 5_000,
+          detail: "The advisory capture exceeded its 5000ms deadline.",
+        }),
+      ),
+    );
+    const harness = await createHarness({
+      checkpointStore: {
+        isGitRepository: vi.fn<CheckpointStoreShape["isGitRepository"]>(() => Effect.succeed(true)),
+        captureCheckpoint,
+      },
+    });
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-checkpoint-budget"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-checkpoint-budget"),
+          role: "user",
+          text: "continue despite the checkpoint budget",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: new Date().toISOString(),
+      }),
+    );
+
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    expect(captureCheckpoint).toHaveBeenCalledTimes(1);
+    expect(harness.sendTurn).toHaveBeenCalledTimes(1);
   });
 
   it("waits for the Studio output baseline before sending the provider turn", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -69,7 +69,10 @@ import {
   checkpointRefForThreadTurn,
   resolveThreadWorkspaceCwd,
 } from "../../checkpointing/Utils.ts";
-import { CheckpointStore } from "../../checkpointing/Services/CheckpointStore.ts";
+import {
+  CheckpointStore,
+  type CaptureCheckpointPolicy,
+} from "../../checkpointing/Services/CheckpointStore.ts";
 import { AgentGatewayOperationRepository } from "../../agentGateway/Services/AgentGatewayOperationRepository.ts";
 import { GitCore } from "../../git/Services/GitCore.ts";
 import {
@@ -444,6 +447,12 @@ const PROVIDER_COMMAND_SAFE_RETRY_DELAY = Duration.millis(50);
 const PROVIDER_COMMAND_INTERRUPT_TIMEOUT = Duration.seconds(10);
 const PROVIDER_COMMAND_STOP_TIMEOUT = Duration.seconds(15);
 const PROVIDER_COMMAND_EVENT_TIMEOUT = Duration.seconds(120);
+const MESSAGE_START_CHECKPOINT_POLICY = {
+  timeoutMs: 5_000,
+  maxOutputBytes: 64 * 1_024,
+  unseededScanMaxOutputBytes: 1_000_000,
+  failureCooldownMs: 60_000,
+} satisfies CaptureCheckpointPolicy;
 const GATEWAY_OPERATION_COMPLETION_WAIT_TIMEOUT = Duration.seconds(120);
 const PROVIDER_INPUT_SAFETY_MARGIN_CHARS = 1_000;
 const THREAD_MENTION_CONTEXT_SUFFIX_PREFIX_CHARS = 2;
@@ -2404,8 +2413,17 @@ const make = Effect.gen(function* () {
           MessageId.makeUnsafe(input.messageId),
         ),
         skipIfExists: true,
+        policy: MESSAGE_START_CHECKPOINT_POLICY,
       });
     }).pipe(
+      Effect.catchTag("CheckpointCaptureBudgetExceededError", (error) =>
+        Effect.logWarning("skipped provider turn start checkpoint within resource budget", {
+          threadId: input.threadId,
+          messageId: input.messageId,
+          reason: error.reason,
+          timeoutMs: error.timeoutMs,
+        }),
+      ),
       Effect.catchCause((cause) =>
         Effect.logWarning("failed to capture provider turn start checkpoint", {
           threadId: input.threadId,


### PR DESCRIPTION
## Summary

- bound the advisory message-start checkpoint to 5 seconds across Git mutation queueing and capture work, while allowing the provider turn to continue on budget exhaustion
- cap `git add` output, preflight oversized unseeded workspaces, and suppress repeated expensive attempts for 60 seconds
- serialize checkpoint mutations through `GitCore.withMutation` and return a typed, path-safe budget error
- preserve the existing 180-second behavior for authoritative checkpoint flows that do not opt into the advisory policy

PR #1115 fixed orchestration event publication backpressure and the visible pre-start timeout path. This change addresses the remaining pre-provider checkpoint work that can still delay `thread.turn.start` in large or noisy Windows workspaces.

## Testing

- `bun run --cwd apps/server test -- src/checkpointing/Layers/CheckpointStore.test.ts src/orchestration/Layers/ProviderCommandReactor.test.ts src/orchestration/Layers/OrchestrationEngine.test.ts` — 260 passed
- post-format `CheckpointStore.test.ts` — 9 passed
- `bun run typecheck` — 7/7 packages passed
- focused `oxfmt --check` — passed
- focused `oxlint` — 0 errors (4 existing warnings)
- `git diff --check` — passed

Broader Windows runs still hit unrelated baseline failures. On the unchanged `e307d251` base, the same two `codexAppServerManager` symlink/auth tests fail, and representative `GitCore` path/performance tests fail with the same results. The root suite's two POSIX-path canary failures and the default-timeout `CheckpointReactor` case were also reproduced on unchanged base; the representative reactor case passes with a 30-second test timeout.