### PR TITLE
[codex] Fix Claude token accounting and verified usage stats

### DIFF
--- a/apps/server/src/agentGateway/harnessPolicy.test.ts
+++ b/apps/server/src/agentGateway/harnessPolicy.test.ts
@@ -1,4 +1,5 @@
 import { assert, describe, it } from "@effect/vitest";
+import { AUTOMATION_AUTHORING_GUIDANCE } from "./automationAuthoringGuidance.ts";
 
 import {
   renderSynaraHarnessPolicy,
@@ -9,6 +10,17 @@ import {
 } from "./harnessPolicy.ts";
 
 describe("Synara harness policy", () => {
+  it("defers duplicate automation authoring text while preserving tool routing and run rules", () => {
+    const inline = renderSynaraHarnessPolicy({ gatewayControlAvailable: true });
+    const deferred = renderSynaraHarnessPolicy({
+      gatewayControlAvailable: true,
+      automationAuthoring: "tool-descriptions",
+    });
+    assert.equal(deferred, inline.replace(`${AUTOMATION_AUTHORING_GUIDANCE}\n`, ""));
+    assert.include(deferred, "synara_create_automation");
+    assert.include(deferred, "synara_view_automation");
+    assert.include(deferred, "synara_report_automation_result");
+  });
   it("includes honest completion evidence and opt-in delegated E2E testing", () => {
     const policy = renderSynaraHarnessPolicy({ gatewayControlAvailable: true });
     for (const text of [

--- a/apps/server/src/agentGateway/harnessPolicy.ts
+++ b/apps/server/src/agentGateway/harnessPolicy.ts
@@ -8,6 +8,7 @@ export const SYNARA_HARNESS_POLICY_MARKER = `[Synara harness policy ${SYNARA_HAR
 
 export interface SynaraHarnessCapabilities {
   readonly gatewayControlAvailable: boolean;
+  readonly automationAuthoring?: "tool-descriptions";
 }
 
 /**
@@ -36,7 +37,10 @@ export function renderSynaraHarnessPolicy(capabilities: SynaraHarnessCapabilitie
         "Mode controls execution: heartbeat appends to an idle target thread; standalone opens a fresh thread per independent run; dedicated reuses one automation-owned thread so runs build on each other without writing into another thread.",
         "Prefer dedicated for ongoing observation or tracking: standalone runs cannot see prior runs beyond memory, while dedicated keeps one growing thread.",
         'Mode does not restrict stop conditions. completionPolicy {"type":"ai-evaluated","stopWhen":"..."} works in both modes and disables the automation when the clause matches a successful run; prefer it over encoding the stop condition in the prompt. maxIterations remains the backstop, and an automation-dispatched run may always call synara_cancel_automation on its own automation.',
-        AUTOMATION_AUTHORING_GUIDANCE,
+        // Claude discovers these same instructions on create/update tool schemas.
+        ...(capabilities.automationAuthoring === "tool-descriptions"
+          ? []
+          : [AUTOMATION_AUTHORING_GUIDANCE]),
         "Prefer synara_create_automation with suggested: true when the user has not explicitly asked to create an automation. Suggested automations remain disabled until the user accepts their proposal card.",
         "Before synara_update_automation, call synara_view_automation. Resend all mutable fields, including unchanged ones: updates replace, not merge.",
         'Automation-dispatched turns receive an identity/run/memory envelope in the current user message. Only that current turn is automation-dispatched; the status never carries into a later manual follow-up such as "continue", even in the same thread.',

--- a/apps/server/src/claudeTokenStats.ts
+++ b/apps/server/src/claudeTokenStats.ts
@@ -1,0 +1,61 @@
+// Shared read-time Claude accounting for Profile Stats and deletion snapshots.
+// Old compact modelUsage may be process-cumulative: only versioned results or
+// retained per-turn main-loop usage are safe. Never infer a version from dates.
+import type * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export function claudeTokenActivityCtes(
+  sql: SqlClient.SqlClient,
+  scope?: { readonly threadId: string },
+) {
+  return sql`
+    claude_completed_ranked AS (
+      SELECT a.thread_id, a.turn_id, a.created_at, a.payload_json,
+        COALESCE(tm.model, CASE WHEN json_valid(th.model_selection_json)
+          AND (json_extract(a.payload_json, '$.provider') IS NULL
+            OR json_extract(a.payload_json, '$.provider') = json_extract(th.model_selection_json, '$.provider'))
+          THEN json_extract(th.model_selection_json, '$.model') END, 'unknown') AS model,
+        pm.dispatch_origin,
+        ROW_NUMBER() OVER (
+          PARTITION BY a.thread_id, a.turn_id
+          ORDER BY a.sequence DESC, a.created_at DESC, a.activity_id DESC
+        ) AS rank
+      FROM projection_thread_activities a
+      JOIN projection_threads th ON th.thread_id = a.thread_id
+      LEFT JOIN turn_model tm ON tm.thread_id = a.thread_id AND tm.turn_id = a.turn_id
+      LEFT JOIN projection_turns pt ON pt.thread_id = a.thread_id AND pt.turn_id = a.turn_id
+      LEFT JOIN projection_thread_messages pm
+        ON pm.thread_id = pt.thread_id AND pm.message_id = pt.pending_message_id
+      WHERE a.kind = 'turn.completed' AND a.turn_id IS NOT NULL
+        AND th.parent_thread_id IS NULL
+        ${scope ? sql`AND a.thread_id = ${scope.threadId}` : sql.literal("")}
+        AND COALESCE(
+          json_extract(a.payload_json, '$.provider'), tm.provider,
+          CASE WHEN json_valid(th.model_selection_json)
+            THEN json_extract(th.model_selection_json, '$.provider') END
+        ) = 'claudeAgent'
+    ),
+    claude_completed AS (
+      SELECT c.*,
+        CASE WHEN json_extract(payload_json, '$.tokenAccountingVersion') = 1
+          THEN json_extract(payload_json, '$.modelUsage') END AS models,
+        CASE WHEN json_extract(payload_json, '$.tokenAccountingVersion') = 1
+          THEN json_extract(payload_json, '$.mainLoopTokens')
+          ELSE legacy.tokens
+        END AS main_tokens
+      FROM claude_completed_ranked c
+      LEFT JOIN profile_stats_claude_legacy_usage legacy
+        ON legacy.thread_id = c.thread_id AND legacy.turn_id = c.turn_id
+      WHERE rank = 1 AND (dispatch_origin IS NULL OR dispatch_origin = 'user')
+    ),
+    claude_token_rows AS (
+      SELECT c.thread_id, c.created_at, m.key AS model,
+        CAST(json_extract(m.value, '$.totalTokens') AS INTEGER) AS tokens
+      FROM claude_completed c, json_each(c.models) m
+      WHERE json_extract(m.value, '$.totalTokens') > 0
+      UNION ALL
+      SELECT thread_id, created_at, model, CAST(main_tokens AS INTEGER) AS tokens
+      FROM claude_completed
+      WHERE (models IS NULL OR models = '{}') AND main_tokens > 0
+    )
+  `;
+}

--- a/apps/server/src/claudeTokenStats.ts
+++ b/apps/server/src/claudeTokenStats.ts
@@ -37,7 +37,9 @@ export function claudeTokenActivityCtes(
       LEFT JOIN projection_turns pt ON pt.thread_id = a.thread_id AND pt.turn_id = a.turn_id
       LEFT JOIN projection_thread_messages pm
         ON pm.thread_id = pt.thread_id AND pm.message_id = pt.pending_message_id
-      WHERE th.parent_thread_id IS NULL
+      -- Provider-native children mirror usage that the parent result already
+      -- includes. Other child threads are independent work and must count.
+      WHERE COALESCE(th.creation_source, '') != 'provider_native'
         AND COALESCE(
           json_extract(a.payload_json, '$.provider'), tm.provider,
           CASE WHEN json_valid(th.model_selection_json)

--- a/apps/server/src/claudeTokenStats.ts
+++ b/apps/server/src/claudeTokenStats.ts
@@ -8,8 +8,20 @@ export function claudeTokenActivityCtes(
   scope?: { readonly threadId: string },
 ) {
   return sql`
+    claude_completed_source AS (
+      SELECT
+        a.thread_id,
+        a.turn_id,
+        a.activity_id,
+        a.sequence,
+        a.created_at,
+        CASE WHEN json_valid(a.payload_json) THEN a.payload_json ELSE '{}' END AS payload_json
+      FROM projection_thread_activities a
+      WHERE a.kind = 'turn.completed' AND a.turn_id IS NOT NULL
+        ${scope ? sql`AND a.thread_id = ${scope.threadId}` : sql.literal("")}
+    ),
     claude_completed_ranked AS (
-      SELECT a.thread_id, a.turn_id, a.created_at, a.payload_json,
+      SELECT a.thread_id, a.turn_id, a.activity_id, a.created_at, a.payload_json,
         COALESCE(tm.model, CASE WHEN json_valid(th.model_selection_json)
           AND (json_extract(a.payload_json, '$.provider') IS NULL
             OR json_extract(a.payload_json, '$.provider') = json_extract(th.model_selection_json, '$.provider'))
@@ -19,15 +31,13 @@ export function claudeTokenActivityCtes(
           PARTITION BY a.thread_id, a.turn_id
           ORDER BY a.sequence DESC, a.created_at DESC, a.activity_id DESC
         ) AS rank
-      FROM projection_thread_activities a
+      FROM claude_completed_source a
       JOIN projection_threads th ON th.thread_id = a.thread_id
       LEFT JOIN turn_model tm ON tm.thread_id = a.thread_id AND tm.turn_id = a.turn_id
       LEFT JOIN projection_turns pt ON pt.thread_id = a.thread_id AND pt.turn_id = a.turn_id
       LEFT JOIN projection_thread_messages pm
         ON pm.thread_id = pt.thread_id AND pm.message_id = pt.pending_message_id
-      WHERE a.kind = 'turn.completed' AND a.turn_id IS NOT NULL
-        AND th.parent_thread_id IS NULL
-        ${scope ? sql`AND a.thread_id = ${scope.threadId}` : sql.literal("")}
+      WHERE th.parent_thread_id IS NULL
         AND COALESCE(
           json_extract(a.payload_json, '$.provider'), tm.provider,
           CASE WHEN json_valid(th.model_selection_json)
@@ -37,9 +47,12 @@ export function claudeTokenActivityCtes(
     claude_completed AS (
       SELECT c.*,
         CASE WHEN json_extract(payload_json, '$.tokenAccountingVersion') = 1
+          AND json_type(payload_json, '$.modelUsage') = 'object'
           THEN json_extract(payload_json, '$.modelUsage') END AS models,
         CASE WHEN json_extract(payload_json, '$.tokenAccountingVersion') = 1
-          THEN json_extract(payload_json, '$.mainLoopTokens')
+          AND json_type(payload_json, '$.mainLoopTokens') IN ('integer', 'real')
+          AND json_extract(payload_json, '$.mainLoopTokens') >= 0
+          THEN CAST(json_extract(payload_json, '$.mainLoopTokens') AS INTEGER)
           ELSE legacy.tokens
         END AS main_tokens
       FROM claude_completed_ranked c
@@ -47,15 +60,59 @@ export function claudeTokenActivityCtes(
         ON legacy.thread_id = c.thread_id AND legacy.turn_id = c.turn_id
       WHERE rank = 1 AND (dispatch_origin IS NULL OR dispatch_origin = 'user')
     ),
-    claude_token_rows AS (
-      SELECT c.thread_id, c.created_at, m.key AS model,
-        CAST(json_extract(m.value, '$.totalTokens') AS INTEGER) AS tokens
+    claude_model_usage_entries AS (
+      SELECT c.activity_id, c.thread_id, c.turn_id, c.created_at, c.model AS fallback_model,
+        m.key AS model,
+        CASE WHEN json_valid(m.value) THEN
+          CASE WHEN json_type(m.value) = 'object' THEN m.value ELSE '{}' END
+        ELSE '{}' END AS usage
       FROM claude_completed c, json_each(c.models) m
-      WHERE json_extract(m.value, '$.totalTokens') > 0
+    ),
+    claude_model_token_candidates AS (
+      SELECT activity_id, thread_id, turn_id, created_at,
+        COALESCE(NULLIF(TRIM(CAST(model AS TEXT)), ''), fallback_model) AS model,
+        CAST(
+          CASE
+            -- Private builds of this PR briefly stored a compact form whose
+            -- inputTokens already included cache reads/writes. Its explicit
+            -- total is authoritative so those cache subsets are not added twice.
+            WHEN json_type(usage, '$.totalTokens') IN ('integer', 'real')
+              AND json_extract(usage, '$.totalTokens') > 0
+            THEN json_extract(usage, '$.totalTokens')
+            -- The SDK modelUsage shape has no totalTokens. Its inputTokens is
+            -- uncached input, so all four disjoint counters form the total.
+            ELSE
+              CASE WHEN json_type(usage, '$.inputTokens') IN ('integer', 'real')
+                AND json_extract(usage, '$.inputTokens') >= 0
+                THEN json_extract(usage, '$.inputTokens') ELSE 0 END
+              + CASE WHEN json_type(usage, '$.cacheReadInputTokens') IN ('integer', 'real')
+                AND json_extract(usage, '$.cacheReadInputTokens') >= 0
+                THEN json_extract(usage, '$.cacheReadInputTokens') ELSE 0 END
+              + CASE WHEN json_type(usage, '$.cacheCreationInputTokens') IN ('integer', 'real')
+                AND json_extract(usage, '$.cacheCreationInputTokens') >= 0
+                THEN json_extract(usage, '$.cacheCreationInputTokens') ELSE 0 END
+              + CASE WHEN json_type(usage, '$.outputTokens') IN ('integer', 'real')
+                AND json_extract(usage, '$.outputTokens') >= 0
+                THEN json_extract(usage, '$.outputTokens') ELSE 0 END
+          END AS INTEGER
+        ) AS tokens
+      FROM claude_model_usage_entries
+    ),
+    claude_model_token_rows AS (
+      SELECT activity_id, thread_id, turn_id, created_at, model, tokens
+      FROM claude_model_token_candidates
+      WHERE tokens > 0
+    ),
+    claude_token_rows AS (
+      SELECT thread_id, created_at, model, tokens
+      FROM claude_model_token_rows
       UNION ALL
-      SELECT thread_id, created_at, model, CAST(main_tokens AS INTEGER) AS tokens
-      FROM claude_completed
-      WHERE (models IS NULL OR models = '{}') AND main_tokens > 0
+      SELECT c.thread_id, c.created_at, c.model, CAST(c.main_tokens AS INTEGER) AS tokens
+      FROM claude_completed c
+      WHERE c.main_tokens > 0
+        AND NOT EXISTS (
+          SELECT 1 FROM claude_model_token_rows m WHERE m.activity_id = c.activity_id
+        )
     )
   `;
 }

--- a/apps/server/src/orchestration/providerRuntimeActivityProjection.test.ts
+++ b/apps/server/src/orchestration/providerRuntimeActivityProjection.test.ts
@@ -690,6 +690,8 @@ describe("provider runtime activity projection", () => {
         turnId: TURN_ID,
         payload: {
           state: "completed",
+          tokenAccountingVersion: 1,
+          mainLoopTokens: 1_000,
           modelUsage: {
             "claude-fable-5": {
               inputTokens: 100,
@@ -706,6 +708,9 @@ describe("provider runtime activity projection", () => {
       kind: "turn.completed",
       payload: {
         state: "completed",
+        provider: "claudeAgent",
+        tokenAccountingVersion: 1,
+        mainLoopTokens: 1_000,
         modelUsage: {
           "claude-fable-5": {
             inputTokens: 960,

--- a/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
+++ b/apps/server/src/orchestration/providerRuntimeActivityProjection.ts
@@ -1094,6 +1094,10 @@ export function projectProviderRuntimeActivities(
           summary,
           payload: toActivityPayload({
             state,
+            ...(event.provider === "claudeAgent" ? { provider: event.provider } : {}),
+            ...(event.payload.tokenAccountingVersion === 1
+              ? { tokenAccountingVersion: 1, mainLoopTokens: event.payload.mainLoopTokens }
+              : {}),
             ...(modelUsage ? { modelUsage } : {}),
             ...(typeof event.payload.totalCostUsd === "number"
               ? { totalCostUsd: event.payload.totalCostUsd }

--- a/apps/server/src/persistence/Migrations.test.ts
+++ b/apps/server/src/persistence/Migrations.test.ts
@@ -304,6 +304,7 @@ managedAttachmentsLegacyLayer("managed attachment migration after private migrat
         [100, "MessageTextChunks"],
         [101, "RemoveTranscriptMarkers"],
         [102, "ProjectionThreadMessagesTurnBoundary"],
+        [103, "ClaudeTokenAccounting"],
       ]);
 
       const tracker = yield* trackerRows(sql);
@@ -358,6 +359,7 @@ managedAttachmentsLegacyLayer("managed attachment migration after private migrat
           { migration_id: 100, name: "MessageTextChunks" },
           { migration_id: 101, name: "RemoveTranscriptMarkers" },
           { migration_id: 102, name: "ProjectionThreadMessagesTurnBoundary" },
+          { migration_id: 103, name: "ClaudeTokenAccounting" },
         ],
       );
       const preserved = yield* sql<{ readonly count: number }>`
@@ -453,6 +455,7 @@ agentGatewayRetentionLegacyLayer(
           [100, "MessageTextChunks"],
           [101, "RemoveTranscriptMarkers"],
           [102, "ProjectionThreadMessagesTurnBoundary"],
+          [103, "ClaudeTokenAccounting"],
         ]);
 
         const columns = yield* sql<{ readonly name: string }>`
@@ -550,6 +553,7 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
         [100, "MessageTextChunks"],
         [101, "RemoveTranscriptMarkers"],
         [102, "ProjectionThreadMessagesTurnBoundary"],
+        [103, "ClaudeTokenAccounting"],
       ]);
 
       const tracker = yield* trackerRows(sql);
@@ -588,6 +592,7 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
           [100, "MessageTextChunks"],
           [101, "RemoveTranscriptMarkers"],
           [102, "ProjectionThreadMessagesTurnBoundary"],
+          [103, "ClaudeTokenAccounting"],
         ],
       );
 
@@ -680,6 +685,7 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
         [100, "MessageTextChunks"],
         [101, "RemoveTranscriptMarkers"],
         [102, "ProjectionThreadMessagesTurnBoundary"],
+        [103, "ClaudeTokenAccounting"],
       ]);
 
       const tracker = yield* trackerRows(sql);
@@ -714,6 +720,7 @@ spacesMigrationCollisionLayer("Spaces migration after the private migration 70 c
           [100, "MessageTextChunks"],
           [101, "RemoveTranscriptMarkers"],
           [102, "ProjectionThreadMessagesTurnBoundary"],
+          [103, "ClaudeTokenAccounting"],
         ],
       );
       const preservedSpaces = yield* sql<{ readonly spaceId: string }>`

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -236,6 +236,7 @@ export const migrationEntries = [
   [100, "MessageTextChunks", Migration0100],
   [101, "RemoveTranscriptMarkers", Migration0101],
   [102, "ProjectionThreadMessagesTurnBoundary", Migration0102],
+  // Keep this ID literal: scripts/check-migration-lineage.ts parses this list.
   [103, "ClaudeTokenAccounting", ClaudeTokenAccountingMigration],
 ] as const;
 

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -118,6 +118,7 @@ import Migration0099 from "./Migrations/099_InvalidateProjectionThreadsCursor.ts
 import Migration0100 from "./Migrations/100_MessageTextChunks.ts";
 import Migration0101 from "./Migrations/101_RemoveTranscriptMarkers.ts";
 import Migration0102 from "./Migrations/102_ProjectionThreadMessagesTurnBoundary.ts";
+import ClaudeTokenAccountingMigration from "./Migrations/103_ClaudeTokenAccounting.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -235,6 +236,7 @@ export const migrationEntries = [
   [100, "MessageTextChunks", Migration0100],
   [101, "RemoveTranscriptMarkers", Migration0101],
   [102, "ProjectionThreadMessagesTurnBoundary", Migration0102],
+  [103, "ClaudeTokenAccounting", ClaudeTokenAccountingMigration],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/103_ClaudeTokenAccounting.test.ts
+++ b/apps/server/src/persistence/Migrations/103_ClaudeTokenAccounting.test.ts
@@ -1,0 +1,53 @@
+// Upgrade coverage: preserve source history and capture only recoverable usage.
+import { assert, it } from "@effect/vitest";
+import { Effect } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+import migration from "./103_ClaudeTokenAccounting.ts";
+
+it.layer(NodeSqliteClient.layerMemory())("Claude accounting migration", (it) => {
+  it.effect("preserves old snapshots and captures the last retained main-loop result once", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* runMigrations({ toMigrationInclusive: 100 });
+      yield* sql`
+        INSERT INTO profile_stats_deleted_tokens (thread_id, created_at, provider, model, tokens)
+        VALUES ('old', '2026-09-10', 'claudeAgent', 'claude-fable-5', 999999)
+      `;
+      for (const [id, provider, usage] of [
+        ["first", "claudeAgent", { input_tokens: 1, output_tokens: 2 }],
+        [
+          "final",
+          "claudeAgent",
+          {
+            input_tokens: 32,
+            cache_creation_input_tokens: 419,
+            cache_read_input_tokens: 26_816,
+            output_tokens: 59,
+          },
+        ],
+        ["other", "codex", { input_tokens: 999 }],
+        ["missing", "claudeAgent", undefined],
+      ] as const) {
+        yield* sql`
+          INSERT INTO provider_runtime_events
+            (event_id, thread_id, turn_id, event_type, event_json, persisted_at)
+          VALUES (${id}, 'root', ${id === "first" || id === "final" ? "turn" : id},
+            'turn.completed', ${JSON.stringify({ provider, payload: { usage } })}, '2026-09-10')
+        `;
+      }
+      const journal = yield* sql`SELECT * FROM provider_runtime_events`;
+      yield* migration;
+      yield* migration;
+      assert.deepEqual(yield* sql`SELECT * FROM provider_runtime_events`, journal);
+      assert.deepEqual(yield* sql`SELECT * FROM profile_stats_claude_legacy_usage`, [
+        { thread_id: "root", turn_id: "turn", tokens: 27_326 },
+      ]);
+      assert.deepEqual(
+        yield* sql`SELECT tokens, token_accounting_version FROM profile_stats_deleted_tokens`,
+        [{ tokens: 999999, token_accounting_version: null }],
+      );
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/103_ClaudeTokenAccounting.test.ts
+++ b/apps/server/src/persistence/Migrations/103_ClaudeTokenAccounting.test.ts
@@ -27,16 +27,23 @@ it.layer(NodeSqliteClient.layerMemory())("Claude accounting migration", (it) => 
             output_tokens: 59,
           },
         ],
+        ["tail-empty", "claudeAgent", {}],
         ["other", "codex", { input_tokens: 999 }],
         ["missing", "claudeAgent", undefined],
       ] as const) {
         yield* sql`
           INSERT INTO provider_runtime_events
             (event_id, thread_id, turn_id, event_type, event_json, persisted_at)
-          VALUES (${id}, 'root', ${id === "first" || id === "final" ? "turn" : id},
+          VALUES (${id}, 'root',
+            ${id === "first" || id === "final" || id === "tail-empty" ? "turn" : id},
             'turn.completed', ${JSON.stringify({ provider, payload: { usage } })}, '2026-09-10')
         `;
       }
+      yield* sql`
+        INSERT INTO provider_runtime_events
+          (event_id, thread_id, turn_id, event_type, event_json, persisted_at)
+        VALUES ('malformed', 'root', 'malformed', 'turn.completed', 'not-json', '2026-09-10')
+      `;
       const journal = yield* sql`SELECT * FROM provider_runtime_events`;
       yield* migration;
       yield* migration;

--- a/apps/server/src/persistence/Migrations/103_ClaudeTokenAccounting.ts
+++ b/apps/server/src/persistence/Migrations/103_ClaudeTokenAccounting.ts
@@ -7,7 +7,11 @@ import { columnExists } from "./schemaHelpers.ts";
 export default Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
   if (!(yield* columnExists(sql, "profile_stats_deleted_tokens", "token_accounting_version"))) {
-    yield* sql`ALTER TABLE profile_stats_deleted_tokens ADD COLUMN token_accounting_version INTEGER`;
+    // Keep this extensible: readers opt into versions they understand, while a
+    // future writer must not need a table rebuild merely to preserve a snapshot.
+    yield* sql`
+      ALTER TABLE profile_stats_deleted_tokens ADD COLUMN token_accounting_version INTEGER
+    `;
   }
   yield* sql`
     CREATE TABLE IF NOT EXISTS profile_stats_claude_legacy_usage (
@@ -21,20 +25,67 @@ export default Effect.gen(function* () {
   // it. Leave compact modelUsage and the immutable event journal untouched.
   yield* sql`
     INSERT OR IGNORE INTO profile_stats_claude_legacy_usage (thread_id, turn_id, tokens)
-    SELECT thread_id, turn_id, CAST(tokens AS INTEGER) FROM (
-      SELECT thread_id, turn_id,
-        ROW_NUMBER() OVER (PARTITION BY thread_id, turn_id ORDER BY sequence DESC) AS rank,
-        COALESCE(
-          json_extract(event_json, '$.payload.usage.total_tokens'),
-          json_extract(event_json, '$.payload.usage.input_tokens')
-            + COALESCE(json_extract(event_json, '$.payload.usage.cache_creation_input_tokens'), 0)
-            + COALESCE(json_extract(event_json, '$.payload.usage.cache_read_input_tokens'), 0)
-            + COALESCE(json_extract(event_json, '$.payload.usage.output_tokens'), 0)
-        ) AS tokens
+    WITH claude_result_source AS (
+      SELECT sequence, thread_id, turn_id,
+        CASE WHEN json_valid(event_json) THEN event_json ELSE '{}' END AS event_json
       FROM provider_runtime_events
       WHERE event_type = 'turn.completed' AND turn_id IS NOT NULL
-        AND json_extract(event_json, '$.provider') = 'claudeAgent'
+    ),
+    claude_result_ranked AS (
+      SELECT thread_id, turn_id, event_json,
+        ROW_NUMBER() OVER (PARTITION BY thread_id, turn_id ORDER BY sequence DESC) AS rank
+      FROM claude_result_source
+      WHERE json_extract(event_json, '$.provider') = 'claudeAgent'
         AND json_extract(event_json, '$.payload.tokenAccountingVersion') IS NULL
-    ) WHERE rank = 1 AND tokens >= 0
+        AND json_type(event_json, '$.payload.usage') = 'object'
+        AND (
+          (json_type(event_json, '$.payload.usage.total_tokens') IN ('integer', 'real')
+            AND json_extract(event_json, '$.payload.usage.total_tokens') >= 0)
+          OR (json_type(event_json, '$.payload.usage.input_tokens') IN ('integer', 'real')
+            AND json_extract(event_json, '$.payload.usage.input_tokens') >= 0)
+          OR (json_type(event_json, '$.payload.usage.cache_creation_input_tokens') IN ('integer', 'real')
+            AND json_extract(event_json, '$.payload.usage.cache_creation_input_tokens') >= 0)
+          OR (json_type(event_json, '$.payload.usage.cache_read_input_tokens') IN ('integer', 'real')
+            AND json_extract(event_json, '$.payload.usage.cache_read_input_tokens') >= 0)
+          OR (json_type(event_json, '$.payload.usage.output_tokens') IN ('integer', 'real')
+            AND json_extract(event_json, '$.payload.usage.output_tokens') >= 0)
+        )
+    ),
+    claude_result_tokens AS (
+      SELECT thread_id, turn_id,
+        CASE
+          WHEN json_type(event_json, '$.payload.usage.total_tokens') IN ('integer', 'real')
+            AND json_extract(event_json, '$.payload.usage.total_tokens') >= 0
+            THEN json_extract(event_json, '$.payload.usage.total_tokens')
+          WHEN (
+            (json_type(event_json, '$.payload.usage.input_tokens') IN ('integer', 'real')
+              AND json_extract(event_json, '$.payload.usage.input_tokens') >= 0)
+            OR (json_type(event_json, '$.payload.usage.cache_creation_input_tokens') IN ('integer', 'real')
+              AND json_extract(event_json, '$.payload.usage.cache_creation_input_tokens') >= 0)
+            OR (json_type(event_json, '$.payload.usage.cache_read_input_tokens') IN ('integer', 'real')
+              AND json_extract(event_json, '$.payload.usage.cache_read_input_tokens') >= 0)
+            OR (json_type(event_json, '$.payload.usage.output_tokens') IN ('integer', 'real')
+              AND json_extract(event_json, '$.payload.usage.output_tokens') >= 0)
+          ) THEN
+            CASE WHEN json_type(event_json, '$.payload.usage.input_tokens') IN ('integer', 'real')
+                AND json_extract(event_json, '$.payload.usage.input_tokens') >= 0
+              THEN json_extract(event_json, '$.payload.usage.input_tokens') ELSE 0 END
+            + CASE WHEN json_type(event_json, '$.payload.usage.cache_creation_input_tokens') IN ('integer', 'real')
+                AND json_extract(event_json, '$.payload.usage.cache_creation_input_tokens') >= 0
+              THEN json_extract(event_json, '$.payload.usage.cache_creation_input_tokens') ELSE 0 END
+            + CASE WHEN json_type(event_json, '$.payload.usage.cache_read_input_tokens') IN ('integer', 'real')
+                AND json_extract(event_json, '$.payload.usage.cache_read_input_tokens') >= 0
+              THEN json_extract(event_json, '$.payload.usage.cache_read_input_tokens') ELSE 0 END
+            + CASE WHEN json_type(event_json, '$.payload.usage.output_tokens') IN ('integer', 'real')
+                AND json_extract(event_json, '$.payload.usage.output_tokens') >= 0
+              THEN json_extract(event_json, '$.payload.usage.output_tokens') ELSE 0 END
+          ELSE NULL
+        END AS tokens
+      FROM claude_result_ranked
+      WHERE rank = 1
+    )
+    SELECT thread_id, turn_id, CAST(tokens AS INTEGER)
+    FROM claude_result_tokens
+    WHERE tokens IS NOT NULL AND tokens >= 0
   `;
 });

--- a/apps/server/src/persistence/Migrations/103_ClaudeTokenAccounting.ts
+++ b/apps/server/src/persistence/Migrations/103_ClaudeTokenAccounting.ts
@@ -1,0 +1,40 @@
+// Distinguish verified Claude deletion snapshots from older inflated counters.
+// Existing history stays untouched; it cannot safely be repaired from totals.
+import { Effect } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import { columnExists } from "./schemaHelpers.ts";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  if (!(yield* columnExists(sql, "profile_stats_deleted_tokens", "token_accounting_version"))) {
+    yield* sql`ALTER TABLE profile_stats_deleted_tokens ADD COLUMN token_accounting_version INTEGER`;
+  }
+  yield* sql`
+    CREATE TABLE IF NOT EXISTS profile_stats_claude_legacy_usage (
+      thread_id TEXT NOT NULL,
+      turn_id TEXT NOT NULL,
+      tokens INTEGER NOT NULL CHECK(tokens >= 0),
+      PRIMARY KEY (thread_id, turn_id)
+    ) WITHOUT ROWID
+  `;
+  // Capture retained, per-turn main-loop evidence before runtime retention removes
+  // it. Leave compact modelUsage and the immutable event journal untouched.
+  yield* sql`
+    INSERT OR IGNORE INTO profile_stats_claude_legacy_usage (thread_id, turn_id, tokens)
+    SELECT thread_id, turn_id, CAST(tokens AS INTEGER) FROM (
+      SELECT thread_id, turn_id,
+        ROW_NUMBER() OVER (PARTITION BY thread_id, turn_id ORDER BY sequence DESC) AS rank,
+        COALESCE(
+          json_extract(event_json, '$.payload.usage.total_tokens'),
+          json_extract(event_json, '$.payload.usage.input_tokens')
+            + COALESCE(json_extract(event_json, '$.payload.usage.cache_creation_input_tokens'), 0)
+            + COALESCE(json_extract(event_json, '$.payload.usage.cache_read_input_tokens'), 0)
+            + COALESCE(json_extract(event_json, '$.payload.usage.output_tokens'), 0)
+        ) AS tokens
+      FROM provider_runtime_events
+      WHERE event_type = 'turn.completed' AND turn_id IS NOT NULL
+        AND json_extract(event_json, '$.provider') = 'claudeAgent'
+        AND json_extract(event_json, '$.payload.tokenAccountingVersion') IS NULL
+    ) WHERE rank = 1 AND tokens >= 0
+  `;
+});

--- a/apps/server/src/profileStats.test.ts
+++ b/apps/server/src/profileStats.test.ts
@@ -75,13 +75,18 @@ describe("ProfileStatsQuery", () => {
       Effect.gen(function* () {
         const sql = yield* SqlClient.SqlClient;
         const stats = yield* ProfileStatsQuery;
-        for (const threadId of ["root", "child"]) {
+        for (const [threadId, parentThreadId, creationSource] of [
+          ["root", null, null],
+          ["mirrored-child", "root", "provider_native"],
+          ["independent-child", "root", "synara_mcp"],
+        ] as const) {
           yield* sql`
           INSERT INTO projection_threads
             (thread_id, project_id, title, model_selection_json, runtime_mode, interaction_mode,
-             env_mode, created_at, updated_at, parent_thread_id)
+             env_mode, created_at, updated_at, parent_thread_id, creation_source)
           VALUES (${threadId}, 'project', 'Claude', '{"provider":"claudeAgent","model":"claude-fable-5"}',
-            'full-access', 'default', 'local', '2026-09-10', '2026-09-10', ${threadId === "child" ? "root" : null})
+            'full-access', 'default', 'local', '2026-09-10', '2026-09-10',
+            ${parentThreadId}, ${creationSource})
         `;
         }
         const addActivity = (id: string, threadId: string, turnId: string, payload: object) => sql`
@@ -117,7 +122,7 @@ describe("ProfileStatsQuery", () => {
         };
         yield* addActivity("1", "root", "first", versioned);
         yield* addActivity("2", "root", "first", versioned);
-        yield* addActivity("3", "child", "mirrored", versioned);
+        yield* addActivity("3", "mirrored-child", "mirrored", versioned);
         yield* addActivity("4", "root", "legacy", { modelUsage: versioned.modelUsage });
         yield* addActivity("5", "root", "unrecoverable", { modelUsage: versioned.modelUsage });
         // An earlier private build emitted a compact shape whose input already
@@ -142,6 +147,7 @@ describe("ProfileStatsQuery", () => {
           mainLoopTokens: 250,
           modelUsage: { "claude-fable-5": "unusable" },
         });
+        yield* addActivity("8", "independent-child", "independent", versioned);
         // Successful main-loop usage survives even though old compact model totals
         // cannot be classified as per-turn or cumulative without process evidence.
         yield* sql`
@@ -177,10 +183,10 @@ describe("ProfileStatsQuery", () => {
         // The verified fallback must outlive ordinary runtime-event retention.
         yield* sql`DELETE FROM provider_runtime_events`;
         const result = yield* stats.getProfileTokenStats({ utcOffsetMinutes: 0 });
-        expect(result.lifetimeTotalTokens).toBe(56_902);
+        expect(result.lifetimeTotalTokens).toBe(85_228);
         expect(result.models.map(({ model, tokens }) => ({ model, tokens }))).toEqual([
-          { model: "claude-fable-5", tokens: 55_902 },
-          { model: "claude-opus-4-8", tokens: 1_000 },
+          { model: "claude-fable-5", tokens: 83_228 },
+          { model: "claude-opus-4-8", tokens: 2_000 },
         ]);
       }),
     );
@@ -925,6 +931,17 @@ describe("ProfileStatsQuery", () => {
               'client',
               '{"threadId":"thread-hybrid","messageId":"message-hybrid-claude","modelSelection":{"provider":"claudeAgent","model":"claude-haiku-4-5"}}',
               '{}'
+            ),
+            (
+              'event-hybrid-codex-after',
+              'thread',
+              'thread-hybrid',
+              3,
+              'thread.turn-start-requested',
+              '2026-06-13T12:20:00.000Z',
+              'client',
+              '{"threadId":"thread-hybrid","messageId":"message-hybrid-codex-after","modelSelection":{"provider":"codex","model":"gpt-5-codex"}}',
+              '{}'
             )
         `;
 
@@ -953,11 +970,20 @@ describe("ProfileStatsQuery", () => {
               'completed',
               '2026-06-13T12:10:00.000Z',
               '[]'
+            ),
+            (
+              'thread-hybrid',
+              'turn-hybrid-codex-after',
+              'message-hybrid-codex-after',
+              'completed',
+              '2026-06-13T12:20:00.000Z',
+              '[]'
             )
         `;
 
         // Codex has cumulative totals, so its usedTokens-only dip is ignored.
-        // Claude final usage is counted independently of the Codex counter series.
+        // A large legacy Claude counter sits between the two Codex turns, but
+        // Claude final usage is counted independently and cannot reset that delta.
         yield* sql`
           INSERT INTO projection_thread_activities (
             activity_id,
@@ -994,15 +1020,15 @@ describe("ProfileStatsQuery", () => {
               '2026-06-13T12:03:00.000Z'
             ),
             (
-              'activity-hybrid-codex-2',
+              'activity-hybrid-claude-legacy',
               'thread-hybrid',
-              'turn-hybrid-codex',
+              'turn-hybrid-claude',
               'info',
               'context-window.updated',
               'tokens updated',
-              '{"usedTokens":1500,"totalProcessedTokens":2500}',
+              '{"usedTokens":700,"totalProcessedTokens":999999}',
               3,
-              '2026-06-13T12:04:00.000Z'
+              '2026-06-13T12:11:00.000Z'
             ),
             (
               'activity-hybrid-claude-1',
@@ -1013,7 +1039,7 @@ describe("ProfileStatsQuery", () => {
               'tokens updated',
               '{"usedTokens":700}',
               4,
-              '2026-06-13T12:11:00.000Z'
+              '2026-06-13T12:11:30.000Z'
             ),
             (
               'activity-hybrid-claude-2',
@@ -1025,6 +1051,17 @@ describe("ProfileStatsQuery", () => {
               '{"tokenAccountingVersion":1,"mainLoopTokens":1700}',
               5,
               '2026-06-13T12:12:00.000Z'
+            ),
+            (
+              'activity-hybrid-codex-2',
+              'thread-hybrid',
+              'turn-hybrid-codex-after',
+              'info',
+              'context-window.updated',
+              'tokens updated',
+              '{"usedTokens":1500,"totalProcessedTokens":2500}',
+              6,
+              '2026-06-13T12:21:00.000Z'
             )
         `;
 

--- a/apps/server/src/profileStats.test.ts
+++ b/apps/server/src/profileStats.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 
 import { ServerConfig } from "./config";
 import { SqlitePersistenceMemory } from "./persistence/Layers/Sqlite";
+import recoverClaudeUsage from "./persistence/Migrations/103_ClaudeTokenAccounting";
 import {
   aggregateProfileSkillUsageRows,
   heatmapIntensity,
@@ -69,6 +70,89 @@ describe("heatmapIntensity", () => {
 });
 
 describe("ProfileStatsQuery", () => {
+  it("uses versioned Claude results once, recovers retained main usage, and excludes unverifiable history", async () => {
+    await runProfileStatsTest(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        const stats = yield* ProfileStatsQuery;
+        for (const threadId of ["root", "child"]) {
+          yield* sql`
+          INSERT INTO projection_threads
+            (thread_id, project_id, title, model_selection_json, runtime_mode, interaction_mode,
+             env_mode, created_at, updated_at, parent_thread_id)
+          VALUES (${threadId}, 'project', 'Claude', '{"provider":"claudeAgent","model":"claude-fable-5"}',
+            'full-access', 'default', 'local', '2026-09-10', '2026-09-10', ${threadId === "child" ? "root" : null})
+        `;
+        }
+        const addActivity = (id: string, threadId: string, turnId: string, payload: object) => sql`
+        INSERT INTO projection_thread_activities
+          (activity_id, thread_id, turn_id, tone, kind, summary, payload_json, sequence, created_at)
+        VALUES (${id}, ${threadId}, ${turnId}, 'info', 'turn.completed', 'done',
+          ${JSON.stringify(payload)}, ${Number(id)}, '2026-09-10T12:00:00Z')
+      `;
+        const versioned = {
+          tokenAccountingVersion: 1,
+          mainLoopTokens: 27_326,
+          modelUsage: {
+            "claude-fable-5": {
+              inputTokens: 27_267,
+              outputTokens: 59,
+              totalTokens: 27_326,
+              cacheReadInputTokens: 26_816,
+              cacheCreationInputTokens: 419,
+            },
+            "claude-opus-4-8": { inputTokens: 900, outputTokens: 100, totalTokens: 1_000 },
+          },
+        };
+        yield* addActivity("1", "root", "first", versioned);
+        yield* addActivity("2", "root", "first", versioned);
+        yield* addActivity("3", "child", "mirrored", versioned);
+        yield* addActivity("4", "root", "legacy", { modelUsage: versioned.modelUsage });
+        yield* addActivity("5", "root", "unrecoverable", { modelUsage: versioned.modelUsage });
+        // Successful main-loop usage survives even though old compact model totals
+        // cannot be classified as per-turn or cumulative without process evidence.
+        yield* sql`
+        INSERT INTO provider_runtime_events
+          (event_id, thread_id, turn_id, event_type, event_json, persisted_at)
+        VALUES ('legacy-result', 'root', 'legacy', 'turn.completed',
+          ${JSON.stringify({
+            provider: "claudeAgent",
+            payload: {
+              usage: {
+                input_tokens: 32,
+                cache_creation_input_tokens: 419,
+                cache_read_input_tokens: 26_816,
+                output_tokens: 59,
+              },
+            },
+          })}, '2026-09-10')
+      `;
+        yield* sql`
+        INSERT INTO projection_thread_activities
+          (activity_id, thread_id, turn_id, tone, kind, summary, payload_json, created_at)
+        VALUES ('inflated', 'root', 'first', 'info', 'context-window.updated', 'usage',
+          '{"provider":"claudeAgent","totalProcessedTokens":141818233}', '2026-09-10')
+      `;
+        yield* sql`
+        INSERT INTO profile_stats_deleted_tokens (thread_id, created_at, provider, model, tokens)
+        VALUES ('old-deleted', '2026-09-10', 'claudeAgent', 'claude-fable-5', 999999)
+      `;
+        const journalBefore = yield* sql`SELECT * FROM provider_runtime_events`;
+        yield* recoverClaudeUsage;
+        yield* recoverClaudeUsage;
+        expect(yield* sql`SELECT * FROM provider_runtime_events`).toEqual(journalBefore);
+        // The verified fallback must outlive ordinary runtime-event retention.
+        yield* sql`DELETE FROM provider_runtime_events`;
+        const result = yield* stats.getProfileTokenStats({ utcOffsetMinutes: 0 });
+        expect(result.lifetimeTotalTokens).toBe(55_652);
+        expect(result.models.map(({ model, tokens }) => ({ model, tokens }))).toEqual([
+          { model: "claude-fable-5", tokens: 54_652 },
+          { model: "claude-opus-4-8", tokens: 1_000 },
+        ]);
+      }),
+    );
+  });
+
   it("normalizes profile skill usage from structured refs plus slash and dollar prompt tokens", () => {
     expect(
       aggregateProfileSkillUsageRows([
@@ -501,9 +585,9 @@ describe("ProfileStatsQuery", () => {
               'thread-claude',
               'turn-claude-1',
               'info',
-              'context-window.updated',
+              'turn.completed',
               'tokens updated',
-              '{"totalProcessedTokens":5000}',
+              '{"tokenAccountingVersion":1,"mainLoopTokens":5000}',
               1,
               '2026-06-13T10:06:00.000Z'
             )
@@ -643,8 +727,7 @@ describe("ProfileStatsQuery", () => {
             )
         `;
 
-        // thread-switch never reports the cumulative counter (like the Claude
-        // adapter below the context window), so usedTokens drives its series.
+        // Claude completes with per-turn totals; provisional context rows are ignored.
         // thread-mixed dips to context scale mid-thread and recovers: only the
         // cumulative rows count (6000 total, not 6000 + the dip recovery).
         yield* sql`
@@ -676,9 +759,9 @@ describe("ProfileStatsQuery", () => {
               'thread-switch',
               'turn-switch-1',
               'info',
-              'context-window.updated',
+              'turn.completed',
               'tokens updated',
-              '{"usedTokens":3000}',
+              '{"tokenAccountingVersion":1,"mainLoopTokens":3000}',
               2,
               '2026-06-13T09:03:00.000Z'
             ),
@@ -687,9 +770,9 @@ describe("ProfileStatsQuery", () => {
               'thread-switch',
               'turn-switch-2',
               'info',
-              'context-window.updated',
+              'turn.completed',
               'tokens updated',
-              '{"usedTokens":5000}',
+              '{"tokenAccountingVersion":1,"mainLoopTokens":2000}',
               3,
               '2026-06-13T09:21:00.000Z'
             ),
@@ -841,8 +924,7 @@ describe("ProfileStatsQuery", () => {
         `;
 
         // Codex has cumulative totals, so its usedTokens-only dip is ignored.
-        // Claude never reports cumulative totals in this thread, so its own
-        // usedTokens series is still counted instead of being dropped.
+        // Claude final usage is counted independently of the Codex counter series.
         yield* sql`
           INSERT INTO projection_thread_activities (
             activity_id,
@@ -905,9 +987,9 @@ describe("ProfileStatsQuery", () => {
               'thread-hybrid',
               'turn-hybrid-claude',
               'info',
-              'context-window.updated',
+              'turn.completed',
               'tokens updated',
-              '{"usedTokens":1700}',
+              '{"tokenAccountingVersion":1,"mainLoopTokens":1700}',
               5,
               '2026-06-13T12:12:00.000Z'
             )
@@ -1517,9 +1599,9 @@ describe("ProfileStatsQuery", () => {
               'thread-legacy-bad-json',
               'turn-legacy-1',
               'info',
-              'context-window.updated',
+              'turn.completed',
               'tokens updated',
-              '{"totalProcessedTokens":1500,"provider":"claudeAgent"}',
+              '{"tokenAccountingVersion":1,"mainLoopTokens":1500,"provider":"claudeAgent"}',
               2,
               '2026-06-14T09:10:00.000Z'
             )

--- a/apps/server/src/profileStats.test.ts
+++ b/apps/server/src/profileStats.test.ts
@@ -95,13 +95,24 @@ describe("ProfileStatsQuery", () => {
           mainLoopTokens: 27_326,
           modelUsage: {
             "claude-fable-5": {
-              inputTokens: 27_267,
+              inputTokens: 32,
               outputTokens: 59,
-              totalTokens: 27_326,
               cacheReadInputTokens: 26_816,
               cacheCreationInputTokens: 419,
+              webSearchRequests: 0,
+              costUSD: 0.031,
+              contextWindow: 200_000,
+              maxOutputTokens: 32_000,
             },
-            "claude-opus-4-8": { inputTokens: 900, outputTokens: 100, totalTokens: 1_000 },
+            "claude-opus-4-8": {
+              inputTokens: 900,
+              outputTokens: 100,
+              cacheReadInputTokens: 0,
+              cacheCreationInputTokens: 0,
+              costUSD: 0.02,
+              contextWindow: 200_000,
+              maxOutputTokens: 32_000,
+            },
           },
         };
         yield* addActivity("1", "root", "first", versioned);
@@ -109,6 +120,28 @@ describe("ProfileStatsQuery", () => {
         yield* addActivity("3", "child", "mirrored", versioned);
         yield* addActivity("4", "root", "legacy", { modelUsage: versioned.modelUsage });
         yield* addActivity("5", "root", "unrecoverable", { modelUsage: versioned.modelUsage });
+        // An earlier private build emitted a compact shape whose input already
+        // included cache tokens. Its explicit total remains authoritative.
+        yield* addActivity("6", "root", "compact", {
+          tokenAccountingVersion: 1,
+          mainLoopTokens: 1_000,
+          modelUsage: {
+            "claude-fable-5": {
+              inputTokens: 900,
+              outputTokens: 100,
+              totalTokens: 1_000,
+              cacheReadInputTokens: 800,
+              cacheCreationInputTokens: 60,
+            },
+          },
+        });
+        // A malformed nonempty breakdown must not suppress the verified
+        // main-loop fallback or make SQLite JSON functions fail.
+        yield* addActivity("7", "root", "fallback", {
+          tokenAccountingVersion: 1,
+          mainLoopTokens: 250,
+          modelUsage: { "claude-fable-5": "unusable" },
+        });
         // Successful main-loop usage survives even though old compact model totals
         // cannot be classified as per-turn or cumulative without process evidence.
         yield* sql`
@@ -144,9 +177,9 @@ describe("ProfileStatsQuery", () => {
         // The verified fallback must outlive ordinary runtime-event retention.
         yield* sql`DELETE FROM provider_runtime_events`;
         const result = yield* stats.getProfileTokenStats({ utcOffsetMinutes: 0 });
-        expect(result.lifetimeTotalTokens).toBe(55_652);
+        expect(result.lifetimeTotalTokens).toBe(56_902);
         expect(result.models.map(({ model, tokens }) => ({ model, tokens }))).toEqual([
-          { model: "claude-fable-5", tokens: 54_652 },
+          { model: "claude-fable-5", tokens: 55_902 },
           { model: "claude-opus-4-8", tokens: 1_000 },
         ]);
       }),

--- a/apps/server/src/profileStats.ts
+++ b/apps/server/src/profileStats.ts
@@ -21,6 +21,7 @@ import { Effect, Layer, ServiceMap } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import { ServerConfig } from "./config";
+import { claudeTokenActivityCtes } from "./claudeTokenStats";
 
 const HEATMAP_WINDOW_DAYS = 274; // ~9 months, GitHub-style contribution grid.
 const SKILL_RESULT_LIMIT = 12;
@@ -696,7 +697,9 @@ const makeProfileStatsQuery = Effect.gen(function* () {
       `,
     );
 
-  // Token usage for EVERY provider, straight from Synara's own DB (no external
+  // Claude uses versioned turn results (including subagents once), with retained
+  // main-loop results as a partial historical fallback; see claudeTokenStats.ts.
+  // Other providers' token usage comes straight from Synara's own DB (no external
   // ~/.codex/~/.claude archives, so it is provider-agnostic AND per-instance). Each
   // `context-window.updated` activity carries a running per-thread token counter;
   // the positive delta is the tokens processed in that step, bucketed by the
@@ -714,6 +717,7 @@ const makeProfileStatsQuery = Effect.gen(function* () {
         WITH turn_model AS (
           ${turnModelSelectionCte(sql)}
         ),
+        ${claudeTokenActivityCtes(sql)},
         ev AS (
           SELECT
             a.thread_id AS thread_id,
@@ -880,10 +884,16 @@ const makeProfileStatsQuery = Effect.gen(function* () {
         ),
         all_tokens AS (
           SELECT day, provider, model, d FROM cumulative_delta
-          WHERE dispatch_origin IS NULL OR dispatch_origin = 'user'
+          WHERE provider != 'claudeAgent'
+            AND (dispatch_origin IS NULL OR dispatch_origin = 'user')
           UNION ALL
           SELECT day, provider, model, d FROM used_only_delta
-          WHERE dispatch_origin IS NULL OR dispatch_origin = 'user'
+          WHERE provider != 'claudeAgent'
+            AND (dispatch_origin IS NULL OR dispatch_origin = 'user')
+          UNION ALL
+          SELECT STRFTIME('%Y-%m-%d', DATETIME(created_at, ${tz})),
+            'claudeAgent', model, tokens
+          FROM claude_token_rows
           UNION ALL
           SELECT
             STRFTIME('%Y-%m-%d', DATETIME(a.created_at, ${tz})) AS day,
@@ -891,6 +901,7 @@ const makeProfileStatsQuery = Effect.gen(function* () {
             COALESCE(a.model, 'unknown') AS model,
             a.tokens AS d
           FROM profile_stats_deleted_tokens a
+          WHERE COALESCE(a.provider, 'unknown') != 'claudeAgent' OR a.token_accounting_version = 1
         )
         SELECT day, provider, model, SUM(d) AS tokens
         FROM all_tokens

--- a/apps/server/src/profileStats.ts
+++ b/apps/server/src/profileStats.ts
@@ -718,7 +718,7 @@ const makeProfileStatsQuery = Effect.gen(function* () {
           ${turnModelSelectionCte(sql)}
         ),
         ${claudeTokenActivityCtes(sql)},
-        ev AS (
+        token_activity AS (
           SELECT
             a.thread_id AS thread_id,
             STRFTIME('%Y-%m-%d', DATETIME(a.created_at, ${tz})) AS day,
@@ -767,6 +767,12 @@ const makeProfileStatsQuery = Effect.gen(function* () {
               json_extract(a.payload_json, '$.totalProcessedTokens'),
               json_extract(a.payload_json, '$.usedTokens')
             ) IS NOT NULL
+        ),
+        -- Claude's verified per-turn results are counted separately below. Drop
+        -- provisional/legacy Claude context rows before windowing so they cannot
+        -- change a neighboring provider's cumulative or used-only delta.
+        ev AS (
+          SELECT * FROM token_activity WHERE provider != 'claudeAgent'
         ),
         provider_model_scale AS (
           SELECT thread_id, provider, model, MAX(tp IS NOT NULL) AS has_cumulative
@@ -884,12 +890,10 @@ const makeProfileStatsQuery = Effect.gen(function* () {
         ),
         all_tokens AS (
           SELECT day, provider, model, d FROM cumulative_delta
-          WHERE provider != 'claudeAgent'
-            AND (dispatch_origin IS NULL OR dispatch_origin = 'user')
+          WHERE dispatch_origin IS NULL OR dispatch_origin = 'user'
           UNION ALL
           SELECT day, provider, model, d FROM used_only_delta
-          WHERE provider != 'claudeAgent'
-            AND (dispatch_origin IS NULL OR dispatch_origin = 'user')
+          WHERE dispatch_origin IS NULL OR dispatch_origin = 'user'
           UNION ALL
           SELECT STRFTIME('%Y-%m-%d', DATETIME(created_at, ${tz})),
             'claudeAgent', model, tokens

--- a/apps/server/src/profileStatsArchive.test.ts
+++ b/apps/server/src/profileStatsArchive.test.ts
@@ -371,6 +371,62 @@ describe("ProfileStatsArchive", () => {
     ]);
   });
 
+  it("removes legacy Claude rows before computing other providers' archive deltas", () => {
+    const rows = aggregateThreadTokenRows([
+      {
+        totalProcessedTokens: 1_000,
+        usedTokens: null,
+        provider: "codex",
+        model: "gpt-5.5",
+        createdAt: "2026-06-13T12:00:00.000Z",
+      },
+      {
+        totalProcessedTokens: 99_000,
+        usedTokens: null,
+        provider: "claudeAgent",
+        model: "claude-fable-5",
+        createdAt: "2026-06-13T12:01:00.000Z",
+      },
+      {
+        totalProcessedTokens: 1_500,
+        usedTokens: null,
+        provider: "codex",
+        model: "gpt-5.5",
+        createdAt: "2026-06-13T12:02:00.000Z",
+      },
+      {
+        totalProcessedTokens: null,
+        usedTokens: 100,
+        provider: "pi",
+        model: "pi",
+        createdAt: "2026-06-13T12:03:00.000Z",
+      },
+      {
+        totalProcessedTokens: null,
+        usedTokens: 9_000,
+        provider: "claudeAgent",
+        model: "claude-opus-4-8",
+        createdAt: "2026-06-13T12:04:00.000Z",
+      },
+      {
+        totalProcessedTokens: null,
+        usedTokens: 150,
+        provider: "pi",
+        model: "pi",
+        createdAt: "2026-06-13T12:05:00.000Z",
+      },
+    ]);
+
+    expect(
+      rows.map(({ provider, createdAt, tokens }) => ({ provider, createdAt, tokens })),
+    ).toEqual([
+      { provider: "codex", createdAt: "2026-06-13T12:00:00.000Z", tokens: 1_000 },
+      { provider: "codex", createdAt: "2026-06-13T12:02:00.000Z", tokens: 500 },
+      { provider: "pi", createdAt: "2026-06-13T12:03:00.000Z", tokens: 100 },
+      { provider: "pi", createdAt: "2026-06-13T12:05:00.000Z", tokens: 50 },
+    ]);
+  });
+
   it("keeps a stamped activity provider instead of a mismatched thread fallback", () => {
     const rows = aggregateThreadTokenRows(
       [
@@ -403,6 +459,13 @@ describe("ProfileStatsArchive", () => {
         const archive = yield* ProfileStatsArchive;
         yield* seedTwoThreadsWithActivity;
         yield* acknowledgeProviderCommandJournal(sql);
+        // Independent child threads are real work. Only provider-native mirrors
+        // are excluded from Claude result accounting.
+        yield* sql`
+          UPDATE projection_threads
+          SET parent_thread_id = 'thread-keep', creation_source = 'synara_mcp'
+          WHERE thread_id = 'thread-purge'
+        `;
         yield* sql`
         UPDATE projection_thread_activities SET payload_json = '{"provider":"claudeAgent","totalProcessedTokens":999999}'
         WHERE thread_id = 'thread-purge'

--- a/apps/server/src/profileStatsArchive.test.ts
+++ b/apps/server/src/profileStatsArchive.test.ts
@@ -414,7 +414,15 @@ describe("ProfileStatsArchive", () => {
               provider: "claudeAgent",
               tokenAccountingVersion: 1,
               modelUsage: {
-                "claude-fable-5": { totalTokens: 1000, inputTokens: 900, outputTokens: 100 },
+                "claude-fable-5": {
+                  inputTokens: 100,
+                  outputTokens: 40,
+                  cacheReadInputTokens: 800,
+                  cacheCreationInputTokens: 60,
+                  costUSD: 0.01,
+                  contextWindow: 200_000,
+                  maxOutputTokens: 32_000,
+                },
               },
             },
           ],

--- a/apps/server/src/profileStatsArchive.test.ts
+++ b/apps/server/src/profileStatsArchive.test.ts
@@ -296,14 +296,14 @@ describe("ProfileStatsArchive", () => {
       {
         totalProcessedTokens: null,
         usedTokens: 700,
-        provider: "claudeAgent",
+        provider: "pi",
         model: "claude-haiku-4-5",
         createdAt: "2026-06-13T12:11:00.000Z",
       },
       {
         totalProcessedTokens: null,
         usedTokens: 1700,
-        provider: "claudeAgent",
+        provider: "pi",
         model: "claude-haiku-4-5",
         createdAt: "2026-06-13T12:12:00.000Z",
       },
@@ -324,13 +324,13 @@ describe("ProfileStatsArchive", () => {
       },
       {
         createdAt: "2026-06-13T12:11:00.000Z",
-        provider: "claudeAgent",
+        provider: "pi",
         model: "claude-haiku-4-5",
         tokens: 700,
       },
       {
         createdAt: "2026-06-13T12:12:00.000Z",
-        provider: "claudeAgent",
+        provider: "pi",
         model: "claude-haiku-4-5",
         tokens: 1000,
       },
@@ -377,7 +377,7 @@ describe("ProfileStatsArchive", () => {
         {
           totalProcessedTokens: 1_500,
           usedTokens: null,
-          provider: "claudeAgent",
+          provider: "pi",
           model: null,
           createdAt: "2026-06-13T12:00:00.000Z",
         },
@@ -388,11 +388,65 @@ describe("ProfileStatsArchive", () => {
     expect(rows).toEqual([
       {
         createdAt: "2026-06-13T12:00:00.000Z",
-        provider: "claudeAgent",
+        provider: "pi",
         model: null,
         tokens: 1_500,
       },
     ]);
+  });
+
+  it("archives verified Claude results and legacy evidence without reintroducing block totals", async () => {
+    await runArchiveTest(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        const stats = yield* ProfileStatsQuery;
+        const archive = yield* ProfileStatsArchive;
+        yield* seedTwoThreadsWithActivity;
+        yield* acknowledgeProviderCommandJournal(sql);
+        yield* sql`
+        UPDATE projection_thread_activities SET payload_json = '{"provider":"claudeAgent","totalProcessedTokens":999999}'
+        WHERE thread_id = 'thread-purge'
+      `;
+        for (const [turnId, payload] of [
+          [
+            "verified",
+            {
+              provider: "claudeAgent",
+              tokenAccountingVersion: 1,
+              modelUsage: {
+                "claude-fable-5": { totalTokens: 1000, inputTokens: 900, outputTokens: 100 },
+              },
+            },
+          ],
+          ["legacy", { provider: "claudeAgent" }],
+        ] as const) {
+          yield* sql`
+          INSERT INTO projection_thread_activities
+            (activity_id, thread_id, turn_id, tone, kind, summary, payload_json, sequence, created_at)
+          VALUES (${turnId}, 'thread-purge', ${turnId}, 'info', 'turn.completed', 'done',
+            ${JSON.stringify(payload)}, 100, '2026-06-13T18:45:00Z')
+        `;
+        }
+        yield* sql`
+        INSERT INTO profile_stats_claude_legacy_usage VALUES ('thread-purge', 'legacy', 500)
+      `;
+        const before = yield* stats.getProfileTokenStats({ utcOffsetMinutes: 330 });
+        yield* archive.purgeThreadWithStatsSnapshot({
+          threadId: ThreadId.makeUnsafe("thread-purge"),
+        });
+        expect(yield* stats.getProfileTokenStats({ utcOffsetMinutes: 330 })).toEqual(before);
+        expect(
+          yield* sql`
+        SELECT tokens, token_accounting_version AS version FROM profile_stats_deleted_tokens
+        WHERE provider = 'claudeAgent' ORDER BY tokens
+      `,
+        ).toEqual([
+          { tokens: 500, version: 1 },
+          { tokens: 1000, version: 1 },
+        ]);
+        expect(yield* sql`SELECT * FROM profile_stats_claude_legacy_usage`).toEqual([]);
+      }),
+    );
   });
 
   it("purges a thread's rows while keeping every profile stat unchanged", async () => {

--- a/apps/server/src/profileStatsArchive.ts
+++ b/apps/server/src/profileStatsArchive.ts
@@ -28,6 +28,7 @@ import { aggregateProfileSkillUsageRows, turnModelSelectionCte } from "./profile
 import { PROVIDER_COMMAND_REACTOR_CONSUMER } from "./persistence/Services/OrchestrationEventDeliveries";
 import { isProviderIntentEventType } from "./orchestration/providerIntentClassification";
 import { THREAD_RETENTION_COMMAND_ID_PREFIX } from "./threadRetention";
+import { claudeTokenActivityCtes } from "./claudeTokenStats";
 
 interface PurgeThreadRow {
   readonly projectId: string | null;
@@ -318,6 +319,7 @@ export function aggregateThreadTokenRows(
       continue;
     }
     const { provider, model } = resolveTokenProviderModel(row, fallbackSelection);
+    if (provider === "claudeAgent") continue;
     addTokenSnapshotRow(tokensByKey, {
       createdAt: row.createdAt,
       provider,
@@ -345,6 +347,7 @@ export function aggregateThreadTokenRows(
         : Math.max(0, total - previousUsedTotal);
     previousUsedTotal = total;
     previousUsedProviderModelKey = providerModelKey;
+    if (provider === "claudeAgent") continue;
     if (
       delta <= 0 ||
       row.createdAt === null ||
@@ -663,6 +666,15 @@ const makeProfileStatsArchive = Effect.gen(function* () {
         provider: threadSelection?.provider ?? null,
         model: threadSelection?.model ?? null,
       });
+      // Preserve the same verified Claude rows as the live profile before the
+      // retained runtime fallback is purged along with this thread.
+      const claudeTokenRows = yield* sql<ThreadTokenSnapshotRow>`
+        WITH turn_model AS (${turnModelSelectionCte(sql, { threadId })}),
+          ${claudeTokenActivityCtes(sql, { threadId })}
+        SELECT created_at AS createdAt, 'claudeAgent' AS provider, model, tokens
+        FROM claude_token_rows
+      `;
+      tokenRows.push(...claudeTokenRows);
       const skillRows = aggregateProfileSkillUsageRows(skillMessageRows);
       const hasStatsContribution = hasProfileStatsContribution({
         promptRows: skillMessageRows,
@@ -712,8 +724,10 @@ const makeProfileStatsArchive = Effect.gen(function* () {
         yield* Effect.forEach(
           tokenRows,
           (row) => sql`
-            INSERT INTO profile_stats_deleted_tokens (thread_id, created_at, provider, model, tokens)
-            VALUES (${threadId}, ${row.createdAt}, ${row.provider}, ${row.model}, ${row.tokens})
+            INSERT INTO profile_stats_deleted_tokens
+              (thread_id, created_at, provider, model, tokens, token_accounting_version)
+            VALUES (${threadId}, ${row.createdAt}, ${row.provider}, ${row.model}, ${row.tokens},
+              ${row.provider === "claudeAgent" ? 1 : null})
           `,
           { concurrency: 1, discard: true },
         );
@@ -802,6 +816,7 @@ const makeProfileStatsArchive = Effect.gen(function* () {
       yield* sql`DELETE FROM provider_session_runtime WHERE thread_id = ${threadId}`;
       yield* sql`DELETE FROM projection_pending_interactions WHERE thread_id = ${threadId}`;
       yield* sql`DELETE FROM projection_thread_activities WHERE thread_id = ${threadId}`;
+      yield* sql`DELETE FROM profile_stats_claude_legacy_usage WHERE thread_id = ${threadId}`;
       yield* sql`DELETE FROM projection_thread_messages WHERE thread_id = ${threadId}`;
       yield* sql`DELETE FROM message_text_segments WHERE thread_id = ${threadId}`;
       yield* sql`DELETE FROM projection_thread_proposed_plans WHERE thread_id = ${threadId}`;

--- a/apps/server/src/profileStatsArchive.ts
+++ b/apps/server/src/profileStatsArchive.ts
@@ -290,9 +290,15 @@ export function aggregateThreadTokenRows(
   rows: ReadonlyArray<TokenActivityRow>,
   fallbackSelection?: { readonly provider: string | null; readonly model: string | null },
 ): ThreadTokenSnapshotRow[] {
+  // Claude's verified turn results are snapshotted separately. Remove its old
+  // context rows before maintaining any delta state, otherwise a large Claude
+  // counter can reset or inflate the next provider's archived delta.
+  const nonClaudeRows = rows.filter(
+    (row) => resolveTokenProviderModel(row, fallbackSelection).provider !== "claudeAgent",
+  );
   const tokensByKey = new Map<string, ThreadTokenSnapshotRow>();
   const cumulativeProviderModels = new Set<string>();
-  for (const row of rows) {
+  for (const row of nonClaudeRows) {
     if (tokenCounterValue(row.totalProcessedTokens) === null) {
       continue;
     }
@@ -301,7 +307,7 @@ export function aggregateThreadTokenRows(
   }
 
   let previousCumulativeTotal: number | null = null;
-  for (const row of rows) {
+  for (const row of nonClaudeRows) {
     const total = tokenCounterValue(row.totalProcessedTokens);
     if (total === null) {
       continue;
@@ -319,7 +325,6 @@ export function aggregateThreadTokenRows(
       continue;
     }
     const { provider, model } = resolveTokenProviderModel(row, fallbackSelection);
-    if (provider === "claudeAgent") continue;
     addTokenSnapshotRow(tokensByKey, {
       createdAt: row.createdAt,
       provider,
@@ -330,7 +335,7 @@ export function aggregateThreadTokenRows(
 
   let previousUsedTotal: number | null = null;
   let previousUsedProviderModelKey: string | null = null;
-  for (const row of rows) {
+  for (const row of nonClaudeRows) {
     const { provider, model } = resolveTokenProviderModel(row, fallbackSelection);
     const providerModelKey = tokenProviderModelKey(provider, model);
     if (cumulativeProviderModels.has(providerModelKey)) {
@@ -347,7 +352,6 @@ export function aggregateThreadTokenRows(
         : Math.max(0, total - previousUsedTotal);
     previousUsedTotal = total;
     previousUsedProviderModelKey = providerModelKey;
-    if (provider === "claudeAgent") continue;
     if (
       delta <= 0 ||
       row.createdAt === null ||

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -9303,6 +9303,104 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
     );
   });
 
+  it.effect("preserves resultless synthetic-turn usage across the next result and resume", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const events: ProviderRuntimeEvent[] = [];
+      const firstCompleted = yield* Deferred.make<void>();
+      const syntheticStarted = yield* Deferred.make<void>();
+      const allCompleted = yield* Deferred.make<void>();
+      let completedCount = 0;
+      yield* adapter.streamEvents.pipe(
+        Stream.runForEach((event) => {
+          events.push(event);
+          if (event.type === "turn.completed") {
+            completedCount += 1;
+            if (completedCount === 1) return Deferred.succeed(firstCompleted, undefined);
+            if (completedCount === 3) return Deferred.succeed(allCompleted, undefined);
+          }
+          if (event.type === "turn.started" && completedCount === 1) {
+            return Deferred.succeed(syntheticStarted, undefined);
+          }
+          return Effect.void;
+        }),
+        Effect.forkChild,
+      );
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({ threadId: THREAD_ID, input: "first", attachments: [] });
+      emitAssistantUsage(
+        harness.query,
+        "sdk-resultless-accounting",
+        "first-block",
+        "first",
+        { input_tokens: 100 },
+        "first-call",
+      );
+      emitSuccessResult(harness.query, "sdk-resultless-accounting", "first-result", {
+        input_tokens: 100,
+      });
+      yield* Deferred.await(firstCompleted);
+
+      // Background output opens a synthetic UI turn. The next user prompt closes
+      // that turn before Claude emits an SDK result for it.
+      emitAssistantUsage(
+        harness.query,
+        "sdk-resultless-accounting",
+        "background-block",
+        "background",
+        { input_tokens: 10 },
+        "background-call",
+      );
+      yield* Deferred.await(syntheticStarted);
+      yield* adapter.sendTurn({ threadId: THREAD_ID, input: "next", attachments: [] });
+
+      // A larger late snapshot from the closed request must stay quarantined.
+      emitAssistantUsage(
+        harness.query,
+        "sdk-resultless-accounting",
+        "background-tail",
+        "late",
+        { input_tokens: 15 },
+        "background-call",
+      );
+      emitAssistantUsage(
+        harness.query,
+        "sdk-resultless-accounting",
+        "next-block",
+        "next",
+        { input_tokens: 20 },
+        "next-call",
+      );
+      emitSuccessResult(harness.query, "sdk-resultless-accounting", "next-result", {
+        input_tokens: 20,
+      });
+      yield* Deferred.await(allCompleted);
+      assert.equal(
+        events.filter((event) => event.type === "turn.completed")[1]?.payload.mainLoopTokens,
+        10,
+      );
+      assert.deepEqual(
+        events
+          .filter((event) => event.type === "thread.token-usage.updated")
+          .map((event) => event.payload.usage.totalProcessedTokens),
+        [100, 100, 110, 110, 110, 130, 130],
+      );
+      const resumeCursor = (yield* adapter.listSessions())[0]!.resumeCursor as
+        | { processedTokenTotal?: number }
+        | undefined;
+      assert.equal(resumeCursor?.processedTokenTotal, 130);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect(
     "keeps request accounting across interruption, late delivery, clear, and resume",
     () => {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -536,6 +536,7 @@ function emitAssistantUsage(
   uuid: string,
   text: string,
   usage: Record<string, number>,
+  messageId = uuid,
 ): void {
   query.emit({
     type: "assistant",
@@ -543,7 +544,7 @@ function emitAssistantUsage(
     uuid,
     parent_tool_use_id: null,
     message: {
-      id: uuid,
+      id: messageId,
       content: [{ type: "text", text }],
       usage,
     },
@@ -2287,6 +2288,18 @@ describe("ClaudeAdapterLive", () => {
       } as unknown as SDKMessage);
 
       harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-subagent",
+        uuid: "assistant-subagent-block-2",
+        parent_tool_use_id: "tool-task-1",
+        message: {
+          id: "assistant-message-subagent-1",
+          content: [{ type: "text", text: "The migration looks correct." }],
+          usage: { input_tokens: 10, output_tokens: 8 },
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
         type: "tool_progress",
         tool_use_id: "tool-subagent-heartbeat-1",
         tool_name: "Grep",
@@ -2332,6 +2345,12 @@ describe("ClaudeAdapterLive", () => {
       const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
       const childEvents = runtimeEvents.filter(
         (event) => event.providerRefs?.providerThreadId === "tool-task-1",
+      );
+      assert.deepEqual(
+        childEvents
+          .filter((event) => event.type === "thread.token-usage.updated")
+          .map((event) => event.payload.usage.totalProcessedTokens),
+        [15, 18, undefined, 18],
       );
       assert.equal(
         childEvents.every((event) => event.providerRefs?.providerParentThreadId === THREAD_ID),
@@ -6421,6 +6440,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
       if (usageEvent?.type === "thread.token-usage.updated") {
         assert.deepEqual(usageEvent.payload, {
           usage: {
+            tokenAccountingVersion: 1,
             usedTokens: 24542,
             lastUsedTokens: 24542,
             inputTokens: 23863,
@@ -6487,6 +6507,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
       if (usageEvent?.type === "thread.token-usage.updated") {
         assert.deepEqual(usageEvent.payload, {
           usage: {
+            tokenAccountingVersion: 1,
             usedTokens: 200000,
             lastUsedTokens: 200000,
             totalProcessedTokens: 535000,
@@ -6568,6 +6589,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         if (finalUsageEvent?.type === "thread.token-usage.updated") {
           assert.deepEqual(finalUsageEvent.payload, {
             usage: {
+              tokenAccountingVersion: 1,
               usedTokens: 190000,
               lastUsedTokens: 190000,
               totalProcessedTokens: 535000,
@@ -6648,6 +6670,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
       if (finalUsageEvent?.type === "thread.token-usage.updated") {
         assert.deepEqual(finalUsageEvent.payload, {
           usage: {
+            tokenAccountingVersion: 1,
             usedTokens: 190000,
             lastUsedTokens: 190000,
             totalProcessedTokens: 535000,
@@ -6727,6 +6750,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
       if (finalUsageEvent?.type === "thread.token-usage.updated") {
         assert.deepEqual(finalUsageEvent.payload, {
           usage: {
+            tokenAccountingVersion: 1,
             usedTokens: 190000,
             lastUsedTokens: 190000,
             maxTokens: 200_000,
@@ -8428,6 +8452,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
           runtimeMode: "full-access" as const,
         };
         yield* adapter.startSession(startInput);
+        const systemPrompt = structuredClone(harness.createInputs[0]!.options.systemPrompt);
         let query = harness.queries[0]!;
         const collectCompletion = () =>
           adapter.streamEvents.pipe(
@@ -8531,6 +8556,10 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
               event.payload.message.includes("conversation_reset"),
           ),
         );
+        // Session identities and turn content never enter the appended prefix.
+        for (const input of harness.createInputs) {
+          assert.deepEqual(input.options.systemPrompt, systemPrompt);
+        }
       }).pipe(
         Effect.provideService(Random.Random, makeDeterministicRandomService()),
         Effect.provide(harness.layer),
@@ -9183,6 +9212,228 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
     );
   });
 
+  it.effect("counts repeated Claude content blocks once and reconciles provisional output", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+      });
+      const collectTurn = () =>
+        adapter.streamEvents.pipe(
+          Stream.takeUntil((event) => event.type === "turn.completed"),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+      const observed = yield* collectTurn();
+      yield* adapter.sendTurn({ threadId: THREAD_ID, input: "first", attachments: [] });
+      const emitBlock = (uuid: string, output: number, id = "request-1") => {
+        harness.query.emit({
+          type: "assistant",
+          session_id: "sdk-block-accounting",
+          uuid,
+          parent_tool_use_id: null,
+          request_id: id,
+          message: {
+            id,
+            content: [{ type: "text", text: uuid }],
+            usage: {
+              input_tokens: 32,
+              cache_creation_input_tokens: 419,
+              cache_read_input_tokens: 26_816,
+              output_tokens: output,
+            },
+          },
+        } as unknown as SDKMessage);
+      };
+      emitBlock("thinking-block", 59);
+      emitBlock("text-block", 59);
+      emitBlock("text-block", 59);
+      emitBlock("later-output", 100);
+      emitBlock("distinct-request", 59, "request-2");
+      emitSuccessResult(harness.query, "sdk-block-accounting", "result-1", {
+        total_tokens: 54_700,
+      });
+      const events = Array.from(yield* Fiber.join(observed));
+      assert.deepEqual(
+        events
+          .filter((event) => event.type === "thread.token-usage.updated")
+          .map((event) => event.payload.usage.totalProcessedTokens),
+        [27_326, 27_326, 27_326, 27_367, 54_693, 54_700],
+      );
+
+      const next = yield* collectTurn();
+      yield* adapter.sendTurn({ threadId: THREAD_ID, input: "second", attachments: [] });
+      emitBlock("next-request", 59, "request-3");
+      emitSuccessResult(harness.query, "sdk-block-accounting", "result-2", {
+        total_tokens: 27_320,
+      });
+      const nextEvents = Array.from(yield* Fiber.join(next));
+      const usage = nextEvents.filter((event) => event.type === "thread.token-usage.updated");
+      assert.deepEqual(
+        usage.map((event) => event.payload.usage.totalProcessedTokens),
+        [82_026, 82_020],
+      );
+      const zero = yield* collectTurn();
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "zero-usage command",
+        attachments: [],
+      });
+      emitBlock("synthetic-output", 0, "request-4");
+      emitSuccessResult(harness.query, "sdk-block-accounting", "result-zero", {
+        input_tokens: 0,
+        output_tokens: 0,
+      });
+      const zeroEvents = Array.from(yield* Fiber.join(zero));
+      assert.equal(
+        zeroEvents.find((event) => event.type === "turn.completed")?.payload.mainLoopTokens,
+        0,
+      );
+      assert.equal(
+        zeroEvents.findLast((event) => event.type === "thread.token-usage.updated")?.payload.usage
+          .totalProcessedTokens,
+        82_020,
+      );
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect(
+    "keeps request accounting across interruption, late delivery, clear, and resume",
+    () => {
+      const harness = makeMultiQueryHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+        const start = {
+          threadId: THREAD_ID,
+          provider: "claudeAgent" as const,
+          runtimeMode: "full-access" as const,
+        };
+        yield* adapter.startSession(start);
+        let query = harness.queries[0]!;
+        const collect = () =>
+          adapter.streamEvents.pipe(
+            Stream.takeUntil((event) => event.type === "turn.completed"),
+            Stream.runCollect,
+            Effect.forkChild,
+          );
+        const first = yield* collect();
+        yield* adapter.sendTurn({ threadId: THREAD_ID, input: "first", attachments: [] });
+        emitAssistantUsage(
+          query,
+          "sdk-lifecycle",
+          "block-1",
+          "partial",
+          { input_tokens: 100 },
+          "call-1",
+        );
+        emitAssistantUsage(
+          query,
+          "sdk-lifecycle",
+          "block-2",
+          "partial",
+          { input_tokens: 100 },
+          "call-1",
+        );
+        yield* adapter.interruptTurn(THREAD_ID);
+        const failed = {
+          type: "result",
+          subtype: "error_during_execution",
+          is_error: true,
+          errors: ["interrupted"],
+          session_id: "sdk-lifecycle",
+          uuid: "failed-result",
+          usage: { input_tokens: 0, output_tokens: 0 },
+          modelUsage: {},
+          total_cost_usd: 0,
+        } as unknown as SDKMessage;
+        query.emit(failed);
+        const firstEvents = Array.from(yield* Fiber.join(first));
+        assert.equal(
+          firstEvents.find((event) => event.type === "turn.completed")?.payload.mainLoopTokens,
+          100,
+        );
+        assert.equal(
+          firstEvents.find((event) => event.type === "turn.completed")?.payload.state,
+          "interrupted",
+        );
+
+        const next = yield* collect();
+        yield* adapter.sendTurn({ threadId: THREAD_ID, input: "next", attachments: [] });
+        query.emit(failed);
+        emitAssistantUsage(
+          query,
+          "sdk-lifecycle",
+          "late-block",
+          "tail",
+          { input_tokens: 100 },
+          "call-1",
+        );
+        emitAssistantUsage(
+          query,
+          "sdk-lifecycle",
+          "new-block",
+          "next",
+          { input_tokens: 20 },
+          "call-2",
+        );
+        emitSuccessResult(query, "sdk-lifecycle", "next-result", { input_tokens: 20 });
+        const nextEvents = Array.from(yield* Fiber.join(next));
+        assert.deepEqual(
+          nextEvents
+            .filter((event) => event.type === "thread.token-usage.updated")
+            .map((event) => event.payload.usage.totalProcessedTokens),
+          [100, 120, 120],
+        );
+
+        const cleared = yield* collect();
+        yield* adapter.sendTurn({ threadId: THREAD_ID, input: "/clear", attachments: [] });
+        query.emit({
+          type: "conversation_reset",
+          new_conversation_id: "new-lifecycle",
+          session_id: "sdk-lifecycle",
+          uuid: "clear",
+        } as unknown as SDKMessage);
+        emitAssistantUsage(
+          query,
+          "new-lifecycle",
+          "after-clear",
+          "cleared",
+          { input_tokens: 20 },
+          "call-2",
+        );
+        emitSuccessResult(query, "new-lifecycle", "clear-result", { input_tokens: 20 });
+        yield* Fiber.join(cleared);
+        const resumeCursor = (yield* adapter.listSessions())[0]!.resumeCursor;
+        assert.equal((resumeCursor as { processedTokenTotal?: number }).processedTokenTotal, 140);
+        yield* adapter.stopSession(THREAD_ID);
+        yield* adapter.startSession({ ...start, resumeCursor });
+        query = harness.queries[1]!;
+        const resumed = yield* collect();
+        yield* adapter.sendTurn({ threadId: THREAD_ID, input: "resumed", attachments: [] });
+        emitAssistantUsage(query, "new-lifecycle", "resumed-block", "resumed", {
+          input_tokens: 10,
+        });
+        emitSuccessResult(query, "new-lifecycle", "resumed-result", { input_tokens: 10 });
+        const events = Array.from(yield* Fiber.join(resumed));
+        assert.deepEqual(
+          events
+            .filter((event) => event.type === "thread.token-usage.updated")
+            .map((event) => event.payload.usage.totalProcessedTokens),
+          [150, 150],
+        );
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
+
   it.effect("invalidates compaction-call usage until the next assistant response", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
@@ -9221,6 +9472,14 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         "assistant-compaction-call",
         "Compacted",
         { input_tokens: 1, cache_read_input_tokens: 189_999, output_tokens: 0 },
+      );
+      emitAssistantUsage(
+        harness.query,
+        "sdk-session-compact",
+        "another-compaction-block",
+        "Compacted text block",
+        { input_tokens: 1, cache_read_input_tokens: 189_999, output_tokens: 0 },
+        "assistant-compaction-call",
       );
       emitSuccessResult(harness.query, "sdk-session-compact", "result-compact", {
         total_tokens: 350_000,
@@ -9266,6 +9525,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
       assertTokenUsageEvent(accountingUsage);
       assert.deepEqual(accountingUsage.payload.usage, {
         usedTokens: 0,
+        tokenAccountingVersion: 1,
         totalProcessedTokens: 350_000,
       });
       const freshUsage = events[3];
@@ -9299,6 +9559,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         resumeCursor: {
           threadId: THREAD_ID,
           processedTokenTotal: 350_000,
+          tokenAccountingVersion: 1,
         },
       });
       yield* adapter.sendTurn({
@@ -9324,6 +9585,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
       assertTokenUsageEvent(usageEvents[0]);
       assert.deepEqual(usageEvents[0].payload.usage, {
         usedTokens: 20_000,
+        tokenAccountingVersion: 1,
         lastUsedTokens: 20_000,
         totalProcessedTokens: 370_000,
         maxTokens: 1_000_000,
@@ -9347,7 +9609,7 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
         threadId: THREAD_ID,
         provider: "claudeAgent",
         runtimeMode: "full-access",
-        resumeCursor: { threadId: THREAD_ID, turnCount: 1 },
+        resumeCursor: { threadId: THREAD_ID, turnCount: 1, processedTokenTotal: 999_999 },
       });
       yield* adapter.sendTurn({
         threadId: session.threadId,
@@ -9659,6 +9921,8 @@ await agent("Draft the spec", { label: "delta-agent", phase: "Two" });
       if (finalUsageEvent?.type === "thread.token-usage.updated") {
         assert.deepEqual(finalUsageEvent.payload, {
           usage: {
+            tokenAccountingVersion: 1,
+            totalProcessedTokens: 23_000,
             usedTokens: 23_000,
             lastUsedTokens: 23_000,
             maxTokens: 1_000_000,
@@ -11193,6 +11457,7 @@ describe("ClaudeAdapterLive forkThread", () => {
           resume: "forked-session-1",
           turnCount: 4,
           processedTokenTotal: 0,
+          tokenAccountingVersion: 1,
         },
       });
     }).pipe(
@@ -11289,6 +11554,7 @@ describe("ClaudeAdapterLive forkThread", () => {
         resume: "forked-session-2",
         turnCount: 4,
         processedTokenTotal: 0,
+        tokenAccountingVersion: 1,
       });
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -108,6 +108,7 @@ import { ServerConfig } from "../../config.ts";
 import { buildFileAttachmentsPromptBlock } from "../attachmentProjection.ts";
 import { loadClaudeAgentSdk } from "../claudeAgentSdk.ts";
 import { buildClaudeProcessEnv } from "../claudeProcessEnv.ts";
+import { ClaudeRequestUsage } from "../claudeRequestUsage.ts";
 import {
   CLAUDE_CONTEXT_WINDOW_MAX_TOKENS,
   decideClaudeContextUsageWarnings,
@@ -192,6 +193,7 @@ interface ClaudeResumeState {
   readonly turnCount?: number;
   readonly trackedTasks?: ReadonlyArray<ClaudeTrackedTask>;
   readonly processedTokenTotal?: number;
+  readonly tokenAccountingVersion?: 1;
 }
 
 interface ClaudeTurnState {
@@ -367,12 +369,17 @@ interface ClaudeSessionContext {
   contextUsageControlEnabled: boolean;
   lastKnownTokenUsage: ThreadTokenUsageSnapshot | undefined;
   tokenUsageState: ClaudeTokenUsageState;
+  compactionMessageId: string | undefined;
   // Assistant snapshots report one API call at a time. Keep their processed-token
   // accounting separately from the current context size so compaction can clear
-  // the meter without resetting the cumulative counter used by profile stats.
+  // the meter without resetting the cumulative processed estimate.
   processedTokenTotal: number;
   processedTokenTurnBaseline: number;
+  // Native results delimit SDK turns, even when a UI turn closes early.
+  processedTokenResultBaseline: number;
   processedTokenBaselineKnown: boolean;
+  readonly requestUsage: ClaudeRequestUsage;
+  lastResultUuid: string | undefined;
   lastAssistantUuid: string | undefined;
   lastThreadStartedId: string | undefined;
   // Original API model id the runtime rerouted away from (safeguard refusal
@@ -927,6 +934,7 @@ function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undef
     turnCount?: unknown;
     trackedTasks?: unknown;
     processedTokenTotal?: unknown;
+    tokenAccountingVersion?: unknown;
   };
 
   const threadIdCandidate = typeof cursor.threadId === "string" ? cursor.threadId : undefined;
@@ -960,7 +968,9 @@ function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undef
       ? { turnCount: turnCountValue }
       : {}),
     ...(trackedTasks.length > 0 ? { trackedTasks } : {}),
-    ...(processedTokenTotal !== undefined ? { processedTokenTotal } : {}),
+    ...(processedTokenTotal !== undefined && cursor.tokenAccountingVersion === 1
+      ? { processedTokenTotal, tokenAccountingVersion: 1 as const }
+      : {}),
   };
 }
 
@@ -1162,7 +1172,10 @@ export const buildEmbeddedClaudeSystemPromptAppend = (gatewayControlAvailable: b
     "When the user asks about the current project, codebase, or repository, proactively inspect files in the current working directory before asking the user where to look.",
     "When spawning subagents, set the Agent tool's `model` parameter and pick reasoning effort by choosing a worker-<tier> subagent type (worker-low, worker-medium, worker-high, worker-xhigh).",
     "Honor explicit user instructions about a subagent's model or effort verbatim; otherwise match task complexity: mechanical work → haiku or worker-low, standard work → sonnet or worker-medium, hard reasoning → opus or fable with worker-high and above.",
-    renderSynaraHarnessPolicy({ gatewayControlAvailable }),
+    renderSynaraHarnessPolicy({
+      gatewayControlAvailable,
+      automationAuthoring: "tool-descriptions",
+    }),
   ].join("\n");
 
 const CLAUDE_WORKER_EFFORT_TIERS = ["low", "medium", "high", "xhigh"] as const;
@@ -2111,7 +2124,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             ? { trackedTasks: Array.from(context.trackedTasks.values()) }
             : {}),
           ...(context.processedTokenBaselineKnown
-            ? { processedTokenTotal: context.processedTokenTotal }
+            ? { processedTokenTotal: context.processedTokenTotal, tokenAccountingVersion: 1 }
             : {}),
         };
 
@@ -2805,23 +2818,27 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           context.lastKnownAutoCompactThreshold = liveAutoCompactThreshold;
         }
 
-        // The SDK result.usage contains *accumulated* totals across all API calls
-        // (input_tokens, cache_read_input_tokens, etc. summed over every request).
-        // This does NOT represent the current context window size.
-        // Instead, use the last known context-window-accurate usage from task_progress
-        // events and treat the accumulated total as totalProcessedTokens.
+        // result.usage settles this turn's main loop, not the context size or
+        // subagents. Successful results may correct provisional block output down.
         const accumulatedSnapshot = normalizeClaudeTokenUsage(
           result?.usage,
           claudeEffectiveContextBudget(context),
         );
+        const reportedZeroUsage =
+          result?.usage?.input_tokens === 0 &&
+          result.usage.output_tokens === 0 &&
+          (result.usage.cache_creation_input_tokens ?? 0) === 0 &&
+          (result.usage.cache_read_input_tokens ?? 0) === 0;
         const resultProcessedTokens =
-          accumulatedSnapshot?.totalProcessedTokens ?? accumulatedSnapshot?.usedTokens;
+          accumulatedSnapshot?.totalProcessedTokens ??
+          accumulatedSnapshot?.usedTokens ??
+          (reportedZeroUsage ? 0 : undefined);
         if (resultProcessedTokens !== undefined) {
-          const resultBaseline = context.turnState ? context.processedTokenTurnBaseline : 0;
-          context.processedTokenTotal = Math.max(
-            context.processedTokenTotal,
-            resultBaseline + resultProcessedTokens,
-          );
+          const reconciledTotal = context.processedTokenResultBaseline + resultProcessedTokens;
+          context.processedTokenTotal =
+            status === "completed"
+              ? reconciledTotal
+              : Math.max(context.processedTokenTotal, reconciledTotal);
         }
         const totalProcessedTokens =
           context.processedTokenTotal > 0 ? context.processedTokenTotal : resultProcessedTokens;
@@ -2845,7 +2862,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           context.processedTokenBaselineKnown && totalProcessedTokens !== undefined
             ? { usedTokens: 0, totalProcessedTokens }
             : undefined;
-        const usageSnapshot: ThreadTokenUsageSnapshot | undefined =
+        const mergedUsageSnapshot: ThreadTokenUsageSnapshot | undefined =
           context.tokenUsageState !== "current"
             ? accountingOnlyUsage
             : !context.processedTokenBaselineKnown
@@ -2857,7 +2874,26 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
                     maxTokens,
                   )
                 : accountedAccumulatedSnapshot;
-        context.processedTokenTurnBaseline = context.processedTokenTotal;
+        // The context merge preserves context size; accounting has its own final
+        // value and must not inherit the merge's monotonic provisional maximum.
+        const usageSnapshot = mergedUsageSnapshot
+          ? {
+              ...withoutProcessedTokenTotal(mergedUsageSnapshot),
+              tokenAccountingVersion: 1 as const,
+              ...(context.processedTokenBaselineKnown && totalProcessedTokens !== undefined
+                ? { totalProcessedTokens }
+                : {}),
+            }
+          : undefined;
+        const mainLoopTokens = Math.max(
+          0,
+          context.processedTokenTotal -
+            (result ? context.processedTokenResultBaseline : context.processedTokenTurnBaseline),
+        );
+        if (result) {
+          context.processedTokenResultBaseline = context.processedTokenTotal;
+          context.requestUsage.settleTurn();
+        }
 
         // A safeguard reroute only applies to the turn that just finished.
         // Restore the user-selected model so subsequent turns do not silently
@@ -2919,6 +2955,8 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               ...(result?.stop_reason !== undefined ? { stopReason: result.stop_reason } : {}),
               ...(result?.usage ? { usage: result.usage } : {}),
               ...(turnResultUsage ? { modelUsage: turnResultUsage.modelUsage } : {}),
+              tokenAccountingVersion: 1,
+              mainLoopTokens,
               ...(typeof result?.total_cost_usd === "number"
                 ? { totalCostUsd: turnResultUsage?.totalCostUsd ?? result.total_cost_usd }
                 : {}),
@@ -3032,6 +3070,8 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             ...(result?.stop_reason !== undefined ? { stopReason: result.stop_reason } : {}),
             ...(result?.usage ? { usage: result.usage } : {}),
             ...(turnResultUsage ? { modelUsage: turnResultUsage.modelUsage } : {}),
+            tokenAccountingVersion: 1,
+            mainLoopTokens,
             ...(typeof result?.total_cost_usd === "number"
               ? { totalCostUsd: turnResultUsage?.totalCostUsd ?? result.total_cost_usd }
               : {}),
@@ -3112,9 +3152,13 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           contextUsageControlEnabled: false,
           lastKnownTokenUsage: undefined,
           tokenUsageState: "current",
+          compactionMessageId: undefined,
           processedTokenTotal: 0,
           processedTokenTurnBaseline: 0,
+          processedTokenResultBaseline: 0,
           processedTokenBaselineKnown: true,
+          requestUsage: new ClaudeRequestUsage(),
+          lastResultUuid: undefined,
           lastAssistantUuid: undefined,
           lastThreadStartedId: undefined,
           rerouteOriginalApiModelId: undefined,
@@ -3784,25 +3828,30 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         // this reflects the actual prompt + output size for this single API call.
         const perCallUsage = (message.message as { usage?: unknown } | undefined)?.usage;
         if (perCallUsage) {
+          const messageId = message.message.id ?? message.request_id ?? message.uuid;
           const normalizedPerCallUsage = normalizeClaudeTokenUsage(
             perCallUsage as Record<string, unknown>,
             claudeEffectiveContextBudget(context),
           );
           if (normalizedPerCallUsage) {
-            context.processedTokenTotal +=
-              normalizedPerCallUsage.totalProcessedTokens ?? normalizedPerCallUsage.usedTokens;
+            context.processedTokenTotal += context.requestUsage.add(
+              messageId,
+              normalizedPerCallUsage.totalProcessedTokens ?? normalizedPerCallUsage.usedTokens,
+            );
           }
           if (context.tokenUsageState === "skip-compaction-call") {
+            context.compactionMessageId = messageId;
             context.tokenUsageState = "awaiting-fresh-assistant";
-          } else {
+          } else if (context.compactionMessageId !== messageId) {
             yield* maybeEmitContextUsageWarning(context, perCallUsage as Record<string, unknown>);
             if (normalizedPerCallUsage) {
-              const currentUsage = context.processedTokenBaselineKnown
-                ? {
-                    ...normalizedPerCallUsage,
-                    totalProcessedTokens: context.processedTokenTotal,
-                  }
-                : normalizedPerCallUsage;
+              const currentUsage = {
+                ...withoutProcessedTokenTotal(normalizedPerCallUsage),
+                tokenAccountingVersion: 1 as const,
+                ...(context.processedTokenBaselineKnown
+                  ? { totalProcessedTokens: context.processedTokenTotal }
+                  : {}),
+              };
               context.lastKnownTokenUsage = currentUsage;
               context.tokenUsageState = "current";
               const usageStamp = yield* makeEventStamp();
@@ -3839,6 +3888,8 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         if (message.type !== "result") {
           return;
         }
+        if (message.uuid && context.lastResultUuid === message.uuid) return;
+        context.lastResultUuid = message.uuid;
 
         const assistantError = context.turnState?.assistantError;
         let status: ProviderRuntimeTurnStatus;
@@ -4634,6 +4685,10 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           case "conversation_reset":
             // The query survives /clear even when its cumulative counters restart.
             delete context.resultUsageBaseline;
+            context.requestUsage.reset();
+            context.compactionMessageId = undefined;
+            context.processedTokenTurnBaseline = context.processedTokenTotal;
+            context.processedTokenResultBaseline = context.processedTokenTotal;
             return;
           case "result":
             yield* handleResultMessage(context, message);
@@ -5498,7 +5553,10 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               turnCount: resumeState?.turnCount ?? 0,
               ...(trackedTasks.size > 0 ? { trackedTasks: Array.from(trackedTasks.values()) } : {}),
               ...(processedTokenBaselineKnown
-                ? { processedTokenTotal: resumeState?.processedTokenTotal ?? 0 }
+                ? {
+                    processedTokenTotal: resumeState?.processedTokenTotal ?? 0,
+                    tokenAccountingVersion: 1,
+                  }
                 : {}),
             },
             createdAt: startedAt,
@@ -5546,9 +5604,13 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             contextUsageControlEnabled: true,
             lastKnownTokenUsage: undefined,
             tokenUsageState: "current",
+            compactionMessageId: undefined,
             processedTokenTotal: resumeState?.processedTokenTotal ?? 0,
             processedTokenTurnBaseline: resumeState?.processedTokenTotal ?? 0,
+            processedTokenResultBaseline: resumeState?.processedTokenTotal ?? 0,
             processedTokenBaselineKnown,
+            requestUsage: new ClaudeRequestUsage(),
+            lastResultUuid: undefined,
             lastAssistantUuid: resumeState?.resumeSessionAt,
             lastThreadStartedId: undefined,
             rerouteOriginalApiModelId: undefined,
@@ -6189,6 +6251,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           resume: forked.sessionId,
           turnCount: Math.max(liveSource?.turns.length ?? 0, sourceState?.turnCount ?? 0),
           processedTokenTotal: 0,
+          tokenAccountingVersion: 1,
         };
         return { threadId: input.threadId, resumeCursor };
       });

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -375,7 +375,8 @@ interface ClaudeSessionContext {
   // the meter without resetting the cumulative processed estimate.
   processedTokenTotal: number;
   processedTokenTurnBaseline: number;
-  // Native results delimit SDK turns, even when a UI turn closes early.
+  // Native results normally delimit SDK turns. A synthetic UI turn can close
+  // before its result, so every logical completion must advance this baseline.
   processedTokenResultBaseline: number;
   processedTokenBaselineKnown: boolean;
   readonly requestUsage: ClaudeRequestUsage;
@@ -2890,10 +2891,12 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           context.processedTokenTotal -
             (result ? context.processedTokenResultBaseline : context.processedTokenTurnBaseline),
         );
-        if (result) {
-          context.processedTokenResultBaseline = context.processedTokenTotal;
-          context.requestUsage.settleTurn();
-        }
+        // A synthetic/background UI turn may be auto-closed before the SDK emits
+        // a result. Its per-request usage is still final for this logical turn;
+        // carry it into the next result baseline and quarantine late snapshots so
+        // a later result cannot replace the cumulative total below these tokens.
+        context.processedTokenResultBaseline = context.processedTokenTotal;
+        context.requestUsage.settleTurn();
 
         // A safeguard reroute only applies to the turn that just finished.
         // Restore the user-selected model so subsequent turns do not silently

--- a/apps/server/src/provider/claudeRequestUsage.ts
+++ b/apps/server/src/provider/claudeRequestUsage.ts
@@ -1,0 +1,26 @@
+// Counts request snapshots within a Claude turn, including later output updates.
+// Retains the last nonempty SDK turn to ignore its already-settled tail.
+export class ClaudeRequestUsage {
+  private requests = new Map<string, number>();
+  private previousRequests = new Map<string, number>();
+
+  settleTurn(): void {
+    if (this.requests.size === 0) return;
+    this.previousRequests = this.requests;
+    this.requests = new Map();
+  }
+
+  // Block UUIDs identify delivery, whereas message.id identifies the API response.
+  add(messageId: string, tokens: number): number {
+    if (this.previousRequests.has(messageId)) return 0;
+    const previous = this.requests.get(messageId) ?? 0;
+    if (tokens <= previous) return 0;
+    this.requests.set(messageId, tokens);
+    return tokens - previous;
+  }
+
+  reset(): void {
+    this.requests.clear();
+    this.previousRequests.clear();
+  }
+}

--- a/apps/server/src/provider/claudeResultUsage.test.ts
+++ b/apps/server/src/provider/claudeResultUsage.test.ts
@@ -7,6 +7,8 @@ function result(
   reads: number,
   writes: number,
   cost: number,
+  webSearchRequests = 0,
+  thinkingTokens = 0,
 ): ClaudeResultUsageBaseline {
   return {
     total_cost_usd: cost,
@@ -14,10 +16,11 @@ function result(
       sonnet: {
         inputTokens: input,
         outputTokens: output,
+        thinkingTokens,
         cacheReadInputTokens: reads,
         cacheCreationInputTokens: writes,
         costUSD: cost,
-        webSearchRequests: 0,
+        webSearchRequests,
         contextWindow: 200000,
         maxOutputTokens: 64000,
       },
@@ -27,14 +30,16 @@ function result(
 
 describe("Claude cumulative result accounting", () => {
   it("subtracts the preceding SDK result instead of charging prior turns again", () => {
-    const first = result(6, 211, 86202, 43334, 0.1926984);
-    const next = result(8, 239, 129623, 43334, 0.2018);
+    const first = result(6, 211, 86202, 43334, 0.1926984, 2, 100);
+    const next = result(8, 239, 129623, 43334, 0.2018, 5, 120);
     const usage = claudeTurnResultUsage(next, first);
     expect(usage.modelUsage.sonnet).toMatchObject({
       inputTokens: 2,
       outputTokens: 28,
+      thinkingTokens: 20,
       cacheReadInputTokens: 43421,
       cacheCreationInputTokens: 0,
+      webSearchRequests: 3,
       contextWindow: 200000,
     });
     expect(usage.totalCostUsd).toBeCloseTo(0.0091016);

--- a/apps/server/src/provider/claudeResultUsage.ts
+++ b/apps/server/src/provider/claudeResultUsage.ts
@@ -20,11 +20,15 @@ export function claudeTurnResultUsage(
           ...current,
           inputTokens: delta(current.inputTokens, before?.inputTokens),
           outputTokens: delta(current.outputTokens, before?.outputTokens),
+          ...(current.thinkingTokens !== undefined
+            ? { thinkingTokens: delta(current.thinkingTokens, before?.thinkingTokens) }
+            : {}),
           cacheReadInputTokens: delta(current.cacheReadInputTokens, before?.cacheReadInputTokens),
           cacheCreationInputTokens: delta(
             current.cacheCreationInputTokens,
             before?.cacheCreationInputTokens,
           ),
+          webSearchRequests: delta(current.webSearchRequests, before?.webSearchRequests),
           costUSD: delta(current.costUSD, before?.costUSD),
         },
       ];

--- a/apps/web/src/components/chat/ContextWindowMeter.tsx
+++ b/apps/web/src/components/chat/ContextWindowMeter.tsx
@@ -100,8 +100,8 @@ export function ContextWindowMeter(props: {
           {(usage.totalProcessedTokens ?? null) !== null &&
           (usage.totalProcessedTokens ?? 0) > usage.usedTokens ? (
             <div className="text-xs text-muted-foreground">
-              Total processed: {formatContextWindowTokens(usage.totalProcessedTokens ?? null)}{" "}
-              tokens
+              {usage.tokenAccountingVersion === 1 ? "Estimated total processed" : "Total processed"}
+              : {formatContextWindowTokens(usage.totalProcessedTokens ?? null)} tokens
             </div>
           ) : null}
           {usage.compactsAutomatically ? (

--- a/apps/web/src/components/settings/ProfileSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProfileSettingsPanel.tsx
@@ -139,6 +139,13 @@ function ProfileContent({
       </div>
 
       {/* Heatmap */}
+      {stats.providerModels.some((entry) => entry.provider === "claudeAgent") ||
+      tokenStats?.providers.includes("claudeAgent") ? (
+        <p className="text-xs text-muted-foreground">
+          Claude token totals use verifiable records. Older history and unfinished turns may be
+          incomplete.
+        </p>
+      ) : null}
       <section className="flex min-w-0 flex-col gap-3">
         <h3 className="text-sm font-medium">Activity</h3>
         {tokensPending ? (

--- a/apps/web/src/lib/contextWindow.test.ts
+++ b/apps/web/src/lib/contextWindow.test.ts
@@ -29,6 +29,24 @@ function makeActivity(
 }
 
 describe("contextWindow", () => {
+  it("withholds old Claude processed totals while preserving context and other providers", () => {
+    for (const provider of ["claudeAgent", "codex"]) {
+      const payload = { provider, usedTokens: 100, totalProcessedTokens: 400 };
+      const legacy = deriveLatestContextWindowState([
+        makeActivity("legacy", "context-window.updated", payload),
+      ]).snapshot;
+      expect(legacy?.usedTokens).toBe(100);
+      expect(legacy?.totalProcessedTokens).toBe(provider === "claudeAgent" ? null : 400);
+      const corrected = deriveLatestContextWindowState([
+        makeActivity("corrected", "context-window.updated", {
+          ...payload,
+          tokenAccountingVersion: 1,
+        }),
+      ]).snapshot;
+      expect(corrected?.totalProcessedTokens).toBe(400);
+    }
+  });
+
   it("derives the latest valid context window snapshot", () => {
     const snapshot = deriveLatestContextWindowState([
       makeActivity("activity-1", "context-window.updated", {

--- a/apps/web/src/lib/contextWindow.ts
+++ b/apps/web/src/lib/contextWindow.ts
@@ -107,7 +107,13 @@ function deriveLatestUsageContextWindowState(
       snapshot: {
         usedTokens,
         usedPercent: payloadUsedPercent,
-        totalProcessedTokens: asFiniteNumber(payload?.totalProcessedTokens),
+        // Older Claude totals counted completed content blocks repeatedly.
+        // Keep the context meter, but withhold an unverifiable lifetime counter.
+        totalProcessedTokens:
+          payload?.provider === "claudeAgent" && payload.tokenAccountingVersion !== 1
+            ? null
+            : asFiniteNumber(payload?.totalProcessedTokens),
+        tokenAccountingVersion: payload?.tokenAccountingVersion === 1 ? 1 : null,
         maxTokens,
         remainingTokens,
         usedPercentage,
@@ -187,6 +193,7 @@ export function deriveLatestContextWindowState(
       usedTokens,
       usedPercent: usageSnapshot?.usedPercent ?? null,
       totalProcessedTokens: usageSnapshot?.totalProcessedTokens ?? null,
+      tokenAccountingVersion: usageSnapshot?.tokenAccountingVersion ?? null,
       maxTokens,
       remainingTokens,
       usedPercentage,

--- a/docs/claude-token-accounting.md
+++ b/docs/claude-token-accounting.md
@@ -19,11 +19,19 @@ corrections; missing or zeroed error results retain the observed estimate.
 | SDK `result.modelUsage`               | Cumulative query-pipeline usage, including subagents and compaction |
 | Projected `turn.completed.modelUsage` | Difference from the preceding native result                         |
 
-Compact projected `inputTokens` already includes cache reads and writes.
-`thinkingTokens` is already included in output. Neither subset is added twice.
+The SDK's raw per-model shape has no `totalTokens`: its four disjoint counters
+are uncached `inputTokens`, `cacheReadInputTokens`,
+`cacheCreationInputTokens`, and `outputTokens`. `thinkingTokens` is already
+included in output. The compact projected shape adds those counters once,
+stores that value as `totalTokens`, and folds both cache counters into its
+`inputTokens`. Profile Stats accepts both shapes: an explicit positive total is
+authoritative for compact rows; otherwise it sums the four raw SDK counters.
+This prevents cache and thinking tokens from being added twice.
+
 Profile Stats uses versioned completed model totals, counts mirrored children
-only through the parent, and attributes usage to the completion date. Interrupted
-turns without a usable model breakdown fall back to observed main-loop usage.
+only through the parent, and attributes usage to the completion date. Completed
+turns without any usable positive model row fall back to verified main-loop
+usage, including when a malformed nonempty breakdown is present.
 
 ## Historical limits
 
@@ -45,6 +53,13 @@ against a matching database/WAL backup, bind requests to native sessions and
 turns, deduplicate copied requests across files, and distinguish process resets
 from continuation. It must store provenance and uncovered ranges separately;
 neither dividing old counters by two nor summing old modelUsage is a repair.
+
+## Migration lineage
+
+Migration 101 removes transcript markers, migration 102 adds persisted message
+turn boundaries, and Claude accounting follows them at migration 103. Keep the
+numeric `migrationEntries` values literal because the lineage checker parses
+that source.
 
 ## Input and cache behavior
 

--- a/docs/claude-token-accounting.md
+++ b/docs/claude-token-accounting.md
@@ -1,0 +1,72 @@
+# Claude token accounting
+
+The Agent SDK emits completed content blocks separately. Several `assistant`
+events can share `message.id` and repeat provisional usage. Count each response
+once and add only increases from later snapshots. A block's UUID is a delivery
+identity, not an API response identity.
+
+Synara keeps request accounting on each native query context. The current and
+previous SDK turn are retained; native results advance that boundary. Closing a
+UI turn early does not reset native accounting. Subagent contexts own independent
+counters. Successful results reconcile main-loop usage, including downward
+corrections; missing or zeroed error results retain the observed estimate.
+
+| Value                                 | Scope                                                               |
+| ------------------------------------- | ------------------------------------------------------------------- |
+| Context `usedTokens`                  | Latest request or local context summary                             |
+| Context `totalProcessedTokens`        | Main conversation's accumulated estimate                            |
+| SDK `result.usage`                    | This SDK turn's main loop                                           |
+| SDK `result.modelUsage`               | Cumulative query-pipeline usage, including subagents and compaction |
+| Projected `turn.completed.modelUsage` | Difference from the preceding native result                         |
+
+Compact projected `inputTokens` already includes cache reads and writes.
+`thinkingTokens` is already included in output. Neither subset is added twice.
+Profile Stats uses versioned completed model totals, counts mirrored children
+only through the parent, and attributes usage to the completion date. Interrupted
+turns without a usable model breakdown fall back to observed main-loop usage.
+
+## Historical limits
+
+`tokenAccountingVersion: 1` identifies corrected accounting and trusted resume
+counters. Unversioned Claude processed totals are hidden; they are not reused
+as a resume baseline. Other providers retain their existing accounting.
+
+Older compact model totals can be either per-turn or process-cumulative. Dates
+cannot distinguish them. Migration 103 preserves retained raw main-loop results
+in `profile_stats_claude_legacy_usage` before runtime retention removes that
+evidence. It does not rewrite the event journal, old counters, or compact model
+usage. This recovery is partial: missing results, subagent pipeline usage, and
+already-purged legacy aggregates cannot be reconstructed from those records.
+Profile Stats excludes unverifiable totals and explains that history can be
+incomplete. Verified deletion snapshots retain their accounting version.
+
+A future opt-in native-transcript import must first produce a dry-run report
+against a matching database/WAL backup, bind requests to native sessions and
+turns, deduplicate copied requests across files, and distinguish process resets
+from continuation. It must store provenance and uncovered ranges separately;
+neither dividing old counters by two nor summing old modelUsage is a repair.
+
+## Input and cache behavior
+
+Claude obtains automation authoring guidance from the create/update tool
+descriptions. Removing the identical system-prompt copy saves 381 characters
+from the appended host prompt (6,856 to 6,475). This is a text-size measurement,
+not a measured token-price or subscription saving. Tool routing, authorization,
+automation run instructions, and other providers' prompts are preserved.
+
+Native caching, TTL, query reuse, effort selection, idle reaping, and
+`excludeDynamicSections: true` are unchanged. Context polling remains local
+`getContextUsage({ detail: "summary" })`. SDK 0.3.259's snapshot documentation
+conflicts with CLI 2.1.267's initialize schema: that CLI records appended prompts
+by default where recording is enabled. No snapshot override is added. Existing
+native prompt snapshots keep their normal refresh lifecycle.
+
+References: [SDK types](https://platform.claude.com/docs/en/agent-sdk/typescript),
+[cost tracking](https://platform.claude.com/docs/en/agent-sdk/cost-tracking),
+[prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching),
+[native cost and cache diagnostics](https://code.claude.com/docs/en/costs).
+
+Validation lives in the existing ClaudeAdapter fake-SDK suite, token/result
+normalization tests, runtime projection/schema tests, Profile Stats and archive
+tests, migration 103's upgrade test, context-window tests, and harness/tool
+description tests. These need no Claude inference or live account data.

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -331,6 +331,8 @@ export const ThreadTokenUsageSnapshot = Schema.Struct({
     Schema.Number.check(Schema.isGreaterThanOrEqualTo(0)).check(Schema.isLessThanOrEqualTo(100)),
   ),
   totalProcessedTokens: Schema.optional(NonNegativeInt),
+  // Claude v1 counts API responses once; unversioned Claude totals are unreliable.
+  tokenAccountingVersion: Schema.optional(Schema.Literal(1)),
   maxTokens: Schema.optional(PositiveInt),
   inputTokens: Schema.optional(NonNegativeInt),
   cachedInputTokens: Schema.optional(NonNegativeInt),
@@ -388,6 +390,9 @@ const TurnCompletedPayload = Schema.Struct({
   stopReason: Schema.optional(Schema.NullOr(TrimmedNonEmptyStringSchema)),
   usage: Schema.optional(Schema.Unknown),
   modelUsage: Schema.optional(UnknownRecordSchema),
+  tokenAccountingVersion: Schema.optional(Schema.Literal(1)),
+  // Per-turn main-loop usage, including observed usage when no result arrives.
+  mainLoopTokens: Schema.optional(NonNegativeInt),
   totalCostUsd: Schema.optional(Schema.Number),
   cumulativeCostUsd: Schema.optional(Schema.Number),
   errorMessage: Schema.optional(TrimmedNonEmptyStringSchema),


### PR DESCRIPTION
## What Changed

Fix Claude token accounting across live context totals, completed-turn statistics, resume cursors, and deletion archives. Multiple completed content blocks from one API response now contribute only increases in that response's usage. Successful SDK results reconcile the final main-loop total, including downward corrections; incomplete error results retain observed usage.

Profile Stats now uses versioned, per-turn model totals and counts mirrored subagents only through their parent. Migration 101 preserves retained raw main-loop results as a partial historical fallback without rewriting the event journal. Unverifiable older Claude totals are excluded and cannot seed resumed counters; other providers retain their current accounting.

Remove the duplicated automation-authoring paragraph from Claude's appended system prompt. The same guidance remains on the create/update tool descriptions. The append shrinks from 6,856 to 6,475 characters (381 characters, 5.6%); this is not a measured token-price or subscription saving. Native cache settings, prompt snapshots, effort selection, idle reaping, and quota telemetry are unchanged.

## Why

Agent SDK 0.3.259 emits one assistant event per completed content block. Events can share a response ID and repeat provisional input/cache/output usage. The adapter previously added each whole snapshot, then used a terminal maximum that could never correct an inflated total. In the fake-SDK regression, two blocks from a single 27,326-token request previously became 54,652 tokens even after the correct final result.

Accounting is bounded to the current and previous nonempty SDK turn, independently of UI turn closure. Coverage includes increasing provisional output, duplicate delivery/results, distinct calls, terminal reconciliation, interruption, compaction, reset, resume, and subagent routing. The existing process-cumulative modelUsage/cost differencing from #1024 is preserved; cache subsets and thinking tokens are not added twice.

Historical recovery is intentionally partial: old compact modelUsage can be either per-turn or process-cumulative, and its date does not identify which. Only retained raw per-turn evidence is recovered. Missing results, older purged aggregates, and unretained subagent usage cannot be reconstructed. The documentation describes the requirements for a future opt-in native-transcript import.

## UI Changes

The Claude context tooltip labels corrected totals as estimates and hides unverifiable legacy lifetime totals. Profile Stats explains that older history and unfinished turns may be incomplete. No layout or animation changes. Screenshot and live GUI verification remain pending.

## Verification

- `bun fmt` passed across the workspace.
- `bun lint` passed with 0 errors and 557 warnings.
- `bun typecheck` passed: 7/7 workspace tasks, none cached.
- `bun run migrations:check` passed against migration identities from 87 release tags.
- `git diff --check` passed.
- 307 focused Vitest tests passed across 12 files using `bun run test`: Claude adapter/token/result accounting, Profile Stats/archive, migration 101, runtime projection/contracts, context-window handling, harness/tool descriptions, and Claude quota mapping. The final request-map cleanup was additionally checked against the four affected adapter regressions.
- Production migration and Profile Stats queries were exercised against isolated copies of the supplied matching database/WAL snapshots; integrity checks passed and journal/runtime rows remained unchanged. Recovery was checked for idempotence and survival after runtime retention. No live account database was modified and no paid Claude inference was used.

Full test-suite, build, live GUI, and GitHub CI results are not claimed by these local checks.

## Checklist

- [x] Changes are scoped to Claude accounting and removal of duplicated Claude prompt guidance.
- [x] Explained behavior, root cause, historical limits, and validation.
- [ ] Before/after screenshots for the tooltip and Profile Stats copy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Claude adapter accounting, profile-stats SQL/migrations, and deletion snapshots; behavior is heavily tested but historical Claude totals remain intentionally incomplete.
> 
> **Overview**
> This PR **fixes inflated Claude usage** by counting each API response once (deduping repeated assistant blocks), reconciling totals on successful SDK results, and emitting **`tokenAccountingVersion: 1`** with **`mainLoopTokens`** on completed turns and token-usage events. Resume cursors only trust versioned processed totals; the UI hides unverifiable legacy Claude lifetime counters and labels corrected ones as estimates.
> 
> **Profile Stats and thread purge archives** switch Claude to versioned `turn.completed` model usage (with legacy main-loop recovery via migration **103**), exclude provisional Claude context-window rows from mixed-provider delta math, and stamp verified deletion snapshots with `token_accounting_version`.
> 
> For embedded Claude sessions, the harness policy can **omit duplicated automation-authoring text** from the appended system prompt when `automationAuthoring: "tool-descriptions"` is set, since the same guidance remains on create/update tool schemas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4a553f95567eb1f79b438cdea6e9aa919446033. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->