### PR TITLE
Unify file manager labels across platforms

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -155,6 +155,7 @@ import {
 } from "./resumableUpdateDownload";
 import { hardenElectronUpdater } from "./electronUpdaterSecurity";
 import { ServerListeningDetector } from "./serverListeningDetector";
+import { showPathInFileManager } from "./showInFileManager";
 import { BackendStartupBlockDetector, type BackendStartupBlock } from "./backendStartupBlock";
 import {
   BACKEND_MAX_CONSECUTIVE_START_FAILURES,
@@ -4547,27 +4548,9 @@ function registerIpcHandlers(): void {
 
   ipcMain.removeHandler(IPC.showInFolder);
   ipcMain.handle(IPC.showInFolder, async (_event, rawPath: unknown) => {
-    if (typeof rawPath !== "string" || rawPath.trim().length === 0) {
-      throw new Error("Missing folder path.");
-    }
-    const resolvedPath = Path.resolve(rawPath);
-
-    let stats: FS.Stats;
-    try {
-      stats = await FS.promises.stat(resolvedPath);
-    } catch {
-      throw new Error(`Folder not found: ${resolvedPath}`);
-    }
-
-    if (stats.isDirectory()) {
-      const errorMessage = await shell.openPath(resolvedPath);
-      if (errorMessage.trim().length > 0) {
-        throw new Error(errorMessage);
-      }
-      return;
-    }
-
-    shell.showItemInFolder(resolvedPath);
+    // Folders open in the file manager, files are revealed inside it; the
+    // renderer picks the matching label/error copy per platform.
+    await showPathInFileManager(rawPath, shell);
   });
 
   ipcMain.removeHandler(IPC.windowMinimize);

--- a/apps/desktop/src/showInFileManager.test.ts
+++ b/apps/desktop/src/showInFileManager.test.ts
@@ -1,0 +1,125 @@
+// FILE: showInFileManager.test.ts
+// Purpose: Proves the desktop:show-in-folder handler opens folders with
+//          shell.openPath and reveals files with shell.showItemInFolder, and that
+//          failures surface as user-readable errors.
+// Layer: Desktop main-process helper tests
+
+import * as FS from "node:fs";
+import * as OS from "node:os";
+import * as Path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { showPathInFileManager, type FileManagerShell } from "./showInFileManager";
+
+let tempDir = "";
+let shell: { openPath: ReturnType<typeof vi.fn>; showItemInFolder: ReturnType<typeof vi.fn> };
+
+beforeEach(async () => {
+  tempDir = await FS.promises.mkdtemp(Path.join(OS.tmpdir(), "synara-show-in-file-manager-"));
+  shell = {
+    openPath: vi.fn(async () => ""),
+    showItemInFolder: vi.fn(),
+  };
+});
+
+afterEach(async () => {
+  await FS.promises.rm(tempDir, { recursive: true, force: true });
+});
+
+function asShell(): FileManagerShell {
+  return shell as unknown as FileManagerShell;
+}
+
+describe("showPathInFileManager", () => {
+  it("opens an existing folder with shell.openPath and never reveals it", async () => {
+    const folderPath = Path.join(tempDir, "Project Folder");
+    await FS.promises.mkdir(folderPath);
+
+    await expect(showPathInFileManager(folderPath, asShell())).resolves.toBeUndefined();
+
+    expect(shell.openPath).toHaveBeenCalledTimes(1);
+    expect(shell.openPath).toHaveBeenCalledWith(Path.resolve(folderPath));
+    expect(shell.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  it("reveals an existing file with shell.showItemInFolder instead of launching it", async () => {
+    const filePath = Path.join(tempDir, "output video.mp4");
+    await FS.promises.writeFile(filePath, "");
+
+    await expect(showPathInFileManager(filePath, asShell())).resolves.toBeUndefined();
+
+    expect(shell.showItemInFolder).toHaveBeenCalledTimes(1);
+    expect(shell.showItemInFolder).toHaveBeenCalledWith(Path.resolve(filePath));
+    expect(shell.openPath).not.toHaveBeenCalled();
+  });
+
+  it("resolves relative paths before handing them to the shell", async () => {
+    const folderPath = Path.join(tempDir, "relative folder");
+    await FS.promises.mkdir(folderPath);
+    const relativePath = Path.relative(process.cwd(), folderPath);
+
+    await showPathInFileManager(relativePath, asShell());
+
+    const expected = Path.resolve(relativePath);
+    expect(shell.openPath).toHaveBeenCalledWith(expected);
+    expect(shell.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  it("reports a missing path with the resolved location", async () => {
+    const missingPath = Path.join(tempDir, "does-not-exist");
+
+    await expect(showPathInFileManager(missingPath, asShell())).rejects.toThrow(
+      `File or folder not found: ${Path.resolve(missingPath)}`,
+    );
+
+    expect(shell.openPath).not.toHaveBeenCalled();
+    expect(shell.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, null, 42, "", "   "])(
+    "rejects an empty or non-string path (%j)",
+    async (rawPath) => {
+      await expect(showPathInFileManager(rawPath, asShell())).rejects.toThrow(
+        "Missing file or folder path.",
+      );
+
+      expect(shell.openPath).not.toHaveBeenCalled();
+      expect(shell.showItemInFolder).not.toHaveBeenCalled();
+    },
+  );
+
+  it("surfaces the shell's own message when opening a folder fails", async () => {
+    const folderPath = Path.join(tempDir, "locked");
+    await FS.promises.mkdir(folderPath);
+    shell.openPath.mockResolvedValue("Failed to open path");
+
+    await expect(showPathInFileManager(folderPath, asShell())).rejects.toThrow(
+      "Failed to open path",
+    );
+
+    expect(shell.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  it("preserves HEAD semantics by treating a whitespace-only shell message as failure", async () => {
+    const folderPath = Path.join(tempDir, "whitespace-failure");
+    await FS.promises.mkdir(folderPath);
+    shell.openPath.mockResolvedValue("   ");
+
+    await expect(showPathInFileManager(folderPath, asShell())).rejects.toMatchObject({
+      message: "   ",
+    });
+    expect(shell.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  it("propagates a file reveal failure without trying to open the file", async () => {
+    const filePath = Path.join(tempDir, "locked.txt");
+    await FS.promises.writeFile(filePath, "");
+    shell.showItemInFolder.mockImplementation(() => {
+      throw new Error("Reveal failed");
+    });
+
+    await expect(showPathInFileManager(filePath, asShell())).rejects.toThrow("Reveal failed");
+
+    expect(shell.openPath).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/showInFileManager.ts
+++ b/apps/desktop/src/showInFileManager.ts
@@ -1,0 +1,42 @@
+// FILE: showInFileManager.ts
+// Purpose: Body of the desktop:show-in-folder IPC handler, kept free of ipcMain
+//          so the file-vs-folder branch is unit-testable. Folders are opened in
+//          the platform file manager (shell.openPath); files are selected inside
+//          their parent folder (shell.showItemInFolder) rather than launched.
+// Layer: Desktop main-process helper
+// Exports: FileManagerShell, showPathInFileManager
+
+import * as FS from "node:fs";
+import * as Path from "node:path";
+import type { Shell } from "electron";
+
+export type FileManagerShell = Pick<Shell, "openPath" | "showItemInFolder">;
+
+export async function showPathInFileManager(
+  rawPath: unknown,
+  shell: FileManagerShell,
+): Promise<void> {
+  if (typeof rawPath !== "string" || rawPath.trim().length === 0) {
+    throw new Error("Missing file or folder path.");
+  }
+  const resolvedPath = Path.resolve(rawPath);
+
+  let stats: FS.Stats;
+  try {
+    stats = await FS.promises.stat(resolvedPath);
+  } catch {
+    throw new Error(`File or folder not found: ${resolvedPath}`);
+  }
+
+  if (stats.isDirectory()) {
+    // shell.openPath resolves with an empty string on success and a
+    // platform-specific message on failure; surface that message verbatim.
+    const errorMessage = await shell.openPath(resolvedPath);
+    if (errorMessage.length > 0) {
+      throw new Error(errorMessage);
+    }
+    return;
+  }
+
+  shell.showItemInFolder(resolvedPath);
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -358,6 +358,8 @@ import {
   DISCLOSURE_INNER_CLASS,
 } from "~/lib/disclosureMotion";
 import { createClientPointMenuAnchor } from "~/lib/clientPointMenuAnchor";
+import { showFileManagerErrorToast } from "~/lib/fileManagerErrorToast";
+import { resolveFileManagerActionLabel } from "~/lib/fileManagerNaming";
 import { resolveThreadModelSummary } from "~/lib/threadModelSummary";
 import {
   canCreateThreadHandoff,
@@ -487,7 +489,7 @@ const DebugFeatureFlagsMenu = import.meta.env.DEV
   : null;
 
 type ProjectContextMenuId =
-  | "open-in-finder"
+  | "open-in-file-manager"
   | "open-in-kanban"
   | "copy-path"
   | "start-dev"
@@ -3504,18 +3506,11 @@ export default function Sidebar() {
       const project = projectById.get(projectId);
       if (!project) return;
 
-      if (clicked === "open-in-finder") {
+      if (clicked === "open-in-file-manager") {
         try {
           await api.shell.showInFolder(project.cwd);
         } catch (error) {
-          toastManager.add({
-            type: "error",
-            title: "Unable to open in Finder",
-            description:
-              error instanceof Error
-                ? error.message
-                : "An unknown error occurred opening the folder.",
-          });
+          showFileManagerErrorToast({ kind: "folder", error });
         }
         return;
       }
@@ -6540,12 +6535,12 @@ export default function Sidebar() {
                 onClick={() =>
                   void handleProjectContextMenuAction(
                     projectContextMenuState.projectId,
-                    "open-in-finder",
+                    "open-in-file-manager",
                   )
                 }
               >
                 <ProjectContextMenuIcon icon={FolderOpenIcon} />
-                <span>Open in Finder</span>
+                <span>{resolveFileManagerActionLabel("folder")}</span>
               </MenuItem>
               <MenuItem
                 className={PROJECT_CONTEXT_MENU_ITEM_CLASS_NAME}

--- a/apps/web/src/components/chat/environment/EnvironmentPanel.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentPanel.tsx
@@ -36,6 +36,7 @@ import { toastManager } from "~/components/ui/toast";
 import { isElectron } from "~/env";
 import { basenameOfPath } from "~/file-icons";
 import type { RepoDiffTotals } from "~/hooks/useRepoDiffTotals";
+import { showFileManagerErrorToast } from "~/lib/fileManagerErrorToast";
 import { ArrowUpRightIcon, ChangesIcon, GitHubIcon, SettingsIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
@@ -311,23 +312,17 @@ export function EnvironmentPanel({
           onClick={() => {
             const api = readNativeApi();
             if (!api) {
-              toastManager.add({
-                type: "error",
-                title: "Unable to open folder",
-                description: "The desktop connection is not available yet.",
+              showFileManagerErrorToast({
+                kind: "folder",
+                error: "The desktop connection is not available yet.",
               });
               return;
             }
             void api.shell
               .showInFolder(studioFolderPath)
               .then(onClose)
-              .catch((error) => {
-                toastManager.add({
-                  type: "error",
-                  title: "Unable to open folder",
-                  description:
-                    error instanceof Error ? error.message : "An unknown error occurred.",
-                });
+              .catch((error: unknown) => {
+                showFileManagerErrorToast({ kind: "folder", error });
               });
           }}
         />

--- a/apps/web/src/components/chat/environment/EnvironmentStudioOutputsSection.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentStudioOutputsSection.tsx
@@ -3,8 +3,9 @@
 //          under the Studio root (attributed server-side from checkpoints, file-change
 //          activities, or per-turn output capture). Click opens the file in the in-app
 //          side panel viewer; meta/ctrl-click (or an unviewable file) reveals it in the
-//          Finder instead. The section renders nothing until the chat has actually
-//          produced output, so non-producing chats keep a clean panel.
+//          platform file manager instead (labels/errors come from fileManagerNaming).
+//          The section renders nothing until the chat has actually produced output,
+//          so non-producing chats keep a clean panel.
 // Layer: Environment panel section
 // Depends on: studio.listThreadOutputs WS method + shell.showInFolder.
 
@@ -12,6 +13,7 @@ import type { StudioOutputEntry, ThreadId } from "@synara/contracts";
 import { isSupportedLocalImagePath } from "@synara/shared/localPreviewFiles";
 import { useQuery } from "@tanstack/react-query";
 
+import { showFileManagerErrorToast } from "~/lib/fileManagerErrorToast";
 import { formatRelativeTime } from "~/lib/relativeTime";
 import { studioThreadOutputsQueryOptions } from "~/lib/serverReactQuery";
 import { humanizeStudioOutputName } from "~/lib/studioOutputDisplay";
@@ -21,9 +23,11 @@ import { readNativeApi } from "~/nativeApi";
 import { FileEntryIcon } from "../FileEntryIcon";
 import { EnvironmentLabeledSection, EnvironmentRow } from "./EnvironmentRow";
 
-function revealEntryInFinder(entry: StudioOutputEntry) {
+function revealEntryInFileManager(entry: StudioOutputEntry) {
   const api = readNativeApi();
-  void api?.shell.showInFolder(entry.fullPath).catch(() => {});
+  void api?.shell.showInFolder(entry.fullPath).catch((error: unknown) => {
+    showFileManagerErrorToast({ kind: "file", error });
+  });
 }
 
 export function EnvironmentStudioOutputsSection({
@@ -37,10 +41,10 @@ export function EnvironmentStudioOutputsSection({
   const fileOpener = useWorkspaceFileOpener();
 
   // Plain click opens the output in the in-app side panel; meta/ctrl-click — or a
-  // file the panel can't view — reveals it in the Finder instead.
-  const openEntry = (entry: StudioOutputEntry, forceFinderReveal: boolean) => {
-    if (forceFinderReveal || !fileOpener?.openFile(entry.fullPath)) {
-      revealEntryInFinder(entry);
+  // file the panel can't view — reveals it in the platform file manager instead.
+  const openEntry = (entry: StudioOutputEntry, forceFileManagerReveal: boolean) => {
+    if (forceFileManagerReveal || !fileOpener?.openFile(entry.fullPath)) {
+      revealEntryInFileManager(entry);
     }
   };
 

--- a/apps/web/src/editorMetadata.test.ts
+++ b/apps/web/src/editorMetadata.test.ts
@@ -11,7 +11,7 @@ describe("resolveEditorLabel", () => {
   it("uses platform-specific labels for the file manager option", () => {
     expect(resolveEditorLabel("file-manager", "MacIntel")).toBe("Finder");
     expect(resolveEditorLabel("file-manager", "Win32")).toBe("Explorer");
-    expect(resolveEditorLabel("file-manager", "Linux x86_64")).toBe("Files");
+    expect(resolveEditorLabel("file-manager", "Linux x86_64")).toBe("File manager");
   });
 });
 

--- a/apps/web/src/editorMetadata.ts
+++ b/apps/web/src/editorMetadata.ts
@@ -32,8 +32,9 @@ import {
   Zed,
 } from "./components/Icons";
 import { FolderClosed } from "./components/FolderClosed";
+import { resolveFileManagerName } from "./lib/fileManagerNaming";
 import { AppsIcon } from "./lib/icons";
-import { isMacPlatform, isWindowsPlatform } from "./lib/utils";
+import { isMacPlatform } from "./lib/utils";
 import { resolveWsHttpUrl } from "./lib/wsHttpUrl";
 
 export interface EditorOption {
@@ -120,7 +121,7 @@ function resolveNativeEditorIcon(editorId: EditorId): Icon {
 // duplicating the editor list across multiple UI components.
 export function resolveEditorLabel(editorId: EditorId, platform: string): string {
   if (editorId === "file-manager") {
-    return isMacPlatform(platform) ? "Finder" : isWindowsPlatform(platform) ? "Explorer" : "Files";
+    return resolveFileManagerName(platform);
   }
 
   if (editorId === "system-default") {

--- a/apps/web/src/lib/fileManagerErrorToast.test.ts
+++ b/apps/web/src/lib/fileManagerErrorToast.test.ts
@@ -1,0 +1,62 @@
+// FILE: fileManagerErrorToast.test.ts
+// Purpose: Verifies the UI toast adapter consumes the shared pure file-manager
+//          presentation without owning platform-specific copy.
+// Layer: Web UI helper tests
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  toast: vi.fn(),
+}));
+
+vi.mock("~/components/ui/toast", () => ({
+  toastManager: { add: harness.toast },
+}));
+
+import { showFileManagerErrorToast } from "./fileManagerErrorToast";
+
+beforeEach(() => {
+  harness.toast.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("showFileManagerErrorToast", () => {
+  it("emits platform-correct folder and file failures", () => {
+    showFileManagerErrorToast({
+      kind: "folder",
+      error: new Error("File or folder not found: C:\\repo"),
+      platform: "Win32",
+    });
+    showFileManagerErrorToast({ kind: "file", error: new Error("nope"), platform: "MacIntel" });
+    showFileManagerErrorToast({ kind: "file", error: undefined, platform: "Linux x86_64" });
+
+    expect(harness.toast.mock.calls.map(([toast]) => toast)).toEqual([
+      {
+        type: "error",
+        title: "Unable to open in Explorer",
+        description: "File or folder not found: C:\\repo",
+      },
+      { type: "error", title: "Unable to reveal in Finder", description: "nope" },
+      {
+        type: "error",
+        title: "Unable to show in folder",
+        description: "The file could not be shown in its folder.",
+      },
+    ]);
+  });
+
+  it("defaults to navigator.platform", () => {
+    vi.stubGlobal("navigator", { platform: "MacIntel" });
+
+    showFileManagerErrorToast({ kind: "folder", error: new Error("busy") });
+
+    expect(harness.toast).toHaveBeenCalledWith({
+      type: "error",
+      title: "Unable to open in Finder",
+      description: "busy",
+    });
+  });
+});

--- a/apps/web/src/lib/fileManagerErrorToast.ts
+++ b/apps/web/src/lib/fileManagerErrorToast.ts
@@ -1,0 +1,24 @@
+// FILE: fileManagerErrorToast.ts
+// Purpose: Thin UI adapter for file-manager failure toasts. All user-facing
+//          copy remains owned by the pure fileManagerNaming module.
+// Layer: Web UI helper
+// Exports: showFileManagerErrorToast
+
+import { toastManager } from "~/components/ui/toast";
+import {
+  type FileManagerTargetKind,
+  resolveFileManagerErrorDescription,
+  resolveFileManagerErrorTitle,
+} from "~/lib/fileManagerNaming";
+
+export function showFileManagerErrorToast(input: {
+  kind: FileManagerTargetKind;
+  error: unknown;
+  platform?: string;
+}): void {
+  toastManager.add({
+    type: "error",
+    title: resolveFileManagerErrorTitle(input.kind, input.platform),
+    description: resolveFileManagerErrorDescription(input.error, input.kind),
+  });
+}

--- a/apps/web/src/lib/fileManagerNaming.test.ts
+++ b/apps/web/src/lib/fileManagerNaming.test.ts
@@ -1,0 +1,108 @@
+// FILE: fileManagerNaming.test.ts
+// Purpose: Locks the pure per-platform file-manager presentation for folders
+//          and files on macOS, Windows, Linux, and unknown platforms.
+// Layer: Web UI helper tests
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  resolveFileManagerActionLabel,
+  resolveFileManagerErrorDescription,
+  resolveFileManagerErrorTitle,
+  resolveFileManagerName,
+  resolveFileManagerPresentation,
+} from "./fileManagerNaming";
+
+const MAC = "MacIntel";
+const WINDOWS = "Win32";
+const LINUX = "Linux x86_64";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("resolveFileManagerPresentation", () => {
+  it.each([
+    [MAC, "folder", "Finder", "Open in Finder", "Unable to open in Finder"],
+    [MAC, "file", "Finder", "Reveal in Finder", "Unable to reveal in Finder"],
+    [WINDOWS, "folder", "Explorer", "Open in Explorer", "Unable to open in Explorer"],
+    [WINDOWS, "file", "Explorer", "Show in Explorer", "Unable to show in Explorer"],
+    [LINUX, "folder", "File manager", "Open folder", "Unable to open folder"],
+    [LINUX, "file", "File manager", "Show in folder", "Unable to show in folder"],
+    ["Plan9", "folder", "File manager", "Open folder", "Unable to open folder"],
+    ["", "file", "File manager", "Show in folder", "Unable to show in folder"],
+  ] as const)(
+    "%s %s uses the expected application, action, and error copy",
+    (platform, kind, managerName, actionLabel, errorTitle) => {
+      expect(resolveFileManagerPresentation(kind, platform)).toEqual({
+        managerName,
+        actionLabel,
+        errorTitle,
+        fallbackDescription:
+          kind === "folder"
+            ? "The folder could not be opened."
+            : "The file could not be shown in its folder.",
+      });
+    },
+  );
+
+  it("reads navigator.platform when no platform is given", () => {
+    vi.stubGlobal("navigator", { platform: WINDOWS });
+    expect(resolveFileManagerName()).toBe("Explorer");
+  });
+
+  it("falls back safely when navigator is unavailable", () => {
+    vi.stubGlobal("navigator", undefined);
+    expect(resolveFileManagerName()).toBe("File manager");
+    expect(resolveFileManagerActionLabel("file")).toBe("Show in folder");
+  });
+
+  it("never mentions Finder off macOS or Explorer off Windows", () => {
+    for (const kind of ["file", "folder"] as const) {
+      expect(resolveFileManagerActionLabel(kind, WINDOWS)).not.toMatch(/finder/i);
+      expect(resolveFileManagerActionLabel(kind, LINUX)).not.toMatch(/finder|explorer/i);
+      expect(resolveFileManagerActionLabel(kind, MAC)).not.toMatch(/explorer/i);
+      expect(resolveFileManagerErrorTitle(kind, WINDOWS)).not.toMatch(/finder/i);
+      expect(resolveFileManagerErrorTitle(kind, LINUX)).not.toMatch(/finder|explorer/i);
+      expect(resolveFileManagerErrorTitle(kind, MAC)).not.toMatch(/explorer/i);
+    }
+  });
+});
+
+describe("resolveFileManagerErrorTitle", () => {
+  it.each([
+    [MAC, "folder", "Unable to open in Finder"],
+    [MAC, "file", "Unable to reveal in Finder"],
+    [WINDOWS, "folder", "Unable to open in Explorer"],
+    [WINDOWS, "file", "Unable to show in Explorer"],
+    [LINUX, "folder", "Unable to open folder"],
+    [LINUX, "file", "Unable to show in folder"],
+  ] as const)("%s %s -> %s", (platform, kind, expected) => {
+    expect(resolveFileManagerErrorTitle(kind, platform)).toBe(expected);
+  });
+});
+
+describe("resolveFileManagerErrorDescription", () => {
+  it("preserves useful messages from Error, string, and serialized error objects", () => {
+    expect(
+      resolveFileManagerErrorDescription(new Error("File or folder not found: /x"), "file"),
+    ).toBe("File or folder not found: /x");
+    expect(
+      resolveFileManagerErrorDescription("The desktop connection is not available yet.", "folder"),
+    ).toBe("The desktop connection is not available yet.");
+    expect(resolveFileManagerErrorDescription({ message: "Serialized failure" }, "file")).toBe(
+      "Serialized failure",
+    );
+  });
+
+  it.each([
+    [new Error("   "), "folder", "The folder could not be opened."],
+    ["", "file", "The file could not be shown in its folder."],
+    [{ message: "  " }, "file", "The file could not be shown in its folder."],
+    [{ custom: 123 }, "folder", "The folder could not be opened."],
+    [null, "folder", "The folder could not be opened."],
+    [undefined, "file", "The file could not be shown in its folder."],
+  ] as const)("uses neutral fallback copy for an unusable error", (error, kind, expected) => {
+    expect(resolveFileManagerErrorDescription(error, kind)).toBe(expected);
+  });
+});

--- a/apps/web/src/lib/fileManagerNaming.ts
+++ b/apps/web/src/lib/fileManagerNaming.ts
@@ -1,0 +1,146 @@
+// FILE: fileManagerNaming.ts
+// Purpose: Single source for how the UI names the platform file manager and the
+//          "open folder" / "reveal file" actions that route through
+//          shell.showInFolder (Electron shell.openPath for folders,
+//          shell.showItemInFolder for files). Every menu item, tooltip, and
+//          error toast in that flow must read its copy from here so Windows and
+//          Linux users never see "Finder" and macOS users never see "Explorer".
+// Layer: Web UI helpers
+// Exports: FileManagerTargetKind, FileManagerPresentation,
+//          resolveFileManagerPresentation, resolveFileManagerName,
+//          resolveFileManagerActionLabel, resolveFileManagerErrorTitle,
+//          resolveFileManagerErrorDescription
+
+import { getNavigatorPlatform, isMacPlatform, isWindowsPlatform } from "~/lib/utils";
+
+/** Folders are opened in the file manager; files are selected inside it. */
+export type FileManagerTargetKind = "file" | "folder";
+
+type FileManagerPlatform = "mac" | "windows" | "generic";
+
+interface FileManagerTargetCopy {
+  actionLabel: string;
+  errorTitle: string;
+}
+
+interface FileManagerPlatformCopy {
+  managerName: string;
+  file: FileManagerTargetCopy;
+  folder: FileManagerTargetCopy;
+}
+
+export interface FileManagerPresentation extends FileManagerTargetCopy {
+  managerName: string;
+  fallbackDescription: string;
+}
+
+const FILE_MANAGER_COPY = {
+  mac: {
+    managerName: "Finder",
+    folder: {
+      actionLabel: "Open in Finder",
+      errorTitle: "Unable to open in Finder",
+    },
+    file: {
+      actionLabel: "Reveal in Finder",
+      errorTitle: "Unable to reveal in Finder",
+    },
+  },
+  windows: {
+    managerName: "Explorer",
+    folder: {
+      actionLabel: "Open in Explorer",
+      errorTitle: "Unable to open in Explorer",
+    },
+    file: {
+      actionLabel: "Show in Explorer",
+      errorTitle: "Unable to show in Explorer",
+    },
+  },
+  generic: {
+    managerName: "File manager",
+    folder: {
+      actionLabel: "Open folder",
+      errorTitle: "Unable to open folder",
+    },
+    file: {
+      actionLabel: "Show in folder",
+      errorTitle: "Unable to show in folder",
+    },
+  },
+} as const satisfies Record<FileManagerPlatform, FileManagerPlatformCopy>;
+
+const FILE_MANAGER_FALLBACK_DESCRIPTIONS = {
+  folder: "The folder could not be opened.",
+  file: "The file could not be shown in its folder.",
+} as const satisfies Record<FileManagerTargetKind, string>;
+
+function classifyPlatform(platform: string): FileManagerPlatform {
+  if (isWindowsPlatform(platform)) {
+    return "windows";
+  }
+  if (isMacPlatform(platform)) {
+    return "mac";
+  }
+  // Linux and unknown hosts: never assume a specific file manager (Files,
+  // Dolphin, Thunar, ...), so the copy stays generic.
+  return "generic";
+}
+
+/** Display name of the file manager as an application, e.g. for editor pickers. */
+export function resolveFileManagerName(platform: string = getNavigatorPlatform()): string {
+  return FILE_MANAGER_COPY[classifyPlatform(platform)].managerName;
+}
+
+export function resolveFileManagerPresentation(
+  kind: FileManagerTargetKind,
+  platform: string = getNavigatorPlatform(),
+): FileManagerPresentation {
+  const platformCopy = FILE_MANAGER_COPY[classifyPlatform(platform)];
+  return {
+    managerName: platformCopy.managerName,
+    ...platformCopy[kind],
+    fallbackDescription: FILE_MANAGER_FALLBACK_DESCRIPTIONS[kind],
+  };
+}
+
+/**
+ * Menu/button label for the action. Folders use "Open" because the file
+ * manager navigates into them; files use "Reveal"/"Show" because they are
+ * selected inside their parent folder rather than launched.
+ */
+export function resolveFileManagerActionLabel(
+  kind: FileManagerTargetKind,
+  platform: string = getNavigatorPlatform(),
+): string {
+  return resolveFileManagerPresentation(kind, platform).actionLabel;
+}
+
+/** Toast title when the action fails; mirrors the action label wording. */
+export function resolveFileManagerErrorTitle(
+  kind: FileManagerTargetKind,
+  platform: string = getNavigatorPlatform(),
+): string {
+  return resolveFileManagerPresentation(kind, platform).errorTitle;
+}
+
+/**
+ * Toast description: the shell's own message (e.g. "File or folder not found:
+ * …") is the most useful detail, so it is passed through verbatim; anything
+ * else gets a neutral fallback that does not name a file manager.
+ */
+export function resolveFileManagerErrorDescription(
+  error: unknown,
+  kind: FileManagerTargetKind,
+): string {
+  const message =
+    typeof error === "string"
+      ? error
+      : error && typeof error === "object" && "message" in error
+        ? (error as { message?: unknown }).message
+        : undefined;
+
+  return typeof message === "string" && message.trim().length > 0
+    ? message
+    : FILE_MANAGER_FALLBACK_DESCRIPTIONS[kind];
+}

--- a/apps/web/src/lib/fileReferenceContextMenu.test.ts
+++ b/apps/web/src/lib/fileReferenceContextMenu.test.ts
@@ -27,7 +27,7 @@ vi.mock("~/components/ui/toast", () => ({
   toastManager: { add: harness.toast },
 }));
 
-import { getRevealInFolderLabel, showFileReferenceContextMenu } from "./fileReferenceContextMenu";
+import { showFileReferenceContextMenu } from "./fileReferenceContextMenu";
 
 beforeEach(() => {
   vi.stubGlobal("window", { desktopBridge: {} });
@@ -46,14 +46,6 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe("getRevealInFolderLabel", () => {
-  it("uses the native file-manager name on supported desktop platforms", () => {
-    expect(getRevealInFolderLabel("Win32")).toBe("Open in Explorer");
-    expect(getRevealInFolderLabel("MacIntel")).toBe("Reveal in Finder");
-    expect(getRevealInFolderLabel("Linux x86_64")).toBe("Show in folder");
-  });
-});
-
 describe("showFileReferenceContextMenu", () => {
   it("offers reveal before copy when an absolute reveal path is available", async () => {
     await showFileReferenceContextMenu({
@@ -65,7 +57,30 @@ describe("showFileReferenceContextMenu", () => {
 
     expect(harness.showContextMenu).toHaveBeenCalledWith(
       [
-        { id: "reveal-in-folder", label: "Open in Explorer" },
+        { id: "reveal-in-folder", label: "Show in Explorer" },
+        { id: "copy-path", label: "Copy path" },
+      ],
+      { x: 12, y: 34 },
+    );
+  });
+
+  it.each([
+    ["MacIntel", "Reveal in Finder"],
+    ["Win32", "Show in Explorer"],
+    ["Linux x86_64", "Show in folder"],
+  ])("labels the file reveal action per platform (%s)", async (platform, label) => {
+    vi.stubGlobal("navigator", { platform });
+
+    await showFileReferenceContextMenu({
+      path: "/repo/output/video.mp4",
+      revealPath: "/repo/output/video.mp4",
+      position: { x: 12, y: 34 },
+      onReferenceInChat: undefined,
+    });
+
+    expect(harness.showContextMenu).toHaveBeenCalledWith(
+      [
+        { id: "reveal-in-folder", label },
         { id: "copy-path", label: "Copy path" },
       ],
       { x: 12, y: 34 },
@@ -117,8 +132,33 @@ describe("showFileReferenceContextMenu", () => {
 
     expect(harness.toast).toHaveBeenCalledWith({
       type: "error",
-      title: "Unable to reveal file",
+      title: "Unable to show in Explorer",
       description: "Folder not found: /repo/output/video.mp4",
+    });
+  });
+
+  it.each([
+    ["MacIntel", "Unable to reveal in Finder"],
+    ["Win32", "Unable to show in Explorer"],
+    ["Linux x86_64", "Unable to show in folder"],
+  ])("titles the reveal failure per platform (%s)", async (platform, title) => {
+    vi.stubGlobal("navigator", { platform });
+    harness.clicked = "reveal-in-folder";
+    harness.showInFolder.mockRejectedValue(
+      new Error("File or folder not found: /repo/output/video.mp4"),
+    );
+
+    await showFileReferenceContextMenu({
+      path: "/repo/output/video.mp4",
+      revealPath: "/repo/output/video.mp4",
+      position: { x: 12, y: 34 },
+      onReferenceInChat: undefined,
+    });
+
+    expect(harness.toast).toHaveBeenCalledWith({
+      type: "error",
+      title,
+      description: "File or folder not found: /repo/output/video.mp4",
     });
   });
 

--- a/apps/web/src/lib/fileReferenceContextMenu.ts
+++ b/apps/web/src/lib/fileReferenceContextMenu.ts
@@ -2,23 +2,13 @@
 // Purpose: Right-click menu shared by file rows, file previews, and chat file
 //          links (editor explorer, changed-file lists, dock file pane).
 // Layer: Web UI helpers
-// Exports: showFileReferenceContextMenu, getRevealInFolderLabel
+// Exports: showFileReferenceContextMenu
 
 import { formatSelectionLabel, type ChatFileReference } from "~/lib/chatReferences";
 import { copyTextToClipboard } from "~/hooks/useCopyToClipboard";
-import { getNavigatorPlatform, isMacPlatform, isWindowsPlatform } from "~/lib/utils";
+import { showFileManagerErrorToast } from "~/lib/fileManagerErrorToast";
+import { resolveFileManagerActionLabel } from "~/lib/fileManagerNaming";
 import { readNativeApi } from "~/nativeApi";
-import { toastManager } from "~/components/ui/toast";
-
-export function getRevealInFolderLabel(platform: string): string {
-  if (isWindowsPlatform(platform)) {
-    return "Open in Explorer";
-  }
-  if (isMacPlatform(platform)) {
-    return "Reveal in Finder";
-  }
-  return "Show in folder";
-}
 
 // Right-click menu shared by explorer rows, changed-file rows, and the file
 // preview. Falls back to a DOM menu outside the desktop app.
@@ -74,7 +64,7 @@ export async function showFileReferenceContextMenu(input: {
         ? [
             {
               id: "reveal-in-folder" as const,
-              label: getRevealInFolderLabel(getNavigatorPlatform()),
+              label: resolveFileManagerActionLabel("file"),
             },
           ]
         : []),
@@ -94,12 +84,7 @@ export async function showFileReferenceContextMenu(input: {
     try {
       await api.shell.showInFolder(revealPath);
     } catch (error) {
-      toastManager.add({
-        type: "error",
-        title: "Unable to reveal file",
-        description:
-          error instanceof Error ? error.message : "An unknown error occurred opening the file.",
-      });
+      showFileManagerErrorToast({ kind: "file", error });
     }
     return;
   }


### PR DESCRIPTION
## Summary

- centralize platform- and target-specific file-manager labels and error copy in a pure web helper
- use a thin toast adapter across the project menu, file references, editor metadata, and Studio environment surfaces
- preserve `showInFolder` while explicitly testing folders through `shell.openPath` and files through `shell.showItemInFolder`
- keep server file-manager launch behavior unchanged

## Focused verification

- web naming, toast, file-reference, and editor metadata: 41 passed
- Sidebar and Environment guards: 125 passed
- desktop file/folder dispatch: 12 passed
- server file-manager case: 1 passed, 23 skipped by the focused filter
- `git show --check`: clean

The full Windows run of `apps/server/src/open.test.ts` produced 22 passes and two unrelated baseline failures: Linux terminal selection expected `konsole` but found `x-terminal-emulator`, and Windows Store VS Code discovery returned false. Neither `apps/server/src/open.ts` nor `apps/server/src/open.test.ts` is changed by this PR.

## Verification not run

Per the task constraints, `bun fmt`, `bun lint`, and `bun typecheck` were not run. Native file-manager UI smoke checks on macOS/Linux also remain outside this Windows-only environment.