### PR TITLE
[codex] Fix Fast mode reset and duplicate skill input

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -2986,39 +2986,61 @@ describe("thread checkpoint control", () => {
     });
   });
 
-  it.skipIf(!process.env.CODEX_BINARY_PATH)("forks a provider thread via thread/fork", async () => {
+  it("forks a provider thread with an explicitly selected Standard tier", async () => {
+    const homePath = mkdtempSync(path.join(os.tmpdir(), "synara-codex-fork-tier-"));
+    writeFileSync(path.join(homePath, "app-server"), "process.stdin.resume();\n");
+    const previousSynaraHome = process.env.SYNARA_HOME;
+    process.env.SYNARA_HOME = path.join(homePath, "synara-home");
     const { manager, sendRequest } = createThreadControlHarness();
+    vi.spyOn(
+      manager as unknown as { assertSupportedCodexCliVersion: () => Promise<void> },
+      "assertSupportedCodexCliVersion",
+    ).mockResolvedValue(undefined);
     sendRequest.mockResolvedValue({
       thread: {
         id: "thread_forked",
       },
     });
 
-    const result = await manager.forkThread({
-      sourceThreadId: asThreadId("thread_1"),
-      sourceResumeCursor: {
-        threadId: "thread_1",
-      },
-      threadId: asThreadId("thread_2"),
-      runtimeMode: "full-access",
-    });
+    try {
+      const result = await manager.forkThread({
+        sourceThreadId: asThreadId("thread_1"),
+        sourceResumeCursor: {
+          threadId: "thread_1",
+        },
+        threadId: asThreadId("thread_2"),
+        cwd: homePath,
+        providerOptions: { codex: { binaryPath: process.execPath, homePath } },
+        modelSelection: {
+          provider: "codex",
+          model: "gpt-5.4",
+          options: { fastMode: false },
+        },
+        runtimeMode: "full-access",
+      });
 
-    expect(sendRequest).toHaveBeenNthCalledWith(
-      3,
-      expect.anything(),
-      "thread/fork",
-      expect.objectContaining({
+      const forkRequest = sendRequest.mock.calls.find(([, method]) => method === "thread/fork");
+      expect(forkRequest?.[2]).toMatchObject({
         threadId: "thread_1",
+        serviceTier: "default",
         approvalPolicy: "never",
         sandbox: "danger-full-access",
-      }),
-    );
-    expect(result).toEqual({
-      threadId: "thread_2",
-      resumeCursor: {
-        threadId: "thread_forked",
-      },
-    });
+      });
+      expect(result).toEqual({
+        threadId: "thread_2",
+        resumeCursor: {
+          threadId: "thread_forked",
+        },
+      });
+    } finally {
+      await manager.stopAll();
+      if (previousSynaraHome === undefined) {
+        delete process.env.SYNARA_HOME;
+      } else {
+        process.env.SYNARA_HOME = previousSynaraHome;
+      }
+      rmSync(homePath, { recursive: true, force: true });
+    }
   });
 
   it("rolls back turns via thread/rollback and resets session running state", async () => {

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -39,7 +39,7 @@ import {
   BROWSER_SCRIPT_API_GUIDANCE,
   BROWSER_SCRIPT_BATCH_GUIDANCE,
 } from "@synara/shared/browserAutomationCatalogue";
-import { getModelSelectionBooleanOptionValue, normalizeModelSlug } from "@synara/shared/model";
+import { normalizeModelSlug } from "@synara/shared/model";
 import { decodeSubagentReceiverThreadIds } from "@synara/shared/subagents";
 import { spawnProcess } from "@synara/shared/processRuntime";
 import { Effect, ServiceMap } from "effect";
@@ -62,6 +62,7 @@ import {
 } from "./agentGateway/sessionLease.ts";
 import { CodexSessionStartError, isNonFatalCodexErrorMessage } from "./codexErrorClassification.ts";
 import { buildCodexProcessEnv } from "./codexProcessEnv.ts";
+import { resolveCodexServiceTier } from "./codexServiceTier.ts";
 import { assertCodexWorkingDirectoryExists } from "./codexWorkingDirectory.ts";
 import { executableIdentity, resolveExecutable } from "./executableLookup.ts";
 import {
@@ -1950,13 +1951,11 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
               context.account,
             )
           : undefined;
-      const useFastServiceTier =
-        input.modelSelection?.provider === "codex" &&
-        getModelSelectionBooleanOptionValue(input.modelSelection, "fastMode") === true;
+      const serviceTier = resolveCodexServiceTier(input.modelSelection);
       const forkParams = {
         threadId: sourceProviderThreadId,
         ...(normalizedModel ? { model: normalizedModel } : {}),
-        ...(useFastServiceTier ? { serviceTier: "fast" as const } : {}),
+        ...(serviceTier !== undefined ? { serviceTier } : {}),
         cwd: resolvedCwd,
         ...mapCodexRuntimeMode(input.runtimeMode),
       };

--- a/apps/server/src/codexServiceTier.ts
+++ b/apps/server/src/codexServiceTier.ts
@@ -1,0 +1,12 @@
+import type { ModelSelection } from "@synara/contracts";
+
+export function resolveCodexServiceTier(
+  modelSelection: ModelSelection | undefined,
+): "fast" | "default" | undefined {
+  if (modelSelection?.provider !== "codex" || modelSelection.options?.fastMode === undefined) {
+    return undefined;
+  }
+
+  // Omitting the tier preserves Codex's previous value, including Fast mode.
+  return modelSelection.options.fastMode ? "fast" : "default";
+}

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -286,6 +286,26 @@ validationLayer("CodexAdapterLive validation", (it) => {
       });
     }),
   );
+  it.effect("explicitly selects Standard when opening a session with Fast disabled", () =>
+    Effect.gen(function* () {
+      validationManager.startSessionImpl.mockClear();
+      const adapter = yield* CodexAdapter;
+
+      yield* adapter.startSession({
+        provider: "codex",
+        threadId: asThreadId("thread-standard"),
+        resumeCursor: { threadId: "previously-fast-thread" },
+        modelSelection: {
+          provider: "codex",
+          model: "gpt-5.4",
+          options: { fastMode: false },
+        },
+        runtimeMode: "full-access",
+      });
+
+      assert.equal(validationManager.startSessionImpl.mock.calls[0]?.[0].serviceTier, "default");
+    }),
+  );
 });
 
 const sessionErrorManager = new FakeCodexManager();
