### PR TITLE
fix(pi): queue mid-turn sends as follow-ups instead of erroring

### DIFF
--- a/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
@@ -605,6 +605,85 @@ it("serializes a concurrent send dispatching behind a committing prompt", async 
   });
 });
 
+it("does not strand a concurrent send when the committing prompt is an extension command", async () => {
+  let markCommandStarted!: () => void;
+  const commandStarted = new Promise<void>((resolve) => {
+    markCommandStarted = resolve;
+  });
+  let releaseCommand!: () => void;
+  const commandGate = new Promise<void>((resolve) => {
+    releaseCommand = resolve;
+  });
+  captured.extensions.push((pi) => {
+    pi.registerCommand("pause", {
+      description: "Pause without inference",
+      handler: async () => {
+        markCommandStarted();
+        await commandGate;
+      },
+    });
+  });
+  const calls = responses("success", "success");
+  await withAdapter(async (adapter, events) => {
+    await send(adapter);
+    await waitFor(() => expect(completions(events)).toHaveLength(1));
+    const command = Effect.runPromise(adapter.sendTurn({ threadId, input: "/pause" }));
+    await commandStarted;
+    const prompt = Effect.runPromise(
+      adapter.sendTurn({ threadId, input: "Run after the command" }),
+    );
+    releaseCommand();
+    const [commandTurn, promptTurn] = await Promise.all([command, prompt]);
+    expect(promptTurn.turnId).not.toBe(commandTurn.turnId);
+    await waitFor(() => expect(completions(events)).toHaveLength(3));
+    expect(calls()).toBe(2);
+    expect(captured.sessions[0]!.pendingMessageCount).toBe(0);
+    expect(
+      captured.sessions[0]!.messages.some(
+        (message) =>
+          message.role === "user" &&
+          JSON.stringify(message.content).includes("Run after the command"),
+      ),
+    ).toBe(true);
+  });
+});
+
+it("starts a concurrent send cleanly after the committing prompt rejects preflight", async () => {
+  responses("success");
+  await withAdapter(async (adapter, events) => {
+    const session = captured.sessions[0]!;
+    const realPrompt = session.prompt.bind(session);
+    let rejectPrompt!: (cause: Error) => void;
+    vi.spyOn(session, "prompt")
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectPrompt = reject;
+          }),
+      )
+      .mockImplementation(realPrompt);
+    const first = await Effect.runPromise(
+      adapter.sendTurn({ threadId, input: "Rejected in preflight" }),
+    );
+    const secondPromise = Effect.runPromise(
+      adapter.sendTurn({ threadId, input: "Run after rejection" }),
+    );
+    rejectPrompt(new Error("preflight rejected"));
+    const second = await secondPromise;
+    expect(second.turnId).not.toBe(first.turnId);
+    await waitFor(() => expect(completions(events)).toHaveLength(2));
+    expect(completions(events)[0]).toMatchObject({
+      turnId: first.turnId,
+      payload: { state: "failed", errorMessage: "preflight rejected" },
+    });
+    expect(completions(events)[1]).toMatchObject({
+      turnId: second.turnId,
+      payload: { state: "completed" },
+    });
+    expect(session.pendingMessageCount).toBe(0);
+  });
+});
+
 it("aborts a turn interrupted while its prompt is still committing", async () => {
   responses("until-abort");
   await withAdapter(async (adapter, events) => {
@@ -667,33 +746,28 @@ it("rejects a send to a turn whose interrupt is pending while still committing",
   });
 });
 
-it("starts a new turn instead of steering into an untracked draining run", async () => {
-  responses("success", "success");
+it("rejects steering into an untracked SDK run instead of orphaning a queued turn", async () => {
+  responses("success");
   await withAdapter(async (adapter, events) => {
-    const turn = await send(adapter);
-    await waitFor(() => expect(completions(events)).toHaveLength(1));
     const session = captured.sessions[0]!;
-    // Simulate the drain tail: the turn is complete but the SDK still reports
-    // streaming (queued continuations draining after prompt() resolved).
     const streamingSpy = vi.spyOn(session, "isStreaming", "get").mockReturnValue(true);
     const steerSpy = vi.spyOn(session, "steer").mockResolvedValue(undefined);
-    const realPrompt = session.prompt.bind(session);
-    const promptSpy = vi.spyOn(session, "prompt").mockImplementation(async (text, options) => {
-      // prompt() must see the real flag — only the adapter's check is mocked.
-      streamingSpy.mockRestore();
-      return realPrompt(text, options);
-    });
-    const second = await Effect.runPromise(
-      adapter.steerTurn!({ threadId, input: "Fresh turn during drain tail" }),
+    const promptSpy = vi.spyOn(session, "prompt");
+    const outcome = await Effect.runPromise(
+      adapter.steerTurn!({ threadId, input: "Fresh turn during untracked run" }).pipe(
+        Effect.match({ onFailure: (error) => error, onSuccess: () => null }),
+      ),
     );
-    expect(second.turnId).not.toBe(turn.turnId);
-    expect(steerSpy).not.toHaveBeenCalled();
-    expect(promptSpy).toHaveBeenCalledTimes(1);
-    await waitFor(() => expect(completions(events)).toHaveLength(2));
-    expect(completions(events)[1]).toMatchObject({
-      turnId: second.turnId,
-      payload: { state: "completed" },
+    expect(outcome).toMatchObject({
+      _tag: "ProviderAdapterValidationError",
+      operation: "steerTurn",
     });
+    expect(steerSpy).not.toHaveBeenCalled();
+    expect(promptSpy).not.toHaveBeenCalled();
+    expect(session.pendingMessageCount).toBe(0);
+    expect(completions(events)).toHaveLength(0);
+    expect((await Effect.runPromise(adapter.listSessions()))[0]?.activeTurnId).toBeUndefined();
+    streamingSpy.mockRestore();
   });
 });
 
@@ -954,6 +1028,17 @@ it("cancels retry and queued steering before awaiting gateway teardown drainage"
       const stopped = Effect.runPromise(adapter.stopSession(threadId));
       try {
         await waitFor(() => expect(credentials.cancelSessionTurnRequests).toHaveBeenCalled());
+        const sendDuringStop = Effect.runPromise(
+          adapter
+            .sendTurn({ threadId, input: "Must not restart during teardown" })
+            .pipe(Effect.match({ onFailure: (error) => error, onSuccess: () => null })),
+        );
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        drain();
+        await stopped;
+        expect(await sendDuringStop).toMatchObject({
+          _tag: "ProviderAdapterSessionNotFoundError",
+        });
         await waitFor(() => expect(session.isIdle).toBe(true));
         expect(calls()).toBe(1);
         expect(session.pendingMessageCount).toBe(0);

--- a/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
@@ -605,6 +605,35 @@ it("serializes a concurrent send dispatching behind a committing prompt", async 
   });
 });
 
+it("aborts a turn interrupted while its prompt is still committing", async () => {
+  responses("until-abort");
+  await withAdapter(async (adapter, events) => {
+    const session = captured.sessions[0]!;
+    const realPrompt = session.prompt.bind(session);
+    let releasePrompt!: () => void;
+    const promptGate = new Promise<void>((resolve) => {
+      releasePrompt = resolve;
+    });
+    const spy = vi.spyOn(session, "prompt").mockImplementation(async (text, options) => {
+      await promptGate;
+      return realPrompt(text, options);
+    });
+    const turn = await send(adapter);
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    // prompt() is gated in preflight — nothing exists for abort() to reach.
+    expect(session.isStreaming).toBe(false);
+    await Effect.runPromise(adapter.interruptTurn(threadId, turn.turnId));
+    releasePrompt();
+    await waitFor(() => expect(completions(events)).toHaveLength(1));
+    expect(completions(events)[0]).toMatchObject({
+      turnId: turn.turnId,
+      payload: { state: "interrupted" },
+    });
+    spy.mockRestore();
+    await expectNextTurn(adapter, events, turn.turnId);
+  });
+});
+
 it("keeps the turn alive through SDK overflow compaction and its continuation", async () => {
   const calls = responses("success", "overflow", "success", "success");
   await withAdapter(async (adapter, events) => {

--- a/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
@@ -634,6 +634,39 @@ it("aborts a turn interrupted while its prompt is still committing", async () =>
   });
 });
 
+it("rejects a send to a turn whose interrupt is pending while still committing", async () => {
+  responses("until-abort");
+  await withAdapter(async (adapter, events) => {
+    const session = captured.sessions[0]!;
+    const realPrompt = session.prompt.bind(session);
+    let releasePrompt!: () => void;
+    const promptGate = new Promise<void>((resolve) => {
+      releasePrompt = resolve;
+    });
+    const spy = vi.spyOn(session, "prompt").mockImplementation(async (text, options) => {
+      await promptGate;
+      return realPrompt(text, options);
+    });
+    const turn = await send(adapter);
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    await Effect.runPromise(adapter.interruptTurn(threadId, turn.turnId));
+    const outcome = await Effect.runPromise(
+      adapter
+        .sendTurn({ threadId, input: "Would be dropped" })
+        .pipe(Effect.match({ onFailure: (error) => error, onSuccess: () => null })),
+    );
+    expect(outcome).toMatchObject({
+      _tag: "ProviderAdapterValidationError",
+      operation: "sendTurn",
+    });
+    releasePrompt();
+    await waitFor(() => expect(completions(events)).toHaveLength(1));
+    expect(completions(events)[0]).toMatchObject({ payload: { state: "interrupted" } });
+    spy.mockRestore();
+    await expectNextTurn(adapter, events, turn.turnId);
+  });
+});
+
 it("keeps the turn alive through SDK overflow compaction and its continuation", async () => {
   const calls = responses("success", "overflow", "success", "success");
   await withAdapter(async (adapter, events) => {

--- a/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
@@ -554,6 +554,57 @@ it("keeps steering during backoff inside the same logical turn", async () => {
   });
 });
 
+it("queues a send during an active turn as an SDK follow-up instead of erroring", async () => {
+  const calls = responses("error", "success", "success");
+  await withAdapter(async (adapter, events) => {
+    const turn = await send(adapter);
+    const session = captured.sessions[0]!;
+    await waitFor(() => expect(session.isRetrying).toBe(true));
+    const queued = await Effect.runPromise(
+      adapter.sendTurn({ threadId, input: "Queued while running" }),
+    );
+    expect(queued.turnId).toBe(turn.turnId);
+    expect(
+      session.getFollowUpMessages().some((text) => text.includes("Queued while running")),
+    ).toBe(true);
+    await waitFor(() => expect(completions(events)).toHaveLength(1));
+    expect(completions(events)[0]).toMatchObject({
+      turnId: turn.turnId,
+      payload: { state: "completed" },
+    });
+    expect(calls()).toBe(3);
+    expect(
+      session.messages.some(
+        (message) =>
+          message.role === "user" &&
+          JSON.stringify(message.content).includes("Queued while running"),
+      ),
+    ).toBe(true);
+    expect(events.filter((event) => event.type === "runtime.error")).toHaveLength(0);
+    await expectNextTurn(adapter, events, turn.turnId);
+  });
+});
+
+it("serializes a concurrent send dispatching behind a committing prompt", async () => {
+  responses("until-abort");
+  await withAdapter(async (adapter, events) => {
+    const first = Effect.runPromise(adapter.sendTurn({ threadId, input: "First prompt" }));
+    const second = Effect.runPromise(
+      adapter.sendTurn({ threadId, input: "Second while first commits" }),
+    );
+    const session = captured.sessions[0]!;
+    const [firstTurn, secondTurn] = await Promise.all([first, second]);
+    expect(secondTurn.turnId).toBe(firstTurn.turnId);
+    await waitFor(() => expect(session.isStreaming).toBe(true));
+    expect(
+      session.getFollowUpMessages().some((text) => text.includes("Second while first commits")),
+    ).toBe(true);
+    await Effect.runPromise(adapter.interruptTurn(threadId, firstTurn.turnId));
+    await waitFor(() => expect(completions(events)).toHaveLength(1));
+    expect(events.filter((event) => event.type === "runtime.error")).toHaveLength(0);
+  });
+});
+
 it("keeps the turn alive through SDK overflow compaction and its continuation", async () => {
   const calls = responses("success", "overflow", "success", "success");
   await withAdapter(async (adapter, events) => {

--- a/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.lifecycle.test.ts
@@ -667,6 +667,36 @@ it("rejects a send to a turn whose interrupt is pending while still committing",
   });
 });
 
+it("starts a new turn instead of steering into an untracked draining run", async () => {
+  responses("success", "success");
+  await withAdapter(async (adapter, events) => {
+    const turn = await send(adapter);
+    await waitFor(() => expect(completions(events)).toHaveLength(1));
+    const session = captured.sessions[0]!;
+    // Simulate the drain tail: the turn is complete but the SDK still reports
+    // streaming (queued continuations draining after prompt() resolved).
+    const streamingSpy = vi.spyOn(session, "isStreaming", "get").mockReturnValue(true);
+    const steerSpy = vi.spyOn(session, "steer").mockResolvedValue(undefined);
+    const realPrompt = session.prompt.bind(session);
+    const promptSpy = vi.spyOn(session, "prompt").mockImplementation(async (text, options) => {
+      // prompt() must see the real flag — only the adapter's check is mocked.
+      streamingSpy.mockRestore();
+      return realPrompt(text, options);
+    });
+    const second = await Effect.runPromise(
+      adapter.steerTurn!({ threadId, input: "Fresh turn during drain tail" }),
+    );
+    expect(second.turnId).not.toBe(turn.turnId);
+    expect(steerSpy).not.toHaveBeenCalled();
+    expect(promptSpy).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(completions(events)).toHaveLength(2));
+    expect(completions(events)[1]).toMatchObject({
+      turnId: second.turnId,
+      payload: { state: "completed" },
+    });
+  });
+});
+
 it("keeps the turn alive through SDK overflow compaction and its continuation", async () => {
   const calls = responses("success", "overflow", "success", "success");
   await withAdapter(async (adapter, events) => {

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -369,6 +369,10 @@ interface PiSessionContext {
   // preflight, so a concurrent send must treat this as still-live rather than
   // settled.
   promptCommitting: TurnId | undefined;
+  // Set when an interrupt lands while the turn's prompt() is still in async
+  // preflight — nothing exists for abort() to reach yet. Fired on the next
+  // agent_start once the run commits; cleared when the turn completes.
+  pendingAbortTurnId: TurnId | undefined;
   activeTurnErrorMessage?: string;
   activeAssistantItemId: RuntimeItemId | undefined;
   activeReasoningItemId: RuntimeItemId | undefined;
@@ -1731,6 +1735,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       cause?: unknown,
     ) => {
       if (context.stopped || context.activeTurnId !== turnId) return;
+      if (context.pendingAbortTurnId === turnId) context.pendingAbortTurnId = undefined;
       const raw = {
         source: "pi.sdk.event" as const,
         method: "prompt",
@@ -2059,6 +2064,23 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       return context.runtime.session.abort();
     };
 
+    // prompt()'s async preflight leaves no run for abort() to reach — an
+    // interrupt in that window would no-op and the turn would start anyway.
+    // Defer it: agent_start fires the abort once the run actually commits.
+    const interruptActiveTurn = (context: PiSessionContext) => {
+      const turnId = context.activeTurnId;
+      if (
+        turnId !== undefined &&
+        context.promptCommitting === turnId &&
+        !context.runtime.session.isStreaming
+      ) {
+        context.pendingAbortTurnId = turnId;
+        context.runtime.session.clearQueue();
+        return Promise.resolve();
+      }
+      return abortSessionTurn(context);
+    };
+
     const disposeSessionContext = async (context: PiSessionContext) => {
       try {
         // Stop retry and queued continuation before waiting for gateway drainage.
@@ -2164,6 +2186,21 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
     const handleSessionEvent = (context: PiSessionContext, event: AgentSessionEvent) => {
       switch (event.type) {
         case "agent_start":
+          if (
+            context.pendingAbortTurnId !== undefined &&
+            context.pendingAbortTurnId === context.activeTurnId
+          ) {
+            // The committing prompt just started its run — land the interrupt
+            // that was deferred because abort() had nothing to reach yet.
+            context.pendingAbortTurnId = undefined;
+            void abortSessionTurn(context).catch((cause) => {
+              offerRuntimeError(context, {
+                message: toMessage(cause, "Failed to interrupt Pi turn."),
+                method: "turn/interrupt",
+                cause,
+              });
+            });
+          }
           offerRuntimeEvent({
             ...makeEventBase(context),
             type: "thread.state.changed",
@@ -2588,6 +2625,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           turns: [],
           activeTurnId: undefined,
           promptCommitting: undefined,
+          pendingAbortTurnId: undefined,
           activeAssistantItemId: undefined,
           activeReasoningItemId: undefined,
           activeToolItems: new Map(),
@@ -2605,7 +2643,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             runtime.session.bindExtensions({
               uiContext: makePiExtensionUIContext(context),
               abortHandler: () => {
-                void abortSessionTurn(context).catch((cause) => {
+                void interruptActiveTurn(context).catch((cause) => {
                   offerRuntimeError(context, {
                     message: toMessage(cause, "Failed to interrupt Pi turn."),
                     method: "turn/interrupt",
@@ -2819,7 +2857,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           context.gatewaySessionLease,
           activeTurnId,
           Effect.tryPromise({
-            try: () => abortSessionTurn(context),
+            try: () => interruptActiveTurn(context),
             catch: (cause) =>
               new ProviderAdapterRequestError({
                 provider: PROVIDER,

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -2846,17 +2846,21 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             });
           }
           const providerText = buildProviderText(context, payload.text);
-          const turnId = context.activeTurnId ?? TurnId.makeUnsafe(crypto.randomUUID());
-          if (!context.activeTurnId) {
+          const joinedTurnId = context.activeTurnId;
+          const turnId = joinedTurnId ?? TurnId.makeUnsafe(crypto.randomUUID());
+          if (joinedTurnId === undefined) {
             context.activeTurnId = turnId;
             context.turns.push({ id: turnId, items: [], toolItemIndexes: new Map() });
           }
           if (
-            context.runtime.session.isStreaming ||
-            context.promptCommitting === context.activeTurnId
+            joinedTurnId !== undefined &&
+            (context.runtime.session.isStreaming || context.promptCommitting === joinedTurnId)
           ) {
             yield* steerPiTurn(context, providerText, payload.images);
           } else {
+            // Fresh turn while an untracked run drains: startPrompt's
+            // streamingBehavior:"followUp" queues it behind the run and its own
+            // prompt() promise completes this turn — steer() would orphan it.
             startPrompt(context, turnId, providerText, payload.images);
           }
           return dispatchResult(context, turnId);

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -1846,16 +1846,24 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       };
       // A prompt owns all SDK retries, compaction and queued continuations.
       // agent_end is per attempt; agent_settled also fires before a rejection.
-      void context.runtime.session.prompt(text, images.length > 0 ? { images } : undefined).then(
-        () => {
-          settled();
-          completePrompt(context, turnId, context.activeTurnErrorMessage);
-        },
-        (cause) => {
-          settled();
-          completePrompt(context, turnId, toMessage(cause, "Pi turn failed."), cause);
-        },
-      );
+      // streamingBehavior is the last-resort fallback: if the session started
+      // streaming between the dispatch check and prompt()'s own check, the
+      // message queues instead of throwing the raw SDK busy error.
+      void context.runtime.session
+        .prompt(text, {
+          streamingBehavior: "followUp",
+          ...(images.length > 0 ? { images } : {}),
+        })
+        .then(
+          () => {
+            settled();
+            completePrompt(context, turnId, context.activeTurnErrorMessage);
+          },
+          (cause) => {
+            settled();
+            completePrompt(context, turnId, toMessage(cause, "Pi turn failed."), cause);
+          },
+        );
     };
 
     // A turn whose run fully settled but whose completion is still queued on
@@ -1921,6 +1929,25 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
     // /reload only exists as a bare text command — attachments make it a prompt.
     const isPiReloadPayload = (payload: { text: string; images: ImageContent[] }) =>
       payload.images.length === 0 && isPiReloadCommand(payload.text);
+
+    const queuePiFollowUp = (
+      context: PiSessionContext,
+      payload: { text: string; images: ImageContent[] },
+    ) =>
+      Effect.tryPromise({
+        try: () =>
+          context.runtime.session.followUp(
+            buildProviderText(context, payload.text),
+            payload.images,
+          ),
+        catch: (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "turn/followUp",
+            detail: toMessage(cause, "Failed to queue Pi follow-up."),
+            cause,
+          }),
+      });
 
     const steerPiTurn = (context: PiSessionContext, text: string, images: ImageContent[]) =>
       Effect.tryPromise({
@@ -2723,7 +2750,19 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           }
           const payload = yield* buildPromptPayload(input);
           closeSettledActiveTurn(context);
-          if (context.activeTurnId !== undefined) {
+          const liveTurnId = context.activeTurnId;
+          if (liveTurnId !== undefined) {
+            // A turn is active: route the send through the SDK's follow-up
+            // queue instead of prompt(), which would throw the raw "Agent is
+            // already processing" error mid-run.
+            if (isPiReloadPayload(payload)) {
+              return yield* sendTurnBusyError();
+            }
+            yield* queuePiFollowUp(context, payload);
+            return dispatchResult(context, liveTurnId);
+          }
+          if (context.runtime.session.isStreaming) {
+            // A run Synara did not dispatch is active (e.g. extension-triggered).
             return yield* sendTurnBusyError();
           }
           const turnId = TurnId.makeUnsafe(crypto.randomUUID());

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -77,6 +77,7 @@ import {
 } from "../Services/ProviderAdapter.ts";
 import { appendFileAttachmentsPromptBlock } from "../attachmentProjection.ts";
 import { makeBoundedCallbackIngress } from "../boundedCallbackIngress.ts";
+import { makeKeyedLock } from "../keyedLock.ts";
 import { settleConcurrentTeardowns } from "../settleConcurrentTeardowns.ts";
 import { classifyPiTurnFailure } from "../piTurnFailure.ts";
 import { fetchOpenRouterModels, OPENROUTER_BASE_URL } from "../OpenRouterDiscovery.ts";
@@ -363,6 +364,11 @@ interface PiSessionContext {
   session: ProviderSession;
   turns: PiStoredTurn[];
   activeTurnId: TurnId | undefined;
+  // The turn whose prompt() has been dispatched but has not committed a run
+  // yet — the SDK's isStreaming flag only flips deep inside prompt()'s async
+  // preflight, so a concurrent send must treat this as still-live rather than
+  // settled.
+  promptCommitting: TurnId | undefined;
   activeTurnErrorMessage?: string;
   activeAssistantItemId: RuntimeItemId | undefined;
   activeReasoningItemId: RuntimeItemId | undefined;
@@ -1389,6 +1395,10 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       PROVIDER_ADAPTER_RUNTIME_EVENT_BUFFER_CAPACITY,
     );
     const sessions = new Map<ThreadId, PiSessionContext>();
+    // Serializes turn dispatch per thread: the activeTurnId/isStreaming check
+    // and the resulting prompt()/steer()/followUp() call stay atomic, so two
+    // overlapping sends cannot both read "idle" and race prompt()'s preflight.
+    const dispatchLock = makeKeyedLock<ThreadId>();
     const ownsNativeEventLogger = options?.nativeEventLogger === undefined;
     const nativeEventLogger =
       options?.nativeEventLogger ??
@@ -1827,12 +1837,41 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       images: ImageContent[],
     ) => {
       delete context.activeTurnErrorMessage;
+      // Marks the prompt as dispatched-but-not-yet-streaming: the SDK's
+      // isStreaming flag only flips deep inside prompt()'s async preflight, so
+      // a concurrent sendTurn/steerTurn must not read the gap as "settled".
+      context.promptCommitting = turnId;
+      const settled = () => {
+        if (context.promptCommitting === turnId) context.promptCommitting = undefined;
+      };
       // A prompt owns all SDK retries, compaction and queued continuations.
       // agent_end is per attempt; agent_settled also fires before a rejection.
       void context.runtime.session.prompt(text, images.length > 0 ? { images } : undefined).then(
-        () => completePrompt(context, turnId, context.activeTurnErrorMessage),
-        (cause) => completePrompt(context, turnId, toMessage(cause, "Pi turn failed."), cause),
+        () => {
+          settled();
+          completePrompt(context, turnId, context.activeTurnErrorMessage);
+        },
+        (cause) => {
+          settled();
+          completePrompt(context, turnId, toMessage(cause, "Pi turn failed."), cause);
+        },
       );
+    };
+
+    // A turn whose run fully settled but whose completion is still queued on
+    // the prompt() promise is stale — close it out so the next dispatch starts
+    // clean instead of joining a dead turn. A still-committing prompt
+    // (isStreaming has not flipped yet) is live, not stale.
+    const closeSettledActiveTurn = (context: PiSessionContext) => {
+      const turnId = context.activeTurnId;
+      if (
+        turnId === undefined ||
+        context.runtime.session.isStreaming ||
+        context.promptCommitting === turnId
+      ) {
+        return;
+      }
+      completePrompt(context, turnId, context.activeTurnErrorMessage);
     };
 
     const buildProviderText = (context: PiSessionContext, text: string) =>
@@ -2521,6 +2560,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           session,
           turns: [],
           activeTurnId: undefined,
+          promptCommitting: undefined,
           activeAssistantItemId: undefined,
           activeReasoningItemId: undefined,
           activeToolItems: new Map(),
@@ -2674,44 +2714,55 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       });
 
     const sendTurn: PiAdapterShape["sendTurn"] = (input) =>
-      Effect.gen(function* () {
-        const context = yield* requireSession(input.threadId);
-        if (context.activeTurnId) {
-          return yield* sendTurnBusyError();
-        }
-        if (input.modelSelection?.provider === "pi") {
-          yield* applyPiModelSelection(context, input.modelSelection);
-        }
-        const payload = yield* buildPromptPayload(input);
-        const turnId = TurnId.makeUnsafe(crypto.randomUUID());
-        context.activeTurnId = turnId;
-        context.turns.push({ id: turnId, items: [], toolItemIndexes: new Map() });
-        context.session = makeSessionSnapshot(context);
-        if (isPiReloadPayload(payload)) {
-          yield* runPiReload(context, payload.text);
-          return dispatchResult(context, turnId);
-        }
-        startPrompt(context, turnId, buildProviderText(context, payload.text), payload.images);
-        return dispatchResult(context, turnId);
-      });
-
-    const steerTurn: NonNullable<PiAdapterShape["steerTurn"]> = (input) =>
-      Effect.gen(function* () {
-        const context = yield* requireSession(input.threadId);
-        const payload = yield* buildPromptPayload(input);
-        const providerText = buildProviderText(context, payload.text);
-        const turnId = context.activeTurnId ?? TurnId.makeUnsafe(crypto.randomUUID());
-        if (!context.activeTurnId) {
+      dispatchLock.withLock(
+        input.threadId,
+        Effect.gen(function* () {
+          const context = yield* requireSession(input.threadId);
+          if (input.modelSelection?.provider === "pi") {
+            yield* applyPiModelSelection(context, input.modelSelection);
+          }
+          const payload = yield* buildPromptPayload(input);
+          closeSettledActiveTurn(context);
+          if (context.activeTurnId !== undefined) {
+            return yield* sendTurnBusyError();
+          }
+          const turnId = TurnId.makeUnsafe(crypto.randomUUID());
           context.activeTurnId = turnId;
           context.turns.push({ id: turnId, items: [], toolItemIndexes: new Map() });
-        }
-        if (context.runtime.session.isStreaming) {
-          yield* steerPiTurn(context, providerText, payload.images);
-        } else {
-          startPrompt(context, turnId, providerText, payload.images);
-        }
-        return dispatchResult(context, turnId);
-      });
+          context.session = makeSessionSnapshot(context);
+          if (isPiReloadPayload(payload)) {
+            yield* runPiReload(context, payload.text);
+            return dispatchResult(context, turnId);
+          }
+          startPrompt(context, turnId, buildProviderText(context, payload.text), payload.images);
+          return dispatchResult(context, turnId);
+        }),
+      );
+
+    const steerTurn: NonNullable<PiAdapterShape["steerTurn"]> = (input) =>
+      dispatchLock.withLock(
+        input.threadId,
+        Effect.gen(function* () {
+          const context = yield* requireSession(input.threadId);
+          const payload = yield* buildPromptPayload(input);
+          closeSettledActiveTurn(context);
+          const providerText = buildProviderText(context, payload.text);
+          const turnId = context.activeTurnId ?? TurnId.makeUnsafe(crypto.randomUUID());
+          if (!context.activeTurnId) {
+            context.activeTurnId = turnId;
+            context.turns.push({ id: turnId, items: [], toolItemIndexes: new Map() });
+          }
+          if (
+            context.runtime.session.isStreaming ||
+            context.promptCommitting === context.activeTurnId
+          ) {
+            yield* steerPiTurn(context, providerText, payload.images);
+          } else {
+            startPrompt(context, turnId, providerText, payload.images);
+          }
+          return dispatchResult(context, turnId);
+        }),
+      );
 
     const interruptTurn: PiAdapterShape["interruptTurn"] = (threadId, turnId) =>
       Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -369,6 +369,7 @@ interface PiSessionContext {
   // preflight, so a concurrent send must treat this as still-live rather than
   // settled.
   promptCommitting: TurnId | undefined;
+  promptCommit: Promise<void> | undefined;
   // Set when an interrupt lands while the turn's prompt() is still in async
   // preflight — nothing exists for abort() to reach yet. Fired on the next
   // agent_start once the run commits; cleared when the turn completes.
@@ -1399,9 +1400,9 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       PROVIDER_ADAPTER_RUNTIME_EVENT_BUFFER_CAPACITY,
     );
     const sessions = new Map<ThreadId, PiSessionContext>();
-    // Serializes turn dispatch per thread: the activeTurnId/isStreaming check
-    // and the resulting prompt()/steer()/followUp() call stay atomic, so two
-    // overlapping sends cannot both read "idle" and race prompt()'s preflight.
+    // Serializes session lifecycle and turn dispatch per thread. Dispatch also
+    // waits for a prior prompt's preflight decision before choosing prompt(),
+    // steer(), or followUp().
     const dispatchLock = makeKeyedLock<ThreadId>();
     const ownsNativeEventLogger = options?.nativeEventLogger === undefined;
     const nativeEventLogger =
@@ -1846,18 +1847,30 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       // isStreaming flag only flips deep inside prompt()'s async preflight, so
       // a concurrent sendTurn/steerTurn must not read the gap as "settled".
       context.promptCommitting = turnId;
+      let resolveCommit!: () => void;
+      const committed = new Promise<void>((resolve) => {
+        resolveCommit = resolve;
+      });
+      context.promptCommit = committed;
+      let commitSettled = false;
       const settled = () => {
+        if (commitSettled) return;
+        commitSettled = true;
         if (context.promptCommitting === turnId) context.promptCommitting = undefined;
+        if (context.promptCommit === committed) context.promptCommit = undefined;
+        resolveCommit();
       };
       // A prompt owns all SDK retries, compaction and queued continuations.
       // agent_end is per attempt; agent_settled also fires before a rejection.
-      // streamingBehavior is the last-resort fallback: if the session started
-      // streaming between the dispatch check and prompt()'s own check, the
-      // message queues instead of throwing the raw SDK busy error.
       void context.runtime.session
         .prompt(text, {
-          streamingBehavior: "followUp",
           ...(images.length > 0 ? { images } : {}),
+          // Release a waiting dispatch once prompt() either commits its own
+          // run or handles the input without a run. A rejected preflight is
+          // released by the promise rejection path below.
+          preflightResult: (success) => {
+            if (success) settled();
+          },
         })
         .then(
           () => {
@@ -1869,6 +1882,13 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             completePrompt(context, turnId, toMessage(cause, "Pi turn failed."), cause);
           },
         );
+    };
+
+    const awaitPromptCommit = (context: PiSessionContext) => {
+      const pending = context.promptCommit;
+      return pending === undefined
+        ? Effect.void
+        : Effect.promise(() => pending).pipe(Effect.uninterruptible);
     };
 
     // A turn whose run fully settled but whose completion is still queued on
@@ -2075,8 +2095,9 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         !context.runtime.session.isStreaming
       ) {
         context.pendingAbortTurnId = turnId;
-        context.runtime.session.clearQueue();
-        return Promise.resolve();
+        // There is no agent run to abort yet, but prompt preflight may be
+        // compacting. Abort that work now and keep the deferred run abort.
+        return abortSessionTurn(context);
       }
       return abortSessionTurn(context);
     };
@@ -2192,7 +2213,6 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           ) {
             // The committing prompt just started its run — land the interrupt
             // that was deferred because abort() had nothing to reach yet.
-            context.pendingAbortTurnId = undefined;
             void abortSessionTurn(context).catch((cause) => {
               offerRuntimeError(context, {
                 message: toMessage(cause, "Failed to interrupt Pi turn."),
@@ -2485,7 +2505,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       };
     };
 
-    const startSession: PiAdapterShape["startSession"] = (input) =>
+    const startSessionUnlocked = (input: Parameters<PiAdapterShape["startSession"]>[0]) =>
       Effect.gen(function* () {
         const cwd = trimToUndefined(input.cwd) ?? serverConfig.cwd;
         const piSdk = yield* loadPiSdk("session/start");
@@ -2625,6 +2645,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           turns: [],
           activeTurnId: undefined,
           promptCommitting: undefined,
+          promptCommit: undefined,
           pendingAbortTurnId: undefined,
           activeAssistantItemId: undefined,
           activeReasoningItemId: undefined,
@@ -2725,6 +2746,9 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         return session;
       });
 
+    const startSession: PiAdapterShape["startSession"] = (input) =>
+      dispatchLock.withLock(input.threadId, startSessionUnlocked(input));
+
     const buildPromptPayload = (input: {
       readonly input?: string | undefined;
       readonly attachments?: ReadonlyArray<ChatAttachment> | undefined;
@@ -2783,6 +2807,13 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         input.threadId,
         Effect.gen(function* () {
           const context = yield* requireSession(input.threadId);
+          if (
+            context.pendingAbortTurnId !== undefined &&
+            context.pendingAbortTurnId === context.activeTurnId
+          ) {
+            return yield* sendTurnBusyError();
+          }
+          yield* awaitPromptCommit(context);
           if (input.modelSelection?.provider === "pi") {
             yield* applyPiModelSelection(context, input.modelSelection);
           }
@@ -2827,6 +2858,17 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         input.threadId,
         Effect.gen(function* () {
           const context = yield* requireSession(input.threadId);
+          if (
+            context.pendingAbortTurnId !== undefined &&
+            context.pendingAbortTurnId === context.activeTurnId
+          ) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "steerTurn",
+              issue: "A Pi turn is already active for this thread.",
+            });
+          }
+          yield* awaitPromptCommit(context);
           const payload = yield* buildPromptPayload(input);
           if (context.stopped) {
             return yield* new ProviderAdapterSessionClosedError({
@@ -2845,8 +2887,15 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
               issue: "A Pi turn is already active for this thread.",
             });
           }
-          const providerText = buildProviderText(context, payload.text);
           const joinedTurnId = context.activeTurnId;
+          if (joinedTurnId === undefined && context.runtime.session.isStreaming) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "steerTurn",
+              issue: "A Pi turn is already active for this thread.",
+            });
+          }
+          const providerText = buildProviderText(context, payload.text);
           const turnId = joinedTurnId ?? TurnId.makeUnsafe(crypto.randomUUID());
           if (joinedTurnId === undefined) {
             context.activeTurnId = turnId;
@@ -2858,9 +2907,6 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           ) {
             yield* steerPiTurn(context, providerText, payload.images);
           } else {
-            // Fresh turn while an untracked run drains: startPrompt's
-            // streamingBehavior:"followUp" queues it behind the run and its own
-            // prompt() promise completes this turn — steer() would orphan it.
             startPrompt(context, turnId, providerText, payload.images);
           }
           return dispatchResult(context, turnId);
@@ -2921,33 +2967,36 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       });
 
     const stopSession: PiAdapterShape["stopSession"] = (threadId) =>
-      Effect.gen(function* () {
-        const context = sessions.get(threadId);
-        if (!context) return;
-        yield* Effect.tryPromise({
-          try: () => disposeSessionContext(context),
-          catch: (cause) =>
-            new ProviderAdapterRequestError({
-              provider: PROVIDER,
-              method: "session/stop",
-              detail: toMessage(cause, "Failed to stop Pi session."),
-              cause,
-            }),
-        });
-        if (sessions.get(threadId) === context) {
-          sessions.delete(threadId);
-        }
-        offerRuntimeEvent({
-          ...makeEventBase(context),
-          type: "thread.state.changed",
-          payload: { state: "closed", detail: { reason: "stopped" } },
-        } satisfies ProviderRuntimeEvent);
-        offerRuntimeEvent({
-          ...makeEventBase(context),
-          type: "session.exited",
-          payload: { reason: "stopped", exitKind: "graceful" },
-        } satisfies ProviderRuntimeEvent);
-      });
+      dispatchLock.withLock(
+        threadId,
+        Effect.gen(function* () {
+          const context = sessions.get(threadId);
+          if (!context) return;
+          yield* Effect.tryPromise({
+            try: () => disposeSessionContext(context),
+            catch: (cause) =>
+              new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method: "session/stop",
+                detail: toMessage(cause, "Failed to stop Pi session."),
+                cause,
+              }),
+          });
+          if (sessions.get(threadId) === context) {
+            sessions.delete(threadId);
+          }
+          offerRuntimeEvent({
+            ...makeEventBase(context),
+            type: "thread.state.changed",
+            payload: { state: "closed", detail: { reason: "stopped" } },
+          } satisfies ProviderRuntimeEvent);
+          offerRuntimeEvent({
+            ...makeEventBase(context),
+            type: "session.exited",
+            payload: { reason: "stopped", exitKind: "graceful" },
+          } satisfies ProviderRuntimeEvent);
+        }),
+      );
 
     const listSessions: PiAdapterShape["listSessions"] = () =>
       Effect.sync(() => Array.from(sessions.values()).map(makeSessionSnapshot));

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -20,6 +20,7 @@ import {
   ApprovalRequestId,
   type ChatAttachment,
   EventId,
+  type PiModelSelection,
   type ProviderComposerCapabilities,
   type ProviderListCommandsResult,
   type ProviderListModelsResult,
@@ -1834,6 +1835,129 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       );
     };
 
+    const buildProviderText = (context: PiSessionContext, text: string) =>
+      [
+        takeSynaraHarnessPolicyForProviderSession(context, {
+          provider: PROVIDER,
+          scopedGatewayConnectionAvailable: context.gatewayControlAvailable,
+        }),
+        text,
+      ]
+        .filter(Boolean)
+        .join("\n\n");
+
+    const sendTurnBusyError = () =>
+      new ProviderAdapterValidationError({
+        provider: PROVIDER,
+        operation: "sendTurn",
+        issue: "A Pi turn is already active for this thread.",
+      });
+
+    const applyPiModelSelection = (context: PiSessionContext, selection: PiModelSelection) =>
+      Effect.gen(function* () {
+        const model = findModelInRegistry(context.modelRegistry, selection.model);
+        if (!model) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "model/set",
+            issue: `Pi model '${selection.model}' is not available. Use a discovered model or a provider-qualified custom model slug like 'openai/gpt-5.5'.`,
+          });
+        }
+        yield* Effect.tryPromise({
+          try: () => context.runtime.session.setModel(model),
+          catch: (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "model/set",
+              detail: toMessage(cause, "Failed to set Pi model."),
+              cause,
+            }),
+        });
+        const thinkingLevel = normalizePiThinkingLevel(selection.options?.thinkingLevel);
+        if (thinkingLevel) {
+          context.runtime.session.setThinkingLevel(thinkingLevel);
+        }
+      });
+
+    // /reload only exists as a bare text command — attachments make it a prompt.
+    const isPiReloadPayload = (payload: { text: string; images: ImageContent[] }) =>
+      payload.images.length === 0 && isPiReloadCommand(payload.text);
+
+    const steerPiTurn = (context: PiSessionContext, text: string, images: ImageContent[]) =>
+      Effect.tryPromise({
+        try: () => context.runtime.session.steer(text, images),
+        catch: (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "turn/steer",
+            detail: toMessage(cause, "Failed to steer Pi turn."),
+            cause,
+          }),
+      });
+
+    const runPiReload = (context: PiSessionContext, command: string) =>
+      Effect.gen(function* () {
+        offerRuntimeEvent({
+          ...makeEventBase(context),
+          type: "turn.started",
+          payload: {
+            ...(context.runtime.session.model
+              ? {
+                  model: `${context.runtime.session.model.provider}/${context.runtime.session.model.id}`,
+                }
+              : {}),
+            effort: context.runtime.session.thinkingLevel,
+          },
+          raw: { source: "pi.sdk.event", method: "reload", payload: { command } },
+        } satisfies ProviderRuntimeEvent);
+        yield* Effect.tryPromise({
+          try: () => context.runtime.session.reload(),
+          catch: (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "session/reload",
+              detail: toMessage(cause, "Failed to reload Pi resources."),
+              cause,
+            }),
+        }).pipe(
+          Effect.catch((error) =>
+            Effect.gen(function* () {
+              const message = error.message;
+              offerRuntimeEvent({
+                ...makeEventBase(context),
+                type: "turn.completed",
+                payload: { state: "failed", stopReason: "error", errorMessage: message },
+                raw: { source: "pi.sdk.event", method: "reload", payload: error },
+              } satisfies ProviderRuntimeEvent);
+              offerRuntimeError(context, {
+                message,
+                method: "session/reload",
+                cause: error,
+              });
+              yield* cancelAgentGatewayTurn(context.gatewaySessionLease, context.activeTurnId);
+              context.activeTurnId = undefined;
+              context.session = makeSessionSnapshot(context);
+              return yield* Effect.fail(error);
+            }),
+          ),
+        );
+        offerRuntimeEvent({
+          ...makeEventBase(context),
+          type: "turn.completed",
+          payload: { state: "completed", stopReason: "reload" },
+          raw: { source: "pi.sdk.event", method: "reload", payload: { command } },
+        } satisfies ProviderRuntimeEvent);
+        yield* cancelAgentGatewayTurn(context.gatewaySessionLease, context.activeTurnId);
+        context.activeTurnId = undefined;
+        context.session = makeSessionSnapshot(context);
+      });
+
+    const dispatchResult = (context: PiSessionContext, turnId: TurnId) => ({
+      threadId: context.session.threadId,
+      turnId,
+      resumeCursor: getSessionFile(context.runtime.session),
+    });
+
     const recordItem = (context: PiSessionContext, item: unknown, toolCallId?: string) => {
       const turn = context.activeTurnId
         ? context.turns.find((candidate) => candidate.id === context.activeTurnId)
@@ -2553,149 +2677,40 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       Effect.gen(function* () {
         const context = yield* requireSession(input.threadId);
         if (context.activeTurnId) {
-          return yield* new ProviderAdapterValidationError({
-            provider: PROVIDER,
-            operation: "sendTurn",
-            issue: "A Pi turn is already active for this thread.",
-          });
+          return yield* sendTurnBusyError();
         }
         if (input.modelSelection?.provider === "pi") {
-          const model = findModelInRegistry(context.modelRegistry, input.modelSelection.model);
-          if (!model) {
-            return yield* new ProviderAdapterValidationError({
-              provider: PROVIDER,
-              operation: "model/set",
-              issue: `Pi model '${input.modelSelection.model}' is not available. Use a discovered model or a provider-qualified custom model slug like 'openai/gpt-5.5'.`,
-            });
-          }
-          yield* Effect.tryPromise({
-            try: () => context.runtime.session.setModel(model),
-            catch: (cause) =>
-              new ProviderAdapterRequestError({
-                provider: PROVIDER,
-                method: "model/set",
-                detail: toMessage(cause, "Failed to set Pi model."),
-                cause,
-              }),
-          });
-          const thinkingLevel = normalizePiThinkingLevel(
-            input.modelSelection.options?.thinkingLevel,
-          );
-          if (thinkingLevel) {
-            context.runtime.session.setThinkingLevel(thinkingLevel);
-          }
+          yield* applyPiModelSelection(context, input.modelSelection);
         }
         const payload = yield* buildPromptPayload(input);
         const turnId = TurnId.makeUnsafe(crypto.randomUUID());
         context.activeTurnId = turnId;
         context.turns.push({ id: turnId, items: [], toolItemIndexes: new Map() });
         context.session = makeSessionSnapshot(context);
-        if (payload.images.length === 0 && isPiReloadCommand(payload.text)) {
-          offerRuntimeEvent({
-            ...makeEventBase(context),
-            type: "turn.started",
-            payload: {
-              ...(context.runtime.session.model
-                ? {
-                    model: `${context.runtime.session.model.provider}/${context.runtime.session.model.id}`,
-                  }
-                : {}),
-              effort: context.runtime.session.thinkingLevel,
-            },
-            raw: { source: "pi.sdk.event", method: "reload", payload: { command: payload.text } },
-          } satisfies ProviderRuntimeEvent);
-          yield* Effect.tryPromise({
-            try: () => context.runtime.session.reload(),
-            catch: (cause) =>
-              new ProviderAdapterRequestError({
-                provider: PROVIDER,
-                method: "session/reload",
-                detail: toMessage(cause, "Failed to reload Pi resources."),
-                cause,
-              }),
-          }).pipe(
-            Effect.catch((error) =>
-              Effect.gen(function* () {
-                const message = error.message;
-                offerRuntimeEvent({
-                  ...makeEventBase(context),
-                  type: "turn.completed",
-                  payload: { state: "failed", stopReason: "error", errorMessage: message },
-                  raw: { source: "pi.sdk.event", method: "reload", payload: error },
-                } satisfies ProviderRuntimeEvent);
-                offerRuntimeError(context, {
-                  message,
-                  method: "session/reload",
-                  cause: error,
-                });
-                yield* cancelAgentGatewayTurn(context.gatewaySessionLease, context.activeTurnId);
-                context.activeTurnId = undefined;
-                context.session = makeSessionSnapshot(context);
-                return yield* Effect.fail(error);
-              }),
-            ),
-          );
-          offerRuntimeEvent({
-            ...makeEventBase(context),
-            type: "turn.completed",
-            payload: { state: "completed", stopReason: "reload" },
-            raw: { source: "pi.sdk.event", method: "reload", payload: { command: payload.text } },
-          } satisfies ProviderRuntimeEvent);
-          yield* cancelAgentGatewayTurn(context.gatewaySessionLease, context.activeTurnId);
-          context.activeTurnId = undefined;
-          context.session = makeSessionSnapshot(context);
-          return {
-            threadId: input.threadId,
-            turnId,
-            resumeCursor: getSessionFile(context.runtime.session),
-          };
+        if (isPiReloadPayload(payload)) {
+          yield* runPiReload(context, payload.text);
+          return dispatchResult(context, turnId);
         }
-        const harnessPolicy = takeSynaraHarnessPolicyForProviderSession(context, {
-          provider: PROVIDER,
-          scopedGatewayConnectionAvailable: context.gatewayControlAvailable,
-        });
-        const providerText = [harnessPolicy, payload.text].filter(Boolean).join("\n\n");
-        startPrompt(context, turnId, providerText, payload.images);
-        return {
-          threadId: input.threadId,
-          turnId,
-          resumeCursor: getSessionFile(context.runtime.session),
-        };
+        startPrompt(context, turnId, buildProviderText(context, payload.text), payload.images);
+        return dispatchResult(context, turnId);
       });
 
     const steerTurn: NonNullable<PiAdapterShape["steerTurn"]> = (input) =>
       Effect.gen(function* () {
         const context = yield* requireSession(input.threadId);
         const payload = yield* buildPromptPayload(input);
-        const harnessPolicy = takeSynaraHarnessPolicyForProviderSession(context, {
-          provider: PROVIDER,
-          scopedGatewayConnectionAvailable: context.gatewayControlAvailable,
-        });
-        const providerText = [harnessPolicy, payload.text].filter(Boolean).join("\n\n");
+        const providerText = buildProviderText(context, payload.text);
         const turnId = context.activeTurnId ?? TurnId.makeUnsafe(crypto.randomUUID());
         if (!context.activeTurnId) {
           context.activeTurnId = turnId;
           context.turns.push({ id: turnId, items: [], toolItemIndexes: new Map() });
         }
         if (context.runtime.session.isStreaming) {
-          yield* Effect.tryPromise({
-            try: () => context.runtime.session.steer(providerText, payload.images),
-            catch: (cause) =>
-              new ProviderAdapterRequestError({
-                provider: PROVIDER,
-                method: "turn/steer",
-                detail: toMessage(cause, "Failed to steer Pi turn."),
-                cause,
-              }),
-          });
+          yield* steerPiTurn(context, providerText, payload.images);
         } else {
           startPrompt(context, turnId, providerText, payload.images);
         }
-        return {
-          threadId: input.threadId,
-          turnId,
-          resumeCursor: getSessionFile(context.runtime.session),
-        };
+        return dispatchResult(context, turnId);
       });
 
     const interruptTurn: PiAdapterShape["interruptTurn"] = (threadId, turnId) =>

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -2787,13 +2787,19 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             yield* applyPiModelSelection(context, input.modelSelection);
           }
           const payload = yield* buildPromptPayload(input);
+          if (context.stopped) {
+            return yield* new ProviderAdapterSessionClosedError({
+              provider: PROVIDER,
+              threadId: input.threadId,
+            });
+          }
           closeSettledActiveTurn(context);
           const liveTurnId = context.activeTurnId;
           if (liveTurnId !== undefined) {
             // A turn is active: route the send through the SDK's follow-up
             // queue instead of prompt(), which would throw the raw "Agent is
             // already processing" error mid-run.
-            if (isPiReloadPayload(payload)) {
+            if (context.pendingAbortTurnId === liveTurnId || isPiReloadPayload(payload)) {
               return yield* sendTurnBusyError();
             }
             yield* queuePiFollowUp(context, payload);
@@ -2822,7 +2828,23 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         Effect.gen(function* () {
           const context = yield* requireSession(input.threadId);
           const payload = yield* buildPromptPayload(input);
+          if (context.stopped) {
+            return yield* new ProviderAdapterSessionClosedError({
+              provider: PROVIDER,
+              threadId: input.threadId,
+            });
+          }
           closeSettledActiveTurn(context);
+          if (
+            context.pendingAbortTurnId !== undefined &&
+            context.pendingAbortTurnId === context.activeTurnId
+          ) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "steerTurn",
+              issue: "A Pi turn is already active for this thread.",
+            });
+          }
           const providerText = buildProviderText(context, payload.text);
           const turnId = context.activeTurnId ?? TurnId.makeUnsafe(crypto.randomUUID());
           if (!context.activeTurnId) {


### PR DESCRIPTION
## What Changed

Fixes `Agent is already processing. Specify streamingBehavior ('steer' or 'followUp') to queue the message.` — the raw Pi SDK error users hit when sending a message while a Pi turn was still running.

`sendTurn`/`steerTurn` dispatched `session.prompt()` with no `streamingBehavior` and no serialization, so any send landing during a live run threw. Mid-turn sends are now a first-class path:

- **Per-thread dispatch lock** (`KeyedLock`, same primitive ProviderService uses) serializes the check→act sequence so overlapping sends can't both read "idle" and race `prompt()`'s async preflight.
- **`session.followUp()` routing**: a send during an active Pi turn queues inside the SDK and is delivered as a continuation of the same turn — returns the live `turnId`.
- **`promptCommitting` marker**: `prompt()` has an async preflight where `isStreaming` is still false; the marker makes the commit window observable so a send in that gap queues as a follow-up instead of being read as "settled".
- **Deferred abort** (`pendingAbortTurnId`): an interrupt landing in the commit window used to silently no-op — no `activeRun` exists yet for `session.abort()` to reach — so the turn started anyway. The abort now fires at `agent_start` when the run commits. Both `interruptTurn` and the extension `abortHandler` share `interruptActiveTurn`.
- **`streamingBehavior: "followUp"` fallback** on every `prompt()` call — ignored when idle, queues instead of throwing if a run materialized between our check and the SDK's own check.
- **Drain-tail guard**: `steerTurn` only calls `steer()` when joining the *tracked* live turn; a fresh turn goes through `startPrompt`, whose fallback queues behind an untracked draining run and completes through its own promise. Steering a fresh turn into a run owned by a completed turn would orphan the new turn `running` forever (completion carries the old `turnId`).
- **Race guards**: dispatches recheck `context.stopped` after the async payload build (`SessionClosed`), and sends/steers targeting an abort-pending turn fail with a validation error instead of queueing a message the deferred abort would silently drop.
- **Stale-turn close**: if the run settled but the completion hasn't projected, `closeSettledActiveTurn` emits it before the next dispatch reuses the slot.

Runs Synara didn't dispatch (extension-triggered) still get the clean "A Pi turn is already active" validation error rather than the raw SDK string, and `/reload` mid-turn still errors rather than becoming literal prompt text.

Commits are atomic — refactor → serialize → follow-up → interrupt → race guards → drain-tail — each verified at its own commit.

## Why

The error string comes from the Pi SDK, but the bug is ours: unserialized dispatch plus a bare `prompt()` call. Mid-turn messaging is the path the SDK intends — `followUp` queues the message and the run processes it when its current pass ends, which is what users expect when they send while the agent is working.

## UI Changes

Provider-adapter change — no UI code. Live evidence from a real thread (Pi · DeepSeek V4 Flash via Particle, isolated dev instance, dark mode):

Mid-turn message queued as a Steer while the essay turn is still streaming:

![Mid-turn message queued as Steer while turn streams](https://github.com/user-attachments/assets/28c1aa8f-17fd-4081-bbbe-e9b6c7b1e689)

Turn completed; the queued follow-up was delivered and answered:

![Completed turn with steered follow-up answer](https://github.com/user-attachments/assets/d54d59dd-ee0d-42d0-9df3-119631c279a4)

Full flow — model selection (Pi → DeepSeek V4 Flash), essay streaming, mid-turn send queued, follow-up processed:

https://github.com/user-attachments/assets/42d0e625-8bba-48f5-81f7-314b0158eb09

## Verification

- `bun run test PiAdapter` — 51/51, including 5 new regression tests: follow-up delivery through a retry, concurrent send during the commit window, interrupt during the commit window, send rejected while abort is pending, steer never lands in an untracked draining run
- `bun run typecheck` (server), `bun fmt`, `bun lint` — clean
- E2E on an isolated dev instance (own home dir, non-default ports): 7 Pi turns including mid-turn sends shown as "Steer" that landed answers mid-stream; zero provider errors in the server log; all turns `completed` in the projection DB

## Checklist

- [x] This PR is small and focused (2 files: the adapter + its lifecycle test)
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

