### PR TITLE
feat(web): combine Pierre editing with fast numbered large-file support

### DIFF
--- a/apps/web/src/components/WorkspaceFilePreview.editing.browser.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.editing.browser.tsx
@@ -10,10 +10,11 @@ import type {
   ProjectReadFileResult,
   ProjectWatchFileInput,
 } from "@synara/contracts";
+import { StrictMode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { page } from "vitest/browser";
+import { page, userEvent, type Locator } from "vitest/browser";
 import { afterEach, expect, it, vi } from "vitest";
-import { render } from "vitest-browser-react";
+import { render, cleanup } from "vitest-browser-react";
 
 import { WorkspaceFilePreview } from "./WorkspaceFilePreview";
 
@@ -53,19 +54,35 @@ function loadedFile(overrides: Partial<ProjectReadFileResult> = {}): ProjectRead
   };
 }
 
+const primaryModifier = /Mac/.test(navigator.platform) ? "Meta" : "Control";
+
+function shortcut(key: string): string {
+  return `{${primaryModifier}>}${key}{/${primaryModifier}}`;
+}
+
+async function replaceEditorContents(editor: Locator, contents: string): Promise<void> {
+  await editor.click();
+  await userEvent.keyboard(shortcut("a"));
+  // Fill replaces DOM text without updating Pierre's document; use native input.
+  await userEvent.keyboard(
+    contents ? contents.replace(/[{[]/g, "$&$&").replace(/\n/g, "{Enter}") : "{Backspace}",
+  );
+}
+
 function pressKeyboardSave(element: Element): void {
   element.dispatchEvent(
     new KeyboardEvent("keydown", {
       key: "s",
       ctrlKey: true,
       bubbles: true,
+      composed: true,
       cancelable: true,
     }),
   );
 }
 
-afterEach(() => {
-  document.body.innerHTML = "";
+afterEach(async () => {
+  await cleanup();
 });
 
 it("requests only the resolved preview file for gutters and refreshes it on file events", async () => {
@@ -124,8 +141,8 @@ it("tracks dirty state and saves the loaded version with Ctrl+S", async () => {
     );
 
     const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
-    await expect.element(editor).toHaveValue("export const value = 1;\n");
-    await editor.fill("export const value = 2;\n");
+    await expect.element(editor).toHaveTextContent("export const value = 1;");
+    await replaceEditorContents(editor, "export const value = 2;\n");
     await expect.element(page.getByRole("status", { name: "Unsaved changes" })).toBeVisible();
 
     pressKeyboardSave(editor.element());
@@ -165,12 +182,12 @@ it("keeps the buffer dirty and shows guarded write failures", async () => {
     );
 
     const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
-    await editor.fill("manual edit\n");
+    await replaceEditorContents(editor, "manual edit\n");
     pressKeyboardSave(editor.element());
 
     await expect.element(page.getByRole("alert")).toHaveTextContent(conflictMessage);
     await expect.element(page.getByRole("status", { name: "Unsaved changes" })).toBeVisible();
-    await expect.element(editor).toHaveValue("manual edit\n");
+    await expect.element(editor).toHaveTextContent("manual edit");
     expect(writeFile).toHaveBeenCalledTimes(1);
   } finally {
     restoreNativeApi();
@@ -194,8 +211,9 @@ it("revalidates on file events without overwriting a dirty edit buffer", async (
       return unsubscribe;
     },
   );
+  const writeFile = vi.fn().mockResolvedValue({ relativePath: FILE_PATH, version: SAVED_VERSION });
   const restoreNativeApi = installNativeApi({
-    projects: { readFile, onFileChange },
+    projects: { readFile, onFileChange, writeFile },
   } as unknown as NativeApi);
 
   try {
@@ -206,8 +224,8 @@ it("revalidates on file events without overwriting a dirty edit buffer", async (
     );
 
     const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
-    await expect.element(editor).toHaveValue("export const value = 1;\n");
-    await editor.fill("manual edit\n");
+    await expect.element(editor).toHaveTextContent("export const value = 1;");
+    await replaceEditorContents(editor, "manual edit\n");
     await vi.waitFor(() => expect(onFileChange).toHaveBeenCalledTimes(1));
 
     fileChangeSubscription.listener?.({
@@ -217,7 +235,7 @@ it("revalidates on file events without overwriting a dirty edit buffer", async (
     });
 
     await vi.waitFor(() => expect(readFile).toHaveBeenCalledTimes(2));
-    await expect.element(editor).toHaveValue("manual edit\n");
+    await expect.element(editor).toHaveTextContent("manual edit");
     await expect
       .element(page.getByText("This file changed on disk. Your unsaved edits are preserved."))
       .toBeVisible();
@@ -225,7 +243,19 @@ it("revalidates on file events without overwriting a dirty edit buffer", async (
     const reloadButton = document.querySelector<HTMLButtonElement>('[role="alert"] button');
     expect(reloadButton).not.toBeNull();
     reloadButton?.click();
-    await expect.element(editor).toHaveValue("external edit\n");
+    await expect.element(editor).toHaveTextContent("external edit");
+    await replaceEditorContents(editor, "after reload\n");
+    pressKeyboardSave(editor.element());
+    await vi.waitFor(() =>
+      expect(writeFile).toHaveBeenCalledWith({
+        cwd: WORKSPACE_ROOT,
+        relativePath: FILE_PATH,
+        contents: "after reload\n",
+        expectedVersion: externalVersion,
+        encoding: "utf8",
+        lineEnding: "lf",
+      }),
+    );
   } finally {
     restoreNativeApi();
   }
@@ -248,7 +278,7 @@ it("stops revalidation when a kept-mounted preview becomes hidden", async () => 
 
     await expect
       .element(page.getByRole("textbox", { name: `Edit ${FILE_PATH}` }))
-      .toHaveValue("export const value = 1;\n");
+      .toHaveTextContent("export const value = 1;");
     await vi.waitFor(() => expect(onFileChange).toHaveBeenCalledTimes(1));
 
     await screen.rerender(
@@ -285,7 +315,7 @@ it("switches the watcher to a workspace path resolved by the file read", async (
 
     await expect
       .element(page.getByRole("textbox", { name: `Edit ${FILE_PATH}` }))
-      .toHaveValue("export const value = 1;\n");
+      .toHaveTextContent("export const value = 1;");
     await vi.waitFor(() =>
       expect(onFileChange).toHaveBeenLastCalledWith(
         { cwd: WORKSPACE_ROOT, relativePath: resolvedPath },
@@ -328,8 +358,8 @@ it("preserves dirty edits when reloading the changed disk version fails", async 
     );
 
     const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
-    await expect.element(editor).toHaveValue("export const value = 1;\n");
-    await editor.fill("manual edit\n");
+    await expect.element(editor).toHaveTextContent("export const value = 1;");
+    await replaceEditorContents(editor, "manual edit\n");
     await vi.waitFor(() => expect(onFileChange).toHaveBeenCalledTimes(1));
     fileChangeSubscription.listener?.({
       type: "changed",
@@ -342,7 +372,7 @@ it("preserves dirty edits when reloading the changed disk version fails", async 
     await reloadButton.click();
 
     await vi.waitFor(() => expect(readFile).toHaveBeenCalledTimes(3));
-    await expect.element(editor).toHaveValue("manual edit\n");
+    await expect.element(editor).toHaveTextContent("manual edit");
     await expect.element(page.getByText("Transient read failure")).toBeVisible();
     await expect.element(page.getByRole("status", { name: "Unsaved changes" })).toBeVisible();
   } finally {
@@ -379,7 +409,7 @@ it("keeps markdown task previews and guarded versions in sync after an editor sa
     );
 
     const editor = page.getByRole("textbox", { name: `Edit ${markdownPath}` });
-    await editor.fill("- [ ] updated task\n");
+    await replaceEditorContents(editor, "- [ ] updated task\n");
     pressKeyboardSave(editor.element());
     await vi.waitFor(() => expect(writeFile).toHaveBeenCalledTimes(1));
     await page.getByRole("radio", { name: "Preview" }).click();
@@ -462,11 +492,11 @@ it("keeps a successful save when an older watcher read resolves afterwards", asy
       </QueryClientProvider>,
     );
     const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
-    await expect.element(editor).toHaveValue("export const value = 1;\n");
+    await expect.element(editor).toHaveTextContent("export const value = 1;");
     await vi.waitFor(() => expect(onFileChange).toHaveBeenCalledTimes(1));
     subscription.listener?.({ type: "changed", relativePath: FILE_PATH, mtimeMs: 1 });
     await vi.waitFor(() => expect(readFile).toHaveBeenCalledTimes(2));
-    await editor.fill("saved contents\n");
+    await replaceEditorContents(editor, "saved contents\n");
     pressKeyboardSave(editor.element());
     await vi.waitFor(() => expect(writeFile).toHaveBeenCalledTimes(1));
     await vi.waitFor(() =>
@@ -475,8 +505,8 @@ it("keeps a successful save when an older watcher read resolves afterwards", asy
     completeRead(loadedFile());
     await pendingRead;
     await vi.waitFor(() => expect(queryClient.isFetching()).toBe(0));
-    await expect.element(editor).toHaveValue("saved contents\n");
-    await editor.fill("next saved contents\n");
+    await expect.element(editor).toHaveTextContent("saved contents");
+    await replaceEditorContents(editor, "next saved contents\n");
     pressKeyboardSave(editor.element());
     await vi.waitFor(() =>
       expect(writeFile).toHaveBeenNthCalledWith(2, {
@@ -491,6 +521,322 @@ it("keeps a successful save when an older watcher read resolves afterwards", asy
   } finally {
     completeRead(loadedFile());
     queryClient.clear();
+    restoreNativeApi();
+  }
+});
+
+it("preserves unsaved Markdown edits across Preview and Source", async () => {
+  const readFile = vi
+    .fn()
+    .mockResolvedValue(loadedFile({ relativePath: "README.md", contents: "original\n" }));
+  const writeFile = vi
+    .fn()
+    .mockResolvedValue({ relativePath: "README.md", version: SAVED_VERSION });
+  const restore = installNativeApi({ projects: { readFile, writeFile } } as unknown as NativeApi);
+  try {
+    await render(
+      <StrictMode>
+        <QueryClientProvider client={makeQueryClient()}>
+          <WorkspaceFilePreview workspaceRoot={WORKSPACE_ROOT} filePath="README.md" editable />
+        </QueryClientProvider>
+      </StrictMode>,
+    );
+    const editor = page.getByRole("textbox", { name: "Edit README.md" });
+    await editor.click();
+    await userEvent.keyboard(shortcut("a") + "unsaved");
+    await expect.element(page.getByRole("status", { name: "Unsaved changes" })).toBeVisible();
+    await expect.element(editor).toHaveTextContent("unsaved");
+    await page.getByRole("radio", { name: "Preview", exact: true }).click();
+    const editorShell = document.querySelector<HTMLElement>(".editor-file-editor__pierre")!;
+    expect(getComputedStyle(editorShell).display).toBe("none");
+    expect(editorShell.getBoundingClientRect().height).toBe(0);
+    await page.getByRole("radio", { name: "Source", exact: true }).click();
+    await expect.element(editor).toHaveTextContent("unsaved");
+  } finally {
+    restore();
+  }
+});
+
+it("preserves edits and focus when a save completes while typing", async () => {
+  let complete!: (v: { relativePath: string; version: string }) => void;
+  const pending = new Promise<{ relativePath: string; version: string }>((r) => (complete = r));
+  const readFile = vi.fn().mockResolvedValue(loadedFile());
+  const writeFile = vi.fn().mockReturnValue(pending);
+  const restore = installNativeApi({ projects: { readFile, writeFile } } as unknown as NativeApi);
+  try {
+    await render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <WorkspaceFilePreview workspaceRoot={WORKSPACE_ROOT} filePath={FILE_PATH} editable />
+      </QueryClientProvider>,
+    );
+    const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
+    await editor.click();
+    await userEvent.keyboard(shortcut("a") + "first");
+    await userEvent.keyboard(shortcut("s"));
+    await vi.waitFor(() => expect(writeFile).toHaveBeenCalledTimes(1));
+    await userEvent.keyboard("second");
+    await expect.element(editor).toHaveTextContent("firstsecond");
+    complete({ relativePath: FILE_PATH, version: SAVED_VERSION });
+    await vi.waitFor(() => expect(document.querySelector('[aria-busy="true"]')).toBeNull());
+    await expect.element(editor).toHaveTextContent("firstsecond");
+    expect(editor.element().getRootNode()).toBeInstanceOf(ShadowRoot);
+    expect((editor.element().getRootNode() as ShadowRoot).activeElement).toBe(editor.element());
+    await userEvent.keyboard(shortcut("z"));
+    await expect.element(editor).not.toHaveTextContent("firstsecond");
+    await userEvent.keyboard(`{${primaryModifier}>}{Shift>}z{/Shift}{/${primaryModifier}}`);
+    await expect.element(editor).toHaveTextContent("firstsecond");
+  } finally {
+    restore();
+  }
+});
+
+it("renders numbered source lines without including the gutter in saved text", async () => {
+  const contents = "one\ntwo\nthree\n";
+  const readFile = vi.fn().mockResolvedValue(loadedFile({ contents }));
+  const writeFile = vi.fn().mockResolvedValue({ relativePath: FILE_PATH, version: SAVED_VERSION });
+  const restoreNativeApi = installNativeApi({
+    projects: { readFile, writeFile },
+  } as unknown as NativeApi);
+  try {
+    await render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <WorkspaceFilePreview workspaceRoot={WORKSPACE_ROOT} filePath={FILE_PATH} editable />
+      </QueryClientProvider>,
+    );
+    const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
+    await expect.element(editor).toBeVisible();
+    const root = editor.element().getRootNode() as ShadowRoot;
+    await vi.waitFor(() =>
+      expect(
+        Array.from(
+          root.querySelectorAll("[data-line-number-content]"),
+          (number) => number.textContent,
+        ),
+      ).toEqual(["1", "2", "3", "4"]),
+    );
+    await replaceEditorContents(editor, `${contents}four`);
+    pressKeyboardSave(editor.element());
+    await vi.waitFor(() =>
+      expect(writeFile).toHaveBeenCalledWith(
+        expect.objectContaining({ contents: `${contents}four` }),
+      ),
+    );
+  } finally {
+    restoreNativeApi();
+  }
+});
+
+it("keeps Pierre line one and editor position stable when the buffer is emptied", async () => {
+  const readFile = vi.fn().mockResolvedValue(loadedFile({ contents: "" }));
+  const restoreNativeApi = installNativeApi({ projects: { readFile } } as unknown as NativeApi);
+  try {
+    await render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <WorkspaceFilePreview workspaceRoot={WORKSPACE_ROOT} filePath={FILE_PATH} editable />
+      </QueryClientProvider>,
+    );
+    const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
+    await expect.element(editor).toBeVisible();
+    const root = editor.element().getRootNode() as ShadowRoot;
+    const originalLeft = editor.element().getBoundingClientRect().left;
+    for (const contents of ["first character", ""]) {
+      await replaceEditorContents(editor, contents);
+      await vi.waitFor(() => {
+        expect(
+          Array.from(
+            root.querySelectorAll("[data-line-number-content]"),
+            (number) => number.textContent,
+          ),
+        ).toEqual(["1"]);
+        expect(editor.element().getBoundingClientRect().left).toBe(originalLeft);
+      });
+    }
+  } finally {
+    restoreNativeApi();
+  }
+});
+
+it("keeps Pierre gutter aligned through horizontal and vertical scrolling", async () => {
+  const contents = Array.from({ length: 100 }, (_, i) => `line${i} ${"x".repeat(300)}`).join("\n");
+  const readFile = vi.fn().mockResolvedValue(loadedFile({ contents }));
+  const restoreNativeApi = installNativeApi({ projects: { readFile } } as unknown as NativeApi);
+  try {
+    await render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <div style={{ width: 400, height: 320 }}>
+          <WorkspaceFilePreview workspaceRoot={WORKSPACE_ROOT} filePath={FILE_PATH} editable />
+        </div>
+      </QueryClientProvider>,
+    );
+    const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
+    await expect.element(editor).toBeVisible();
+    const root = editor.element().getRootNode() as ShadowRoot;
+    const candidates = [
+      ...Array.from(root.querySelectorAll<HTMLElement>("pre,code,[data-content]")),
+      document.querySelector<HTMLElement>(".editor-file-editor__pierre")!,
+    ];
+    const horizontal = candidates.find(
+      (el) =>
+        el.scrollWidth > el.clientWidth &&
+        ["auto", "scroll"].includes(getComputedStyle(el).overflowX),
+    )!;
+    const vertical = candidates.find(
+      (el) =>
+        el.scrollHeight > el.clientHeight &&
+        ["auto", "scroll"].includes(getComputedStyle(el).overflowY),
+    )!;
+    expect(horizontal).toBeDefined();
+    expect(vertical).toBeDefined();
+    horizontal.scrollLeft = horizontal.scrollWidth;
+    vertical.scrollTop = vertical.scrollHeight;
+    expect(horizontal.scrollLeft).toBeGreaterThan(0);
+    expect(vertical.scrollTop).toBeGreaterThan(0);
+    await vi.waitFor(() => {
+      const number = root.querySelector<HTMLElement>('[data-gutter] [data-line-index="99"]')!;
+      const line = root.querySelector<HTMLElement>('[data-content] [data-line-index="99"]')!;
+      expect(
+        Math.abs(number.getBoundingClientRect().top - line.getBoundingClientRect().top),
+      ).toBeLessThan(1);
+    });
+  } finally {
+    restoreNativeApi();
+  }
+});
+
+it("keeps the large-file fallback gutter rows aligned at the bottom of horizontally overflowing files", async () => {
+  const lines = Array.from({ length: 1_001 }, (_, index) => `${index + 1} ${"x".repeat(300)}`);
+  const readFile = vi.fn().mockResolvedValue(loadedFile({ contents: lines.join("\n") }));
+  const restoreNativeApi = installNativeApi({ projects: { readFile } } as unknown as NativeApi);
+
+  try {
+    await render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <div style={{ width: 400, height: 320 }}>
+          <WorkspaceFilePreview workspaceRoot={WORKSPACE_ROOT} filePath={FILE_PATH} editable />
+        </div>
+      </QueryClientProvider>,
+    );
+
+    const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
+    await expect.element(editor).toBeVisible();
+    const area = editor.element() as HTMLTextAreaElement;
+    expect(area.scrollWidth).toBeGreaterThan(area.clientWidth);
+    // Headless Chromium hides scrollbars. Extra bottom padding exercises the
+    // same unequal scroll ranges there; visible scrollbars need no emulation.
+    if (area.offsetHeight === area.clientHeight) {
+      area.style.paddingBottom = `${Number.parseFloat(getComputedStyle(area).paddingBottom) + 10}px`;
+    }
+    area.scrollTop = area.scrollHeight;
+    area.dispatchEvent(new Event("scroll"));
+
+    await vi.waitFor(() => {
+      const lastNumber = document.querySelector(".editor-file-editor__gutter-line:last-child");
+      if (!lastNumber) throw new Error("editor line-number gutter not found");
+      const metrics = getComputedStyle(area);
+      // CSS exposes unrounded line-height; measure native layout to avoid
+      // accumulating subpixel rounding across thousands of rows.
+      const measure = document.createElement("div");
+      Object.assign(measure.style, {
+        position: "absolute",
+        visibility: "hidden",
+        whiteSpace: "pre",
+        font: metrics.font,
+        lineHeight: metrics.lineHeight,
+        padding: "0",
+        border: "0",
+        margin: "0",
+      });
+      measure.textContent = "line\nline";
+      document.body.append(measure);
+      const renderedLineHeight = measure.getBoundingClientRect().height / 2;
+      measure.remove();
+      const lastTextLineTop =
+        area.getBoundingClientRect().top +
+        Number.parseFloat(metrics.paddingTop) +
+        (lines.length - 1) * renderedLineHeight -
+        area.scrollTop;
+      expect(Math.abs(lastNumber.getBoundingClientRect().top - lastTextLineTop)).toBeLessThan(1);
+    });
+  } finally {
+    restoreNativeApi();
+  }
+});
+
+it("preserves the large-file editing engine and line one after clearing and saving", async () => {
+  const readFile = vi.fn().mockResolvedValue(loadedFile({ contents: "line\n".repeat(1_000) }));
+  const writeFile = vi.fn().mockResolvedValue({ relativePath: FILE_PATH, version: SAVED_VERSION });
+  const restoreNativeApi = installNativeApi({
+    projects: { readFile, writeFile },
+  } as unknown as NativeApi);
+  try {
+    await render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <WorkspaceFilePreview workspaceRoot={WORKSPACE_ROOT} filePath={FILE_PATH} editable />
+      </QueryClientProvider>,
+    );
+    const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
+    await expect.element(editor).toBeVisible();
+    const original = editor.element();
+    expect(original.tagName).toBe("TEXTAREA");
+    const left = original.getBoundingClientRect().left;
+    for (const contents of ["", "first character", ""]) {
+      await editor.fill(contents);
+      await vi.waitFor(() => {
+        expect(editor.element()).toBe(original);
+        expect(document.querySelector(".editor-file-editor__gutter")?.textContent).toBe("1");
+        expect(editor.element().getBoundingClientRect().left).toBe(left);
+      });
+    }
+    pressKeyboardSave(editor.element());
+    await vi.waitFor(() =>
+      expect(writeFile).toHaveBeenCalledWith(
+        expect.objectContaining({ contents: "", expectedVersion: LOADED_VERSION }),
+      ),
+    );
+  } finally {
+    restoreNativeApi();
+  }
+});
+
+it("uses the lightweight editor for long single-line files", async () => {
+  const readFile = vi.fn().mockResolvedValue(loadedFile({ contents: "x".repeat(250_001) }));
+  const restoreNativeApi = installNativeApi({ projects: { readFile } } as unknown as NativeApi);
+  try {
+    await render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <WorkspaceFilePreview workspaceRoot={WORKSPACE_ROOT} filePath={FILE_PATH} editable />
+      </QueryClientProvider>,
+    );
+    const editor = page.getByRole("textbox", { name: `Edit ${FILE_PATH}` });
+    await expect.element(editor).toBeVisible();
+    expect(editor.element().tagName).toBe("TEXTAREA");
+    expect(document.querySelector(".editor-file-editor__gutter")?.textContent).toBe("1");
+  } finally {
+    restoreNativeApi();
+  }
+});
+
+it("preserves the lightweight Markdown editor while its preview is open", async () => {
+  const readFile = vi
+    .fn()
+    .mockResolvedValue(loadedFile({ relativePath: "README.md", contents: "line\n".repeat(1_000) }));
+  const restoreNativeApi = installNativeApi({ projects: { readFile } } as unknown as NativeApi);
+  try {
+    await render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <WorkspaceFilePreview workspaceRoot={WORKSPACE_ROOT} filePath="README.md" editable />
+      </QueryClientProvider>,
+    );
+    const editor = page.getByRole("textbox", { name: "Edit README.md" });
+    await expect.element(editor).toBeVisible();
+    const original = editor.element();
+    await editor.fill("# unsaved draft");
+    await page.getByRole("radio", { name: "Preview", exact: true }).click();
+    expect(original.getBoundingClientRect().height).toBe(0);
+    await page.getByRole("radio", { name: "Source", exact: true }).click();
+    await expect.element(editor).toHaveValue("# unsaved draft");
+    expect(editor.element()).toBe(original);
+  } finally {
     restoreNativeApi();
   }
 });

--- a/apps/web/src/components/WorkspaceFilePreview.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.tsx
@@ -11,6 +11,12 @@ import type {
   ProjectFileLineEnding,
   ProjectReadFileResult,
 } from "@synara/contracts";
+import type { FileContents as PierreFileContents } from "@pierre/diffs";
+import {
+  Editor as PierreEditor,
+  type EditorOptions as PierreEditorOptions,
+} from "@pierre/diffs/edit";
+import { EditProvider, File as PierreFile } from "@pierre/diffs/react";
 import {
   isSupportedLocalImagePath,
   isSupportedLocalPdfPath,
@@ -31,6 +37,8 @@ import {
   use,
   useCallback,
   useEffect,
+  useInsertionEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -44,7 +52,11 @@ import {
   getSelectionWithin,
   type ChatFileReference,
 } from "~/lib/chatReferences";
-import { resolveDiffThemeName, type DiffThemeName } from "~/lib/diffRendering";
+import {
+  buildDiffPanelUnsafeCSS,
+  resolveDiffThemeName,
+  type DiffThemeName,
+} from "~/lib/diffRendering";
 import { extractEditorGutterChanges, type EditorGutterChangeRange } from "~/lib/editorGutterDiff";
 import { formatFileCommentRange, type FileCommentSelection } from "~/lib/fileComments";
 import { showFileReferenceContextMenu } from "~/lib/fileReferenceContextMenu";
@@ -258,6 +270,184 @@ function FileContentsView(props: { path: string; contents: string; themeName: Di
         />
       </Suspense>
     </FilePreviewHighlightErrorBoundary>
+  );
+}
+
+function createPierreEditor(options: PierreEditorOptions<undefined>) {
+  return new PierreEditor(options);
+}
+
+type EditableFileContentsProps = {
+  path: string;
+  contents: string;
+  cacheKey: string;
+  hidden: boolean;
+  themeName: DiffThemeName;
+  theme: "light" | "dark";
+  saving: boolean;
+  invalid: boolean;
+  onContentsChange: (contents: string) => void;
+  onSave: () => void;
+};
+
+function PierreEditableFileContents(props: EditableFileContentsProps) {
+  const editorContainerRef = useRef<HTMLDivElement>(null);
+  const editorId = useId();
+  const labelEditor = useCallback(() => {
+    editorContainerRef.current
+      ?.querySelector("diffs-container")
+      ?.shadowRoot?.querySelector<HTMLElement>('[contenteditable="true"]')
+      ?.setAttribute("aria-label", `Edit ${props.path}`);
+  }, [props.path]);
+  const editorObserverRef = useRef<MutationObserver | null>(null);
+  const attachEditor = useCallback(() => {
+    const shadowRoot = editorContainerRef.current?.querySelector("diffs-container")?.shadowRoot;
+    if (!shadowRoot) return;
+    labelEditor();
+    if (editorObserverRef.current === null) {
+      editorObserverRef.current = new MutationObserver(labelEditor);
+    }
+    editorObserverRef.current.observe(shadowRoot, { childList: true, subtree: true });
+  }, [labelEditor]);
+  useEffect(() => {
+    attachEditor();
+    return () => {
+      editorObserverRef.current?.disconnect();
+      editorObserverRef.current = null;
+    };
+  }, [attachEditor]);
+  // Local typing updates this snapshot in the same batch as the parent draft.
+  // Only a different incoming document (reload/watcher) resets Pierre's history.
+  const [document, setDocument] = useState({
+    contents: props.contents,
+    seedContents: props.contents,
+    revision: 0,
+  });
+  if (document.contents !== props.contents) {
+    setDocument({
+      contents: props.contents,
+      seedContents: props.contents,
+      revision: document.revision + 1,
+    });
+  }
+  const onContentsChangeRef = useRef(props.onContentsChange);
+  useInsertionEffect(() => {
+    onContentsChangeRef.current = props.onContentsChange;
+  });
+  const file = useMemo<PierreFileContents>(
+    () => ({
+      name: props.path,
+      contents: document.seedContents,
+      lang: getSyntaxLanguageForPath(props.path),
+      cacheKey: `${props.cacheKey}:${editorId}:${document.revision}`,
+    }),
+    [document.seedContents, document.revision, editorId, props.cacheKey, props.path],
+  );
+  const editorOptions = useMemo<PierreEditorOptions<undefined>>(
+    () => ({
+      onAttach: attachEditor,
+      onChange: (nextFile) => {
+        const contents = nextFile.contents;
+        setDocument((current) => ({ ...current, contents }));
+        onContentsChangeRef.current(contents);
+      },
+    }),
+    [attachEditor],
+  );
+
+  return (
+    <div
+      ref={editorContainerRef}
+      className="editor-file-editor__pierre"
+      hidden={props.hidden}
+      aria-busy={props.saving}
+      aria-invalid={props.invalid ? "true" : undefined}
+      onKeyDown={(event) => {
+        if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
+          event.preventDefault();
+          props.onSave();
+        }
+      }}
+    >
+      <EditProvider createEditor={createPierreEditor}>
+        <PierreFile
+          file={file}
+          edit
+          editorOptions={editorOptions}
+          options={{
+            disableFileHeader: true,
+            overflow: "scroll",
+            preferredHighlighter: "shiki-js",
+            theme: props.themeName,
+            unsafeCSS: buildDiffPanelUnsafeCSS(props.theme),
+          }}
+        />
+      </EditProvider>
+    </div>
+  );
+}
+
+// Keep the editing engine stable for the open document: changing it while
+// typing would discard focus, selection and native undo history.
+function EditableFileContents(props: EditableFileContentsProps) {
+  const [plainText] = useState(
+    () =>
+      props.contents.length > MAX_SYNTAX_HIGHLIGHT_INPUT_CHARS ||
+      props.contents.split("\n").length > 1_000,
+  );
+  return plainText ? (
+    <NumberedPlainEditableFileContents {...props} />
+  ) : (
+    <PierreEditableFileContents {...props} />
+  );
+}
+
+function NumberedPlainEditableFileContents(props: EditableFileContentsProps) {
+  const editorRef = useRef<HTMLTextAreaElement>(null);
+  const gutterRef = useRef<HTMLDivElement>(null);
+  const lineCount = props.contents.split("\n").length;
+  const numbers = useMemo(
+    () =>
+      lineCount <= MAX_PLAIN_NUMBERED_LINES
+        ? Array.from({ length: lineCount }, (_, index) => (
+            <span key={index} className="editor-file-editor__gutter-line">
+              {index + 1}
+            </span>
+          ))
+        : null,
+    [lineCount],
+  );
+  const syncGutter = useCallback(() => {
+    if (editorRef.current && gutterRef.current)
+      gutterRef.current.style.transform = `translateY(${-editorRef.current.scrollTop}px)`;
+  }, []);
+  useEffect(syncGutter, [props.contents, props.hidden, syncGutter]);
+  return (
+    <div className="editor-file-editor-wrap" hidden={props.hidden}>
+      {numbers ? (
+        <div className="editor-file-editor__gutter" aria-hidden="true">
+          <div ref={gutterRef}>{numbers}</div>
+        </div>
+      ) : null}
+      <textarea
+        ref={editorRef}
+        className="editor-file-editor"
+        aria-label={`Edit ${props.path}`}
+        aria-busy={props.saving}
+        aria-invalid={props.invalid ? "true" : undefined}
+        value={props.contents}
+        spellCheck={false}
+        wrap="off"
+        onScroll={syncGutter}
+        onChange={(event) => props.onContentsChange(event.target.value)}
+        onKeyDown={(event) => {
+          if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
+            event.preventDefault();
+            props.onSave();
+          }
+        }}
+      />
+    </div>
   );
 }
 
@@ -1110,118 +1300,125 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
         </PanelStateMessage>
       ) : !hasFileContents ? (
         <FilePreviewLoadingState />
-      ) : activeEditBuffer && editableDocument && !showMarkdownPreview ? (
-        <textarea
-          className="editor-file-editor"
-          aria-label={`Edit ${filePath}`}
-          aria-busy={activeEditBuffer.saving}
-          aria-invalid={activeEditBuffer.error ? "true" : undefined}
-          value={activeEditBuffer.contents}
-          spellCheck={false}
-          autoCapitalize="off"
-          autoCorrect="off"
-          onChange={(event) => handleEditBufferChange(event.currentTarget.value)}
-          onKeyDown={(event) => {
-            if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
-              event.preventDefault();
-              void handleEditBufferSave();
-            }
-          }}
-        />
       ) : (
-        <div
-          ref={contentsRef}
-          className={cn(
-            "editor-file-viewer min-h-0 flex-1 overflow-auto",
-            showMarkdownPreview && "editor-file-viewer--markdown-preview",
-          )}
-          onContextMenu={handleContentsContextMenu}
-          onMouseUp={previewSelectionAction.onContainerMouseUp}
-          onMouseMove={lineCommenting.onContainerMouseMove}
-          onMouseLeave={lineCommenting.onContainerMouseLeave}
-        >
-          {showMarkdownPreview ? (
-            <div className="editor-markdown-preview">
-              <ChatMarkdown
-                text={displayedFileContents}
-                cwd={markdownPreviewCwd(props.workspaceRoot, filePath)}
-                wikiLinkRoot={props.workspaceRoot ?? undefined}
-                isStreaming={false}
-                className="editor-markdown-preview__body text-sm leading-relaxed"
-                {...(canToggleTasks ? { onTaskToggle: handleTaskToggle } : {})}
-              />
-            </div>
-          ) : (
-            <FileContentsView path={filePath} contents={fileContents} themeName={diffThemeName} />
-          )}
-          {!showMarkdownPreview && changeRanges.length > 0 ? (
-            <FilePreviewChangeGutter ranges={changeRanges} subtle={changeGutterSubtle} />
-          ) : null}
-          {!showMarkdownPreview && lineCount > 0 ? (
-            <span className="sr-only">{lineCount} lines</span>
-          ) : null}
-          {previewSelectionAction.pendingAction ? (
-            <TranscriptSelectionAction
-              left={previewSelectionAction.pendingAction.left}
-              top={previewSelectionAction.pendingAction.top}
-              placement={previewSelectionAction.pendingAction.placement}
-              onAddToChat={previewSelectionAction.commit}
+        <>
+          {activeEditBuffer && editableDocument ? (
+            <EditableFileContents
+              key={activeEditBuffer.key}
+              path={filePath}
+              contents={activeEditBuffer.contents}
+              cacheKey={activeEditBuffer.key}
+              hidden={showMarkdownPreview}
+              themeName={diffThemeName}
+              theme={resolvedTheme}
+              saving={activeEditBuffer.saving}
+              invalid={activeEditBuffer.error !== null}
+              onContentsChange={handleEditBufferChange}
+              onSave={() => {
+                void handleEditBufferSave();
+              }}
             />
           ) : null}
-          {lineCommentingEnabled && hoveredCommentLine && !activeCommentLine ? (
-            <button
-              type="button"
-              className="editor-file-viewer__comment-add"
-              style={{
-                top: hoveredCommentLine.top,
-                left: hoveredCommentLine.left,
-                height: hoveredCommentLine.height,
-              }}
-              aria-label={`Comment on line ${hoveredCommentLine.lineNumber}`}
-              title="Comment"
-              onMouseDown={(event) => event.preventDefault()}
-              onClick={(event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                lineCommenting.openComment(hoveredCommentLine);
-              }}
+          {!activeEditBuffer || !editableDocument || showMarkdownPreview ? (
+            <div
+              ref={contentsRef}
+              className={cn(
+                "editor-file-viewer min-h-0 flex-1 overflow-auto",
+                showMarkdownPreview && "editor-file-viewer--markdown-preview",
+              )}
+              onContextMenu={handleContentsContextMenu}
+              onMouseUp={previewSelectionAction.onContainerMouseUp}
+              onMouseMove={lineCommenting.onContainerMouseMove}
+              onMouseLeave={lineCommenting.onContainerMouseLeave}
             >
-              <span className="editor-file-viewer__comment-add-glyph">
-                <PlusIcon className="size-3.5" />
-              </span>
-            </button>
+              {showMarkdownPreview ? (
+                <div className="editor-markdown-preview">
+                  <ChatMarkdown
+                    text={displayedFileContents}
+                    cwd={markdownPreviewCwd(props.workspaceRoot, filePath)}
+                    wikiLinkRoot={props.workspaceRoot ?? undefined}
+                    isStreaming={false}
+                    className="editor-markdown-preview__body text-sm leading-relaxed"
+                    {...(canToggleTasks ? { onTaskToggle: handleTaskToggle } : {})}
+                  />
+                </div>
+              ) : (
+                <FileContentsView
+                  path={filePath}
+                  contents={fileContents}
+                  themeName={diffThemeName}
+                />
+              )}
+              {!showMarkdownPreview && changeRanges.length > 0 ? (
+                <FilePreviewChangeGutter ranges={changeRanges} subtle={changeGutterSubtle} />
+              ) : null}
+              {!showMarkdownPreview && lineCount > 0 ? (
+                <span className="sr-only">{lineCount} lines</span>
+              ) : null}
+              {previewSelectionAction.pendingAction ? (
+                <TranscriptSelectionAction
+                  left={previewSelectionAction.pendingAction.left}
+                  top={previewSelectionAction.pendingAction.top}
+                  placement={previewSelectionAction.pendingAction.placement}
+                  onAddToChat={previewSelectionAction.commit}
+                />
+              ) : null}
+              {lineCommentingEnabled && hoveredCommentLine && !activeCommentLine ? (
+                <button
+                  type="button"
+                  className="editor-file-viewer__comment-add"
+                  style={{
+                    top: hoveredCommentLine.top,
+                    left: hoveredCommentLine.left,
+                    height: hoveredCommentLine.height,
+                  }}
+                  aria-label={`Comment on line ${hoveredCommentLine.lineNumber}`}
+                  title="Comment"
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    lineCommenting.openComment(hoveredCommentLine);
+                  }}
+                >
+                  <span className="editor-file-viewer__comment-add-glyph">
+                    <PlusIcon className="size-3.5" />
+                  </span>
+                </button>
+              ) : null}
+              {lineCommentingEnabled && activeCommentLine ? (
+                <>
+                  <div
+                    className="editor-file-viewer__comment-line-highlight"
+                    style={{ top: activeCommentLine.top, height: activeCommentLine.height }}
+                    aria-hidden="true"
+                  />
+                  <FileLineCommentBox
+                    lineLabel={formatFileCommentRange({
+                      startLine: activeCommentLine.lineNumber,
+                      endLine: activeCommentLine.lineNumber,
+                    })}
+                    top={activeCommentLine.top + activeCommentLine.height}
+                    left={activeCommentLine.left}
+                    width={Math.max(
+                      240,
+                      Math.min(440, activeCommentLine.containerWidth - activeCommentLine.left - 16),
+                    )}
+                    onCancel={lineCommenting.closeComment}
+                    onSubmit={(text) => {
+                      commitLineComment({
+                        startLine: activeCommentLine.lineNumber,
+                        endLine: activeCommentLine.lineNumber,
+                        text,
+                      });
+                      lineCommenting.closeComment();
+                    }}
+                  />
+                </>
+              ) : null}
+            </div>
           ) : null}
-          {lineCommentingEnabled && activeCommentLine ? (
-            <>
-              <div
-                className="editor-file-viewer__comment-line-highlight"
-                style={{ top: activeCommentLine.top, height: activeCommentLine.height }}
-                aria-hidden="true"
-              />
-              <FileLineCommentBox
-                lineLabel={formatFileCommentRange({
-                  startLine: activeCommentLine.lineNumber,
-                  endLine: activeCommentLine.lineNumber,
-                })}
-                top={activeCommentLine.top + activeCommentLine.height}
-                left={activeCommentLine.left}
-                width={Math.max(
-                  240,
-                  Math.min(440, activeCommentLine.containerWidth - activeCommentLine.left - 16),
-                )}
-                onCancel={lineCommenting.closeComment}
-                onSubmit={(text) => {
-                  commitLineComment({
-                    startLine: activeCommentLine.lineNumber,
-                    endLine: activeCommentLine.lineNumber,
-                    text,
-                  });
-                  lineCommenting.closeComment();
-                }}
-              />
-            </>
-          ) : null}
-        </div>
+        </>
       )}
     </div>
   );

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1144,13 +1144,14 @@ label:has(> select#reasoning-effort) select {
 .editor-file-editor {
   min-height: 0;
   flex: 1;
+  min-width: 0;
   resize: none;
   overflow: auto;
   border: 0;
   border-radius: 0;
   outline: none;
   background: transparent;
-  padding: 1rem;
+  padding: 1rem 1rem 1rem 0.75rem;
   color: color-mix(in srgb, var(--foreground) 88%, transparent);
   font-family: var(--font-chat-code-family);
   font-size: var(--app-font-size-chat-code, 12px);
@@ -1161,6 +1162,61 @@ label:has(> select#reasoning-effort) select {
 
 .editor-file-editor:focus-visible {
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ring) 45%, transparent);
+}
+
+/* Inline editor shell for the dock explorer: a plain textarea paired with a
+   line-number gutter column. The textarea keeps its own scroll container and
+   the gutter's inner column follows its scrollTop without a second clamped
+   scroll range (a horizontal scrollbar shortens only the textarea viewport).
+   Type metrics must stay identical to .editor-file-editor to keep rows aligned. */
+.editor-file-editor-wrap {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  min-width: 0;
+}
+
+.editor-file-editor__gutter {
+  flex: none;
+  overflow: hidden;
+  width: calc(4ch + 1.75rem);
+  padding: 1rem 0.5rem 1rem 1rem;
+  text-align: right;
+  font-family: var(--font-chat-code-family);
+  font-size: var(--app-font-size-chat-code, 12px);
+  line-height: 1.65;
+  font-variant-numeric: tabular-nums;
+  color: color-mix(in srgb, var(--foreground) 30%, transparent);
+  pointer-events: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.editor-file-editor__gutter-line {
+  display: block;
+  white-space: pre;
+}
+
+.editor-file-editor-wrap[hidden] {
+  display: none;
+}
+
+.editor-file-editor__pierre {
+  min-height: 0;
+  flex: 1;
+  overflow: auto;
+  background: transparent;
+  color: color-mix(in srgb, var(--foreground) 88%, transparent);
+  font-family: var(--font-chat-code-family);
+  font-size: var(--app-font-size-chat-code, 12px);
+  line-height: 1.65;
+}
+
+.editor-file-editor__pierre > diffs-container {
+  display: block;
+  min-height: 100%;
+  min-width: 100%;
+  width: max-content;
 }
 
 /* Line-number gutter for the read-only file preview. Rendered via CSS counters


### PR DESCRIPTION
## What changes

Explorer gains syntax highlighting and line numbers without making large files slow to edit. This combines the repaired Pierre editor from #1116 with the numbered textarea from #1118.

- Files opened with at most 1,000 lines and within the existing 250,000-character highlighting limit use Pierre. Larger files use the lightweight numbered textarea; its existing 20,000-line gutter cap remains.
- The editing engine stays stable while the document is open. Saving, toggling Markdown Preview/Source, or crossing the size threshold while typing does not remount the editor and discard its draft, focus or undo history.
- Pierre receives a stable document seed during local typing. Real reloads update its document and guarded-write version.
- The plain editor memoizes its line numbers and translates the gutter with native scroll position, avoiding scrollbar-range clamping. Empty files retain line 1.
- Both paths retain guarded writes, dirty-state handling and Ctrl/Cmd+S.

Based on contributions by @kunaaal13 and @itsmejay80. This is the combined successor to #1116 and #1118; those PRs have not been closed. Addresses the inline-editor request in #1117.

## Why the large-file path matters

Local serial Chromium measurements found that the repaired Pierre integration still took roughly 1.2 seconds per edit at 10,000 lines after stabilizing the document seed. The numbered textarea path measured about 25 ms at both 10,000 and 20,000 lines, versus approximately 25 ms for the existing textarea. These are local component measurements, not application-wide performance claims. At 20,000 lines, opening measured 392 ms versus 92 ms on main; at 1,000 lines, Pierre editing measured 67 ms versus 25 ms. Three alternating serial samples per size used the same development runtime and viewport. These costs are retained explicitly in the tradeoff.

## Validation

- 22 focused browser tests passed across editing, selection, relocation and capacity before the final two guard cases were added.
- Final editing suite: 19/19 passed with real classic Chromium scrollbars, including both additional guard cases. The final hybrid benchmark and five-digit gutter probes also passed (3 targeted cases).
- File-buffer unit tests: 21/21 passed.
- Coverage includes native input, exact save payloads, draft retention during pending saves, pre-save undo/redo, reload versions, empty files, gutter alignment, long single-line fallback and hidden Markdown editor geometry.
- Changed-file formatter and diff check passed; targeted lint had zero errors.

CI and Cursor Bugbot on the published head remain separate verification gates. No merge is requested by this description.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core workspace file editing and save/reload semantics across two editor implementations; regressions could lose edits, corrupt saves, or break markdown preview toggling.
> 
> **Overview**
> Explorer inline editing now uses **two engines**: Pierre (Shiki-backed, line numbers in shadow DOM) for files within the existing **250k-character** and **≤1,000-line** limits, and a **numbered textarea + scroll-synced gutter** for larger or longer files so typing stays fast.
> 
> The edit surface **stays mounted** while Markdown **Preview** is shown (hidden instead of replaced), which keeps drafts, focus, and undo when switching Source/Preview. Pierre gets a **stable document seed** during local edits and only **resets on reload/watcher updates**; guarded writes, dirty state, and **Ctrl/Cmd+S** behave as before.
> 
> **CSS** adds layout for the plain gutter column and Pierre container. **Browser tests** were rewired for Pierre (keyboard `replaceEditorContents`, `toHaveTextContent`, `cleanup`) and expanded to cover preview toggles, in-flight saves, gutter alignment, large-file fallback, and long single-line files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 749faf10e2a3cad88a9f434785d7651229e3d232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