@@ -369,6 +389,32 @@ const turnPreparationLayer = it.layer(
 );
 
 turnPreparationLayer("CodexAdapterLive turn input preparation", (it) => {
+  it.effect("clears Fast mode on the next turn while preserving an unspecified tier", () =>
+    Effect.gen(function* () {
+      turnPreparationManager.sendTurnImpl.mockClear();
+      const adapter = yield* CodexAdapter;
+
+      for (const fastMode of [true, false, undefined]) {
+        yield* adapter.sendTurn({
+          threadId: asThreadId("thread-tier-toggle"),
+          input: "Continue",
+          attachments: [],
+          modelSelection: {
+            provider: "codex",
+            model: "gpt-5.4",
+            ...(fastMode !== undefined ? { options: { fastMode } } : {}),
+          },
+        });
+      }
+
+      const requests = turnPreparationManager.sendTurnImpl.mock.calls.map(([input]) => input);
+      assert.deepStrictEqual(
+        requests.map((input) => input.serviceTier),
+        ["fast", "default", undefined],
+      );
+      assert.equal(Object.hasOwn(requests[2]!, "serviceTier"), false);
+    }),
+  );
   it.effect("prepares equivalent rich send and steer manager payloads", () =>
     Effect.gen(function* () {
       const adapter = yield* CodexAdapter;

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -69,6 +69,7 @@ import {
   isNonFatalCodexErrorMessage,
 } from "../../codexErrorClassification.ts";
 import { ServerConfig } from "../../config.ts";
+import { resolveCodexServiceTier } from "../../codexServiceTier.ts";
 import { makeRuntimeTaskListItem } from "../runtimeTaskList.ts";
 import { extractProposedPlanMarkdown } from "../planMode.ts";
 import { appendFileAttachmentsPromptBlock } from "../attachmentProjection.ts";
@@ -191,12 +192,13 @@ function codexModelSelectionOverrides(
     return {};
   }
 
+  const serviceTier = resolveCodexServiceTier(modelSelection);
   return {
     model: modelSelection.model,
     ...(modelSelection.options?.reasoningEffort !== undefined
       ? { effort: modelSelection.options.reasoningEffort }
       : {}),
-    ...(modelSelection.options?.fastMode ? { serviceTier: "fast" } : {}),
+    ...(serviceTier !== undefined ? { serviceTier } : {}),
   };
 }
 

--- a/apps/server/src/provider/skillPromptInjection.test.ts
+++ b/apps/server/src/provider/skillPromptInjection.test.ts
@@ -28,10 +28,12 @@ const codeiumSkillPath = "/Users/me/.codeium/windsurf/skills/reviewer/SKILL.md";
 
 describe("shouldInlineSkillForProvider", () => {
   it("skips codex-native and synara roots for codex but inlines foreign provider roots", () => {
-    // Codex loads .codex roots natively and ~/.synara/skills via the extra
-    // skill root registered at session start.
     expect(shouldInlineSkillForProvider("codex", synaraSkillPath)).toBe(false);
     expect(shouldInlineSkillForProvider("codex", codexSkillPath)).toBe(false);
+    expect(shouldInlineSkillForProvider("codex", agentsSkillPath)).toBe(false);
+    expect(shouldInlineSkillForProvider("codex", "/repo/.agents/skills/reviewer/SKILL.md")).toBe(
+      false,
+    );
     expect(shouldInlineSkillForProvider("codex", claudeSkillPath)).toBe(true);
     expect(shouldInlineSkillForProvider("codex", cursorSkillPath)).toBe(true);
   });
@@ -125,12 +127,25 @@ describe("buildInlineSkillInstructions", () => {
     }
   });
 
-  it("does not inline synara-rooted skills for codex (covered by the extra skill root)", async () => {
-    const text = await buildInlineSkillInstructions({
-      provider: "codex",
-      skills: [{ name: "reviewer", path: synaraSkillPath }],
-      maxChars: 10_000,
-    });
-    expect(text).toBe("");
-  });
+  it.each([".synara", ".agents"])(
+    "does not duplicate %s skill instructions loaded natively by Codex",
+    async (skillRoot) => {
+      const root = mkdtempSync(path.join(os.tmpdir(), "skill-native-"));
+      const skillDir = path.join(root, skillRoot, "skills", "reviewer");
+      try {
+        await mkdir(skillDir, { recursive: true });
+        const skillPath = path.join(skillDir, "SKILL.md");
+        await writeFile(skillPath, "# Reviewer\n\nAlways review carefully.");
+
+        const text = await buildInlineSkillInstructions({
+          provider: "codex",
+          skills: [{ name: "reviewer", path: skillPath }],
+          maxChars: 10_000,
+        });
+        expect(text).toBe("");
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/apps/server/src/provider/skillPromptInjection.ts
+++ b/apps/server/src/provider/skillPromptInjection.ts
@@ -41,11 +41,10 @@ export function shouldInlineSkillForProvider(provider: ProviderKind, skillPath: 
     case "antigravity":
       return true;
     case "codex":
-      // Codex injects structured skill items only from roots it knows: its own
-      // folders plus `~/.synara/skills`, which Synara registers at session start
-      // via skills/extraRoots/set. Skills resolved from other providers' folders
-      // must be inlined.
-      return [".claude", ".cursor", ".agents"].some((dir) => segments.has(dir));
+      // Codex loads .codex and .agents skills natively, plus ~/.synara/skills
+      // registered via skills/extraRoots/set. Only foreign provider roots
+      // need inline instructions alongside their structured skill reference.
+      return [".claude", ".cursor"].some((dir) => segments.has(dir));
     case "cursor":
       // cursor-agent natively scans .cursor/.agents/.claude/.codex skill roots;
       // only Synara-owned paths need inlining.

--- a/apps/web/src/components/BrowserVault.browser.tsx
+++ b/apps/web/src/components/BrowserVault.browser.tsx
@@ -98,8 +98,12 @@ describe("browser saved logins", () => {
         </SafariAccessOnboarding>,
       );
       await page.getByRole("button", { name: "Open System Settings" }).click();
-      await expect.element(page.getByRole("status")).toHaveTextContent("Access is not verified");
-      await page.getByRole("button", { name: "Continue to Synara" }).click();
+      await expect
+        .element(page.getByRole("status"))
+        .toHaveTextContent(
+          "System Settings is open. Once Synara is switched on, quit and reopen it.",
+        );
+      await page.getByRole("button", { name: "Not now" }).click();
       await page.getByRole("button", { name: "Import browser cookies" }).click();
       await page.getByRole("button", { name: "Import for this site" }).click();
       await expect.element(page.getByRole("status")).toHaveTextContent("macOS denied access");

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -365,7 +365,7 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("rounded-[var(--radius-user-message)]");
     expect(markup).toContain("chat-user-message-bubble");
     const bubbleClassName = markup.match(/class="([^"]*chat-user-message-bubble[^"]*)"/)?.[1];
-    expect(bubbleClassName?.split(" ")).toContain("py-3");
+    expect(bubbleClassName?.split(" ")).toContain("py-2.5");
     expect(markup).toContain("group-hover:opacity-100");
   });
 

--- a/apps/web/src/components/chat/composerProviderRegistry.test.tsx
+++ b/apps/web/src/components/chat/composerProviderRegistry.test.tsx
@@ -622,7 +622,10 @@ describe("getComposerProviderState", () => {
     });
   });
 
-  it("drops codex fast mode when runtime discovery does not advertise support", () => {
+  it.each([
+    { fastMode: true, expectedOptions: undefined },
+    { fastMode: false, expectedOptions: { fastMode: false } },
+  ])("normalizes unsupported Codex fastMode=$fastMode", ({ fastMode, expectedOptions }) => {
     const state = getComposerProviderState({
       provider: "codex",
       model: "gpt-5.4-mini",
@@ -635,7 +638,7 @@ describe("getComposerProviderState", () => {
       prompt: "",
       modelOptions: {
         codex: {
-          fastMode: true,
+          fastMode,
         },
       },
     });
@@ -643,11 +646,11 @@ describe("getComposerProviderState", () => {
     expect(state).toEqual({
       provider: "codex",
       promptEffort: "medium",
-      modelOptionsForDispatch: undefined,
+      modelOptionsForDispatch: expectedOptions,
     });
   });
 
-  it("drops explicit codex default/off overrides from dispatch while keeping the selected effort label", () => {
+  it("preserves explicit Codex Fast off for dispatch while keeping the selected effort label", () => {
     const state = getComposerProviderState({
       provider: "codex",
       model: "gpt-5.4",
@@ -663,7 +666,7 @@ describe("getComposerProviderState", () => {
     expect(state).toEqual({
       provider: "codex",
       promptEffort: "high",
-      modelOptionsForDispatch: undefined,
+      modelOptionsForDispatch: { fastMode: false },
     });
   });
 

--- a/apps/web/src/components/chat/composerProviderRegistry.tsx
+++ b/apps/web/src/components/chat/composerProviderRegistry.tsx
@@ -70,7 +70,9 @@ export function getComposerProviderState(input: ComposerProviderStateInput): Com
       const fastModeEnabled = caps.supportsFastMode && providerOptions?.fastMode === true;
       const nextOptions = {
         ...(reasoningEffort ? { reasoningEffort } : {}),
-        ...(fastModeEnabled ? { fastMode: true } : {}),
+        ...(fastModeEnabled || providerOptions?.fastMode === false
+          ? { fastMode: fastModeEnabled }
+          : {}),
       };
       normalizedOptions = Object.keys(nextOptions).length > 0 ? nextOptions : undefined;
       break;


### PR DESCRIPTION
## What Changed

Fix two reproduced sources of avoidable Codex usage:

- Preserve an explicit Fast-off selection through composer normalization and send `serviceTier: "default"` for session startup/resume, subsequent turns, and forks. A shared mapper keeps these paths consistent; an unspecified setting still inherits Codex's current tier.
- Let Codex load selected `.agents/skills` instructions natively instead of also inlining their contents. Keep the existing fallback for foreign skill roots.

## Why

After a Fast turn, switching Fast off could leave later requests on the priority tier: the composer discarded `fastMode: false`, and the server omitted the tier override. The installed Codex CLI and native app binary both retain the previous tier when it is omitted.

Selected `.agents` skills were also passed as both inline instructions and structured skill references. Codex already loads those references, so the model could receive two copies of the skill body.

Both behaviors were reproduced with CLI 0.154.0 and the native app's bundled CLI 0.153.4 against an isolated local mock Responses server. Captured requests showed priority persisting after omission and clearing with explicit Standard; skill instructions appeared twice before removing the inline fallback. These reproductions made no paid inference requests. Historical usage averages do not establish a general Synara usage increase, and this PR makes no aggregate savings claim.

## Verification

- Regression tests failed before each fix and passed afterward.
- Server adapter/manager suites: 170 passed, one existing optional live test skipped.
- Skill injection, Codex turn input, and discovery suites: 19 passed.
- Composer provider registry suite: 57 passed.
- Rechecked the final portable fork test fixture successfully.
- `git diff --check` passed.
- Local full format, lint, and type checks remain pending under AGENTS.md's explicit-request rule; PR CI will run those gates.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Codex service tier and skill prompts are sent, which can affect inference cost and model context; behavior is covered by new regression tests.
> 
> **Overview**
> Fixes Codex **Fast mode** sticking after users turn it off, and stops **duplicate `.agents` skill** text in prompts.
> 
> **Fast / Standard tier:** A shared `resolveCodexServiceTier` mapper now sends `serviceTier: "fast"` or `"default"` when Fast is explicitly on or off, and omits the field when unset so Codex keeps the prior tier. That logic is wired through session start, turns, and thread forks (`CodexAdapter`, `codexAppServerManager`). The composer registry no longer strips `fastMode: false` from dispatch when runtime discovery does not advertise Fast support.
> 
> **Skills:** Codex treats `.agents` skill roots as natively loaded (like `.codex`), so Synara only inlines foreign roots (e.g. `.claude`, `.cursor`) instead of duplicating `.agents` instructions.
> 
> Tests cover fork/session/turn tier behavior and native skill roots; the fork tier test runs without a live Codex binary. Minor browser onboarding and message-bubble test expectation updates are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23cf5aa633ecf8cd2fb1164f6b5c5a443f99287b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->