### PR TITLE
truncate oversized working-tree patches instead of hard-failing

### DIFF
--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -301,9 +301,79 @@ it.layer(TestLayer)("git integration", (it) => {
         yield* writeTextFile(path.join(tmp, "generated.ts"), updated);
 
         const result = yield* core.readUnstagedPatch(tmp);
-        expect(result.patch.length).toBeLessThanOrEqual(1_000_000 * 2);
+        expect(Buffer.byteLength(result.patch, "utf8")).toBeLessThanOrEqual(1_000_000);
         expect(result.truncated).toBe(true);
         expect(result.patch).toContain("diff --git a/generated.ts b/generated.ts");
+      }),
+    );
+
+    it.effect("shares one byte budget across tracked and untracked patch segments", () =>
+      Effect.gen(function* () {
+        const core = yield* GitCore;
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+
+        yield* writeTextFile(path.join(tmp, "tracked.txt"), "x\n".repeat(150_000));
+        yield* git(tmp, ["add", "tracked.txt"]);
+        yield* git(tmp, ["commit", "-m", "add tracked fixture"]);
+        yield* writeTextFile(path.join(tmp, "tracked.txt"), "y\n".repeat(150_000));
+        yield* writeTextFile(path.join(tmp, "untracked.txt"), "z\n".repeat(300_000));
+
+        const result = yield* core.readUnstagedPatch(tmp);
+        expect(Buffer.byteLength(result.patch, "utf8")).toBeLessThanOrEqual(1_000_000);
+        expect(result.truncated).toBe(true);
+        expect(result.patch).toContain("diff --git a/tracked.txt b/tracked.txt");
+        expect(result.patch).toContain("diff --git a/untracked.txt b/untracked.txt");
+      }),
+    );
+
+    it.effect("stops deterministically after the first untracked patch exhausts the budget", () =>
+      Effect.gen(function* () {
+        const realCore = yield* GitCore;
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        yield* writeTextFile(path.join(tmp, "a-first.txt"), "a\n".repeat(200));
+        yield* writeTextFile(path.join(tmp, "b-second.txt"), "b\n".repeat(200));
+        const diffedFiles: string[] = [];
+        const core = yield* makeIsolatedGitCore((input) => {
+          if (input.operation === "GitCore.readUnstagedPatch.untrackedPatch") {
+            diffedFiles.push(input.args.at(-1) ?? "");
+            return realCore.execute({ ...input, maxOutputBytes: 64 });
+          }
+          return realCore.execute(input);
+        });
+
+        const result = yield* core.readUnstagedPatch(tmp);
+        expect(result.truncated).toBe(true);
+        expect(diffedFiles).toEqual(["a-first.txt"]);
+      }),
+    );
+
+    it.effect("surfaces an untracked patch read failure", () =>
+      Effect.gen(function* () {
+        const realCore = yield* GitCore;
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        yield* writeTextFile(path.join(tmp, "vanished.txt"), "content\n");
+        const core = yield* makeIsolatedGitCore((input) => {
+          if (input.operation === "GitCore.readUnstagedPatch.untrackedPatch") {
+            return Effect.succeed({
+              code: 1,
+              stdout: "",
+              stderr: "error: Could not access 'vanished.txt'",
+            });
+          }
+          return realCore.execute(input);
+        });
+
+        const result = yield* Effect.result(core.readUnstagedPatch(tmp));
+        expect(result._tag).toBe("Failure");
+        if (result._tag === "Failure") {
+          expect(result.failure).toMatchObject({
+            operation: "GitCore.readUnstagedPatch.untrackedPatch",
+            detail: "error: Could not access 'vanished.txt'",
+          });
+        }
       }),
     );
 
@@ -372,6 +442,24 @@ it.layer(TestLayer)("git integration", (it) => {
         expect(text).toBe(new TextDecoder().decode(bytes).slice(0, 16));
         expect(truncated).toBe(true);
         expect(received).toEqual(records);
+      }),
+    );
+
+    it.effect("retains a byte-safe UTF-8 prefix without splitting multibyte text", () =>
+      Effect.gen(function* () {
+        const bytes = new TextEncoder().encode("🙂éx");
+        const { text, truncated } = yield* collectGitOutput(
+          { operation: "test utf8 output", cwd: process.cwd(), args: ["diff"] },
+          Stream.fromIterable(Array.from(bytes, (byte) => Uint8Array.of(byte))),
+          5,
+          undefined,
+          "truncate",
+        );
+
+        expect(text).toBe("🙂");
+        expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(5);
+        expect(text).not.toContain("�");
+        expect(truncated).toBe(true);
       }),
     );
 
@@ -2830,7 +2918,7 @@ it.layer(TestLayer)("git integration", (it) => {
 
         const unstaged = yield* core.readUnstagedPatch(tmp);
         expect(unstaged.truncated).toBe(true);
-        expect(unstaged.patch.length).toBeLessThan(1_000_000 * 2);
+        expect(Buffer.byteLength(unstaged.patch, "utf8")).toBeLessThanOrEqual(1_000_000);
 
         yield* git(tmp, ["add", "large.txt"]);
         yield* git(tmp, ["commit", "-m", "add large tracked text"]);

--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -377,6 +377,24 @@ it.layer(TestLayer)("git integration", (it) => {
       }),
     );
 
+    it.effect("accepts an untracked patch when Git emits a line-ending warning", () =>
+      Effect.gen(function* () {
+        const core = yield* GitCore;
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        yield* git(tmp, ["config", "core.autocrlf", "true"]);
+        yield* writeTextFile(path.join(tmp, "untracked.txt"), "first line\nsecond line\n");
+
+        const stats = yield* core.readDiffStats(tmp, "unstaged");
+        const result = yield* core.readUnstagedPatch(tmp);
+
+        expect(stats).toEqual({ additions: 2, deletions: 0, fileCount: 1 });
+        expect(result.truncated).toBe(false);
+        expect(result.patch).toContain("diff --git a/untracked.txt b/untracked.txt");
+        expect(result.patch).toContain("+first line");
+      }),
+    );
+
     it.effect("keeps an ignored renamed symbolic link as a link in ref comparisons", () =>
       Effect.gen(function* () {
         const core = yield* GitCore;

--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -287,6 +287,26 @@ it.layer(TestLayer)("git integration", (it) => {
       );
     }
 
+    it.effect("truncates an oversized unstaged patch instead of failing", () =>
+      Effect.gen(function* () {
+        const core = yield* GitCore;
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+
+        const original = "x\n".repeat(400_000);
+        const updated = "y\n".repeat(400_000);
+        yield* writeTextFile(path.join(tmp, "generated.ts"), original);
+        yield* git(tmp, ["add", "generated.ts"]);
+        yield* git(tmp, ["commit", "-m", "add generated"]);
+        yield* writeTextFile(path.join(tmp, "generated.ts"), updated);
+
+        const result = yield* core.readUnstagedPatch(tmp);
+        expect(result.patch.length).toBeLessThanOrEqual(1_000_000 * 2);
+        expect(result.truncated).toBe(true);
+        expect(result.patch).toContain("diff --git a/generated.ts b/generated.ts");
+      }),
+    );
+
     it.effect("keeps an ignored renamed symbolic link as a link in ref comparisons", () =>
       Effect.gen(function* () {
         const core = yield* GitCore;
@@ -315,7 +335,7 @@ it.layer(TestLayer)("git integration", (it) => {
     it.effect("keeps progress lines after the retained prefix fills across chunks", () =>
       Effect.gen(function* () {
         const lines: string[] = [];
-        const output = yield* collectGitOutput(
+        const { text, truncated } = yield* collectGitOutput(
           { operation: "test output", cwd: process.cwd(), args: ["clone"] },
           Stream.fromIterable(
             ["first\nsecond\n", "third\nfourth\n"].map((text) => new TextEncoder().encode(text)),
@@ -327,7 +347,8 @@ it.layer(TestLayer)("git integration", (it) => {
             }),
           "truncate",
         );
-        expect(output).toBe("first\nse");
+        expect(text).toBe("first\nse");
+        expect(truncated).toBe(true);
         expect(lines).toEqual(["first", "second", "third", "fourth"]);
       }),
     );
@@ -337,7 +358,7 @@ it.layer(TestLayer)("git integration", (it) => {
         const records = ["R100", "old\r\nname", "new é\tname"];
         const bytes = new TextEncoder().encode(records.join("\0") + "\0");
         const received: string[] = [];
-        const output = yield* collectGitOutput(
+        const { text, truncated } = yield* collectGitOutput(
           { operation: "test paths", cwd: process.cwd(), args: ["diff"] },
           Stream.fromIterable(Array.from(bytes, (byte) => Uint8Array.of(byte))),
           16,
@@ -348,7 +369,8 @@ it.layer(TestLayer)("git integration", (it) => {
           "truncate",
           "\0",
         );
-        expect(output).toBe(new TextDecoder().decode(bytes).slice(0, 16));
+        expect(text).toBe(new TextDecoder().decode(bytes).slice(0, 16));
+        expect(truncated).toBe(true);
         expect(received).toEqual(records);
       }),
     );
@@ -2797,37 +2819,32 @@ it.layer(TestLayer)("git integration", (it) => {
       }),
     );
 
-    it.effect(
-      "reads large committed additions against a ref without changing other scope limits",
-      () =>
-        Effect.gen(function* () {
-          const core = yield* GitCore;
-          const tmp = yield* makeTmpDir();
-          yield* initRepoWithCommit(tmp);
-          const baseSha = yield* git(tmp, ["rev-parse", "HEAD"]);
-          const contents = "0123456789abcdef".repeat(75_000) + "\n";
-          yield* writeTextFile(path.join(tmp, "large.txt"), contents);
+    it.effect("truncates large untracked additions and still reads the committed ref patch", () =>
+      Effect.gen(function* () {
+        const core = yield* GitCore;
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        const baseSha = yield* git(tmp, ["rev-parse", "HEAD"]);
+        const contents = "0123456789abcdef".repeat(75_000) + "\n";
+        yield* writeTextFile(path.join(tmp, "large.txt"), contents);
 
-          const unstaged = yield* Effect.result(core.readUnstagedPatch(tmp));
-          expect(unstaged._tag).toBe("Failure");
-          if (unstaged._tag === "Failure") {
-            expect(unstaged.failure.detail).toContain("output exceeded 1000000 bytes");
-          }
+        const unstaged = yield* core.readUnstagedPatch(tmp);
+        expect(unstaged.truncated).toBe(true);
+        expect(unstaged.patch.length).toBeLessThan(1_000_000 * 2);
 
-          yield* git(tmp, ["add", "large.txt"]);
-          yield* git(tmp, ["commit", "-m", "add large tracked text"]);
-          const indexBefore = yield* Effect.promise(() =>
-            fs.readFile(path.join(tmp, ".git/index")),
-          );
-          const result = yield* core.readRefPatch(tmp, baseSha);
-          expect(result.patch).toContain("new file mode 100644");
-          expect(result.patch).toContain(`+${contents}`);
-          const indexAfter = yield* Effect.promise(() => fs.readFile(path.join(tmp, ".git/index")));
-          expect(indexAfter).toEqual(indexBefore);
-        }),
+        yield* git(tmp, ["add", "large.txt"]);
+        yield* git(tmp, ["commit", "-m", "add large tracked text"]);
+        const indexBefore = yield* Effect.promise(() => fs.readFile(path.join(tmp, ".git/index")));
+        const result = yield* core.readRefPatch(tmp, baseSha);
+        expect(result.truncated).toBe(false);
+        expect(result.patch).toContain("new file mode 100644");
+        expect(result.patch).toContain(`+${contents}`);
+        const indexAfter = yield* Effect.promise(() => fs.readFile(path.join(tmp, ".git/index")));
+        expect(indexAfter).toEqual(indexBefore);
+      }),
     );
 
-    it.effect("keeps reference addition patch capture finite and rejects overflow", () =>
+    it.effect("keeps reference addition patch capture finite by truncating overflow", () =>
       Effect.gen(function* () {
         const realCore = yield* GitCore;
         const tmp = yield* makeTmpDir();
@@ -2842,21 +2859,16 @@ it.layer(TestLayer)("git integration", (it) => {
           if (input.operation === "GitCore.readRefPatch.untrackedPatch") {
             requestedLimit = input.maxOutputBytes;
             requestedMode = input.outputMode;
-            // Exercise the real collector's overflow path with a small fixture.
+            // Exercise the real collector's truncate path with a small fixture.
             return realCore.execute({ ...input, maxOutputBytes: 128 });
           }
           return realCore.execute(input);
         });
-        const result = yield* Effect.result(core.readRefPatch(tmp, baseSha));
+        const result = yield* core.readRefPatch(tmp, baseSha);
         expect(requestedLimit).toBe(10_000_000);
-        expect(requestedMode).not.toBe("truncate");
-        expect(result._tag).toBe("Failure");
-        if (result._tag === "Failure") {
-          expect(result.failure).toMatchObject({
-            operation: "GitCore.readRefPatch.untrackedPatch",
-            detail: expect.stringContaining("output exceeded 128 bytes"),
-          });
-        }
+        expect(requestedMode).toBe("truncate");
+        expect(result.truncated).toBe(true);
+        expect(result.patch.length).toBeLessThan(1_000_000);
       }),
     );
 

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -53,6 +53,7 @@ import {
   type GitCoreShape,
   type ExecuteGitInput,
   type ExecuteGitResult,
+  type GitWorkingTreePatch,
 } from "../Services/GitCore.ts";
 import { ServerConfig } from "../../config.ts";
 
@@ -183,19 +184,70 @@ function hasNodeErrorCode(cause: unknown, code: string): boolean {
   );
 }
 
-function joinPatchSegments(segments: ReadonlyArray<string>): string {
-  let combined = "";
-  for (const segment of segments) {
-    if (segment.length === 0) continue;
-    if (combined.length > 0 && !combined.endsWith("\n")) {
-      combined += "\n";
-    }
-    combined += segment;
-    if (!combined.endsWith("\n")) {
-      combined += "\n";
-    }
+/** Returns the longest UTF-8 prefix that fits without splitting a code point. */
+function truncateUtf8Prefix(value: string, maxBytes: number): string {
+  if (maxBytes <= 0) return "";
+  const encoded = Buffer.from(value, "utf8");
+  if (encoded.byteLength <= maxBytes) return value;
+
+  let prefixEnd = maxBytes;
+  while (prefixEnd > 0 && ((encoded[prefixEnd] ?? 0) & 0xc0) === 0x80) {
+    prefixEnd -= 1;
   }
-  return combined;
+  return encoded.subarray(0, prefixEnd).toString("utf8");
+}
+
+interface PatchAccumulator {
+  readonly chunks: string[];
+  bytes: number;
+  truncated: boolean;
+  endsWithNewline: boolean;
+}
+
+function makePatchAccumulator(): PatchAccumulator {
+  return { chunks: [], bytes: 0, truncated: false, endsWithNewline: false };
+}
+
+function appendPatchSegment(
+  accumulator: PatchAccumulator,
+  segment: string,
+  segmentTruncated: boolean,
+  maxOutputBytes: number,
+): void {
+  if (accumulator.truncated) return;
+  if (segment.length === 0) {
+    accumulator.truncated = segmentTruncated;
+    return;
+  }
+
+  if (accumulator.bytes > 0 && !accumulator.endsWithNewline) {
+    if (accumulator.bytes >= maxOutputBytes) {
+      accumulator.truncated = true;
+      return;
+    }
+    accumulator.chunks.push("\n");
+    accumulator.bytes += 1;
+    accumulator.endsWithNewline = true;
+  }
+
+  const segmentBytes = Buffer.byteLength(segment, "utf8");
+  const remainingBytes = maxOutputBytes - accumulator.bytes;
+  const retained =
+    segmentBytes <= remainingBytes ? segment : truncateUtf8Prefix(segment, remainingBytes);
+  const retainedBytes = retained === segment ? segmentBytes : Buffer.byteLength(retained, "utf8");
+  if (retained.length > 0) {
+    accumulator.chunks.push(retained);
+    accumulator.bytes += retainedBytes;
+    accumulator.endsWithNewline = retained.endsWith("\n");
+  }
+  accumulator.truncated = segmentTruncated || retainedBytes < segmentBytes;
+}
+
+function toWorkingTreePatch(accumulator: PatchAccumulator): GitWorkingTreePatch {
+  return {
+    patch: accumulator.chunks.join(""),
+    truncated: accumulator.truncated,
+  };
 }
 
 function parseBranchLine(line: string): { name: string; current: boolean } | null {
@@ -597,12 +649,29 @@ export const collectGitOutput = Effect.fn(function* <E>(
   lineDelimiter: "\n" | "\0" = "\n",
 ): Effect.fn.Return<CollectedGitOutput, GitCommandError> {
   const decoder = new TextDecoder();
-  let bytes = 0;
+  let receivedBytes = 0;
+  let retainedBytes = 0;
   let text = "";
   let lineBuffer = "";
   let truncated = false;
+  let retainedPrefixComplete = false;
   const findSeparator = () =>
     lineDelimiter === "\0" ? lineBuffer.indexOf("\0") : lineBuffer.search(/[\r\n]/);
+
+  const appendRetainedPrefix = (decoded: string) => {
+    if (retainedPrefixComplete || decoded.length === 0) return;
+    const decodedBytes = Buffer.byteLength(decoded, "utf8");
+    const remainingBytes = maxOutputBytes - retainedBytes;
+    const retained =
+      decodedBytes <= remainingBytes ? decoded : truncateUtf8Prefix(decoded, remainingBytes);
+    const appendedBytes = retained === decoded ? decodedBytes : Buffer.byteLength(retained, "utf8");
+    text += retained;
+    retainedBytes += appendedBytes;
+    if (appendedBytes < decodedBytes) {
+      retainedPrefixComplete = true;
+      truncated = true;
+    }
+  };
 
   const emitCompleteLines = (flush: boolean) =>
     Effect.gen(function* () {
@@ -633,8 +702,8 @@ export const collectGitOutput = Effect.fn(function* <E>(
 
   yield* Stream.runForEach(stream, (chunk) =>
     Effect.gen(function* () {
-      bytes += chunk.byteLength;
-      if (bytes > maxOutputBytes) {
+      receivedBytes += chunk.byteLength;
+      if (receivedBytes > maxOutputBytes) {
         truncated = true;
         if (outputMode === "error") {
           return yield* new GitCommandError({
@@ -645,16 +714,13 @@ export const collectGitOutput = Effect.fn(function* <E>(
           });
         }
       }
-      // In truncate mode the retained prefix is complete once `text` is full:
-      // keep draining the pipe so the child can exit promptly, but skip the
-      // decoding and line-scanning work when no progress listener needs it.
-      if (outputMode === "truncate" && text.length >= maxOutputBytes && !onLine) {
+      // Once the retained UTF-8 prefix is complete, keep draining the pipe so
+      // the child can exit promptly, but skip decoding when no listener needs it.
+      if (outputMode === "truncate" && retainedPrefixComplete && !onLine) {
         return;
       }
       const decoded = decoder.decode(chunk, { stream: true });
-      if (text.length < maxOutputBytes) {
-        text += decoded.slice(0, maxOutputBytes - text.length);
-      }
+      appendRetainedPrefix(decoded);
       lineBuffer += decoded;
       yield* emitCompleteLines(false);
       if (outputMode === "truncate" && lineBuffer.length > maxOutputBytes) {
@@ -664,9 +730,7 @@ export const collectGitOutput = Effect.fn(function* <E>(
   ).pipe(Effect.mapError(toGitCommandError(input, "output stream failed.")));
 
   const remainder = decoder.decode();
-  if (text.length < maxOutputBytes) {
-    text += remainder.slice(0, maxOutputBytes - text.length);
-  }
+  appendRetainedPrefix(remainder);
   lineBuffer += remainder;
   yield* emitCompleteLines(true);
   return { text, truncated };
@@ -1695,46 +1759,73 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
     const readUntrackedPatches = (
       cwd: string,
       operationPrefix: string,
+      accumulator: PatchAccumulator,
       files?: ReadonlyArray<string>,
       maxOutputBytes = DEFAULT_MAX_OUTPUT_BYTES,
     ) => {
+      if (accumulator.truncated) {
+        return Effect.succeed(toWorkingTreePatch(accumulator));
+      }
       const resolveFiles: Effect.Effect<ReadonlyArray<string>, GitCommandError> = files
         ? Effect.succeed(files)
         : listUntrackedFiles(cwd, operationPrefix);
       return resolveFiles.pipe(
         Effect.flatMap((untrackedFiles) =>
-          Effect.forEach(
-            untrackedFiles,
-            (filePath) =>
+          Effect.gen(function* () {
+            // Sequential capture is intentional: parallel children would race for the shared
+            // budget and make the retained file prefix nondeterministic. Stop launching work as
+            // soon as the ordered prefix is full.
+            for (const filePath of untrackedFiles.toSorted()) {
+              if (accumulator.truncated) break;
+              const separatorBytes = accumulator.bytes > 0 && !accumulator.endsWithNewline ? 1 : 0;
+              const remainingBytes = maxOutputBytes - accumulator.bytes - separatorBytes;
+              if (remainingBytes <= 0) {
+                accumulator.truncated = true;
+                break;
+              }
+
               // Git diff omits untracked files, so synthesize a normal patch for each one.
-              executeGit(
-                `${operationPrefix}.untrackedPatch`,
-                cwd,
-                [
-                  "diff",
-                  "--no-index",
-                  "--patch",
-                  "--no-color",
-                  "--src-prefix=a/",
-                  "--dst-prefix=b/",
-                  "--",
-                  "/dev/null",
-                  filePath,
-                ],
-                {
-                  allowNonZeroExit: true,
-                  timeoutMs: WORKING_TREE_DIFF_TIMEOUT_MS,
-                  maxOutputBytes,
-                  outputMode: "truncate",
-                },
-              ).pipe(
-                Effect.map((result): { readonly patch: string; readonly truncated: boolean } => ({
-                  patch: result.stdout,
-                  truncated: result.stdoutTruncated === true,
-                })),
-              ),
-            { concurrency: MAX_UNTRACKED_DIFF_CONCURRENCY },
-          ),
+              const operation = `${operationPrefix}.untrackedPatch`;
+              const args = [
+                "diff",
+                "--no-index",
+                "--patch",
+                "--no-color",
+                "--src-prefix=a/",
+                "--dst-prefix=b/",
+                "--",
+                "/dev/null",
+                filePath,
+              ];
+              const result = yield* executeGit(operation, cwd, args, {
+                allowNonZeroExit: true,
+                timeoutMs: WORKING_TREE_DIFF_TIMEOUT_MS,
+                maxOutputBytes: remainingBytes,
+                outputMode: "truncate",
+              });
+              const stderr = result.stderr.trim();
+              if (
+                result.code !== 0 &&
+                !(result.code === 1 && stderr.length === 0 && result.stdout.length > 0)
+              ) {
+                return yield* createGitCommandError(
+                  operation,
+                  cwd,
+                  args,
+                  stderr.length > 0
+                    ? stderr
+                    : `${commandLabel(args)} failed: code=${result.code ?? "null"}`,
+                );
+              }
+              appendPatchSegment(
+                accumulator,
+                result.stdout,
+                result.stdoutTruncated === true,
+                maxOutputBytes,
+              );
+            }
+            return toWorkingTreePatch(accumulator);
+          }),
         ),
       );
     };
@@ -1840,12 +1931,14 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
             outputMode: "truncate",
           },
         );
-        const untrackedPatches = yield* readUntrackedPatches(cwd, "GitCore.readUnstagedPatch");
-
-        return {
-          patch: joinPatchSegments([tracked.stdout, ...untrackedPatches.map((p) => p.patch)]),
-          truncated: tracked.stdoutTruncated === true || untrackedPatches.some((p) => p.truncated),
-        };
+        const accumulator = makePatchAccumulator();
+        appendPatchSegment(
+          accumulator,
+          tracked.stdout,
+          tracked.stdoutTruncated === true,
+          DEFAULT_MAX_OUTPUT_BYTES,
+        );
+        return yield* readUntrackedPatches(cwd, "GitCore.readUnstagedPatch", accumulator);
       });
 
     const readStagedPatch: GitCoreShape["readStagedPatch"] = (cwd) =>
@@ -1974,16 +2067,19 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
           },
         );
 
-        const untrackedPatches = yield* readUntrackedPatches(
+        const accumulator = makePatchAccumulator();
+        appendPatchSegment(
+          accumulator,
+          tracked.stdout,
+          tracked.stdoutTruncated === true,
+          DEFAULT_MAX_OUTPUT_BYTES,
+        );
+        return yield* readUntrackedPatches(
           cwd,
           "GitCore.readWorkingTreePatch",
+          accumulator,
           untrackedFiles,
         );
-
-        return {
-          patch: joinPatchSegments([tracked.stdout, ...untrackedPatches.map((p) => p.patch)]),
-          truncated: tracked.stdoutTruncated === true || untrackedPatches.some((p) => p.truncated),
-        };
       });
 
     const readFileAtRev: GitCoreShape["readFileAtRev"] = (input) =>
@@ -2061,17 +2157,20 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
             outputMode: "truncate",
           },
         );
-        const untrackedPatches = yield* readUntrackedPatches(
+        const accumulator = makePatchAccumulator();
+        appendPatchSegment(
+          accumulator,
+          tracked.stdout,
+          tracked.stdoutTruncated === true,
+          10_000_000,
+        );
+        return yield* readUntrackedPatches(
           cwd,
           "GitCore.readBranchPatch",
+          accumulator,
           undefined,
           10_000_000,
         );
-
-        return {
-          patch: joinPatchSegments([tracked.stdout, ...untrackedPatches.map((p) => p.patch)]),
-          truncated: tracked.stdoutTruncated === true || untrackedPatches.some((p) => p.truncated),
-        };
       });
 
     const resolveCommitObjectId = (cwd: string, rev: string, operation: string) =>
@@ -2296,17 +2395,20 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
                 "GitCore.readRefPatch",
                 seededGitlinks,
               );
-              const untrackedPatches = yield* readUntrackedPatches(
+              const accumulator = makePatchAccumulator();
+              appendPatchSegment(
+                accumulator,
+                tracked.stdout,
+                tracked.stdoutTruncated === true,
+                10_000_000,
+              );
+              return yield* readUntrackedPatches(
                 cwd,
                 "GitCore.readRefPatch",
+                accumulator,
                 untrackedFiles,
                 10_000_000,
               );
-              return {
-                patch: joinPatchSegments([tracked.stdout, ...untrackedPatches.map((p) => p.patch)]),
-                truncated:
-                  tracked.stdoutTruncated === true || untrackedPatches.some((p) => p.truncated),
-              };
             }),
         );
       });

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -413,6 +413,13 @@ function createGitCommandError(
   });
 }
 
+function isSuccessfulNoIndexDiff(result: ExecuteGitResult): boolean {
+  // `--no-index` uses code 1 both for a normal difference and for some read errors.
+  // A produced diff record distinguishes the normal case. Stderr is not decisive because
+  // Git may emit advisory warnings (for example, line-ending conversion) alongside it.
+  return result.code === 0 || (result.code === 1 && result.stdout.length > 0);
+}
+
 const DIRTY_WORKTREE_PATTERN =
   /Your local changes to the following files would be overwritten by (?:checkout|merge):\s*([\s\S]*?)Please commit your changes or stash them/;
 const UNTRACKED_OVERWRITE_PATTERN =
@@ -1804,10 +1811,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
                 outputMode: "truncate",
               });
               const stderr = result.stderr.trim();
-              if (
-                result.code !== 0 &&
-                !(result.code === 1 && stderr.length === 0 && result.stdout.length > 0)
-              ) {
+              if (!isSuccessfulNoIndexDiff(result)) {
                 return yield* createGitCommandError(
                   operation,
                   cwd,
@@ -1833,7 +1837,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
     // `git diff --no-index` exits 1 both when it found differences (the expected
     // outcome for an untracked file vs /dev/null) and when it could not read the
     // path (e.g. the file vanished between `ls-files` and the diff). Only the former
-    // may be treated as success: it produces a numstat record and no stderr.
+    // may be treated as success: it produces a numstat record.
     const readUntrackedNumstats = (
       cwd: string,
       operationPrefix: string,
@@ -1855,10 +1859,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
               }).pipe(
                 Effect.flatMap((result) => {
                   const stderr = result.stderr.trim();
-                  if (
-                    result.code === 0 ||
-                    (result.code === 1 && stderr.length === 0 && result.stdout.length > 0)
-                  ) {
+                  if (isSuccessfulNoIndexDiff(result)) {
                     return Effect.succeed(result.stdout);
                   }
                   return Effect.fail(

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -583,6 +583,11 @@ const createTrace2Monitor = Effect.fn(function* (
   };
 });
 
+export interface CollectedGitOutput {
+  readonly text: string;
+  readonly truncated: boolean;
+}
+
 export const collectGitOutput = Effect.fn(function* <E>(
   input: Pick<ExecuteGitInput, "operation" | "cwd" | "args">,
   stream: Stream.Stream<Uint8Array, E>,
@@ -590,11 +595,12 @@ export const collectGitOutput = Effect.fn(function* <E>(
   onLine: ((line: string) => Effect.Effect<void, never>) | undefined,
   outputMode: "error" | "truncate",
   lineDelimiter: "\n" | "\0" = "\n",
-): Effect.fn.Return<string, GitCommandError> {
+): Effect.fn.Return<CollectedGitOutput, GitCommandError> {
   const decoder = new TextDecoder();
   let bytes = 0;
   let text = "";
   let lineBuffer = "";
+  let truncated = false;
   const findSeparator = () =>
     lineDelimiter === "\0" ? lineBuffer.indexOf("\0") : lineBuffer.search(/[\r\n]/);
 
@@ -627,21 +633,23 @@ export const collectGitOutput = Effect.fn(function* <E>(
 
   yield* Stream.runForEach(stream, (chunk) =>
     Effect.gen(function* () {
+      bytes += chunk.byteLength;
+      if (bytes > maxOutputBytes) {
+        truncated = true;
+        if (outputMode === "error") {
+          return yield* new GitCommandError({
+            operation: input.operation,
+            command: commandLabel(input.args),
+            cwd: input.cwd,
+            detail: `${commandLabel(input.args)} output exceeded ${maxOutputBytes} bytes and was truncated.`,
+          });
+        }
+      }
       // In truncate mode the retained prefix is complete once `text` is full:
       // keep draining the pipe so the child can exit promptly, but skip the
       // decoding and line-scanning work when no progress listener needs it.
-      // A capture limit must not stop later progress lines from reaching callers.
       if (outputMode === "truncate" && text.length >= maxOutputBytes && !onLine) {
         return;
-      }
-      bytes += chunk.byteLength;
-      if (bytes > maxOutputBytes && outputMode === "error") {
-        return yield* new GitCommandError({
-          operation: input.operation,
-          command: commandLabel(input.args),
-          cwd: input.cwd,
-          detail: `${commandLabel(input.args)} output exceeded ${maxOutputBytes} bytes and was truncated.`,
-        });
       }
       const decoded = decoder.decode(chunk, { stream: true });
       if (text.length < maxOutputBytes) {
@@ -661,7 +669,7 @@ export const collectGitOutput = Effect.fn(function* <E>(
   }
   lineBuffer += remainder;
   yield* emitCompleteLines(true);
-  return text;
+  return { text, truncated };
 });
 
 export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"] }) =>
@@ -733,7 +741,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
           // second cleanup attempt.
           yield* Effect.addFinalizer(() => child.kill().pipe(Effect.ignore));
 
-          const [stdout, stderr, exitCode] = yield* Effect.all(
+          const [stdoutResult, stderrResult, exitCode] = yield* Effect.all(
             [
               collectGitOutput(
                 commandInput,
@@ -760,7 +768,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
           yield* trace2Monitor.flush;
 
           if (!input.allowNonZeroExit && exitCode !== 0) {
-            const trimmedStderr = stderr.trim();
+            const trimmedStderr = stderrResult.text.trim();
             return yield* new GitCommandError({
               operation: commandInput.operation,
               command: commandLabel(commandInput.args),
@@ -772,7 +780,13 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
             });
           }
 
-          return { code: exitCode, stdout, stderr } satisfies ExecuteGitResult;
+          return {
+            code: exitCode,
+            stdout: stdoutResult.text,
+            stderr: stderrResult.text,
+            stdoutTruncated: stdoutResult.truncated,
+            stderrTruncated: stderrResult.truncated,
+          } satisfies ExecuteGitResult;
         });
 
         return yield* commandEffect.pipe(
@@ -801,7 +815,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
       cwd: string,
       args: readonly string[],
       options: ExecuteGitOptions = {},
-    ): Effect.Effect<{ code: number; stdout: string; stderr: string }, GitCommandError> =>
+    ): Effect.Effect<ExecuteGitResult, GitCommandError> =>
       execute({
         operation,
         cwd,
@@ -1711,8 +1725,14 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
                   allowNonZeroExit: true,
                   timeoutMs: WORKING_TREE_DIFF_TIMEOUT_MS,
                   maxOutputBytes,
+                  outputMode: "truncate",
                 },
-              ).pipe(Effect.map((result) => result.stdout)),
+              ).pipe(
+                Effect.map((result): { readonly patch: string; readonly truncated: boolean } => ({
+                  patch: result.stdout,
+                  truncated: result.stdoutTruncated === true,
+                })),
+              ),
             { concurrency: MAX_UNTRACKED_DIFF_CONCURRENCY },
           ),
         ),
@@ -1809,19 +1829,22 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
 
     const readUnstagedPatch: GitCoreShape["readUnstagedPatch"] = (cwd) =>
       Effect.gen(function* () {
-        const trackedPatch = yield* executeGit(
+        const tracked = yield* executeGit(
           "GitCore.readUnstagedPatch.trackedPatch",
           cwd,
           ["diff", "--patch", "--no-color", "--no-ext-diff"],
           {
             allowNonZeroExit: true,
             timeoutMs: WORKING_TREE_DIFF_TIMEOUT_MS,
+            maxOutputBytes: DEFAULT_MAX_OUTPUT_BYTES,
+            outputMode: "truncate",
           },
-        ).pipe(Effect.map((result) => result.stdout));
+        );
         const untrackedPatches = yield* readUntrackedPatches(cwd, "GitCore.readUnstagedPatch");
 
         return {
-          patch: joinPatchSegments([trackedPatch, ...untrackedPatches]),
+          patch: joinPatchSegments([tracked.stdout, ...untrackedPatches.map((p) => p.patch)]),
+          truncated: tracked.stdoutTruncated === true || untrackedPatches.some((p) => p.truncated),
         };
       });
 
@@ -1833,8 +1856,15 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
         {
           allowNonZeroExit: true,
           timeoutMs: WORKING_TREE_DIFF_TIMEOUT_MS,
+          maxOutputBytes: DEFAULT_MAX_OUTPUT_BYTES,
+          outputMode: "truncate",
         },
-      ).pipe(Effect.map((result) => ({ patch: result.stdout })));
+      ).pipe(
+        Effect.map((result) => ({
+          patch: result.stdout,
+          truncated: result.stdoutTruncated === true,
+        })),
+      );
 
     const readWorkingTreePatch: GitCoreShape["readWorkingTreePatch"] = (cwd, filePath) =>
       Effect.gen(function* () {
@@ -1925,7 +1955,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
           }
         }
 
-        const trackedPatch = yield* executeGit(
+        const tracked = yield* executeGit(
           "GitCore.readWorkingTreePatch.trackedPatch",
           cwd,
           [
@@ -1939,8 +1969,10 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
           {
             allowNonZeroExit: true,
             timeoutMs: WORKING_TREE_DIFF_TIMEOUT_MS,
+            maxOutputBytes: DEFAULT_MAX_OUTPUT_BYTES,
+            outputMode: "truncate",
           },
-        ).pipe(Effect.map((result) => result.stdout));
+        );
 
         const untrackedPatches = yield* readUntrackedPatches(
           cwd,
@@ -1949,7 +1981,8 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
         );
 
         return {
-          patch: joinPatchSegments([trackedPatch, ...untrackedPatches]),
+          patch: joinPatchSegments([tracked.stdout, ...untrackedPatches.map((p) => p.patch)]),
+          truncated: tracked.stdoutTruncated === true || untrackedPatches.some((p) => p.truncated),
         };
       });
 
@@ -2018,19 +2051,26 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
       Effect.gen(function* () {
         const mergeBase = yield* resolveBranchMergeBase(cwd);
 
-        const trackedPatch = yield* executeGit(
+        const tracked = yield* executeGit(
           "GitCore.readBranchPatch.trackedPatch",
           cwd,
           ["diff", "--patch", "--minimal", "--no-color", "--no-ext-diff", mergeBase],
           {
             timeoutMs: WORKING_TREE_DIFF_TIMEOUT_MS,
             maxOutputBytes: 10_000_000,
+            outputMode: "truncate",
           },
-        ).pipe(Effect.map((result) => result.stdout));
-        const untrackedPatches = yield* readUntrackedPatches(cwd, "GitCore.readBranchPatch");
+        );
+        const untrackedPatches = yield* readUntrackedPatches(
+          cwd,
+          "GitCore.readBranchPatch",
+          undefined,
+          10_000_000,
+        );
 
         return {
-          patch: joinPatchSegments([trackedPatch, ...untrackedPatches]),
+          patch: joinPatchSegments([tracked.stdout, ...untrackedPatches.map((p) => p.patch)]),
+          truncated: tracked.stdoutTruncated === true || untrackedPatches.some((p) => p.truncated),
         };
       });
 
@@ -2238,7 +2278,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
           "GitCore.readRefPatch",
           (env, seededGitlinks) =>
             Effect.gen(function* () {
-              const trackedPatch = yield* executeGit(
+              const tracked = yield* executeGit(
                 "GitCore.readRefPatch.trackedPatch",
                 cwd,
                 ["diff", "--patch", "--no-color", "--no-ext-diff", resolvedRef],
@@ -2246,8 +2286,9 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
                   env,
                   timeoutMs: WORKING_TREE_DIFF_TIMEOUT_MS,
                   maxOutputBytes: 10_000_000,
+                  outputMode: "truncate",
                 },
-              ).pipe(Effect.map((result) => result.stdout));
+              );
               const untrackedFiles = yield* listWorkingTreeAdditionsAgainstRef(
                 cwd,
                 resolvedRef,
@@ -2261,7 +2302,11 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
                 untrackedFiles,
                 10_000_000,
               );
-              return { patch: joinPatchSegments([trackedPatch, ...untrackedPatches]) };
+              return {
+                patch: joinPatchSegments([tracked.stdout, ...untrackedPatches.map((p) => p.patch)]),
+                truncated:
+                  tracked.stdoutTruncated === true || untrackedPatches.some((p) => p.truncated),
+              };
             }),
         );
       });

--- a/apps/server/src/git/Layers/GitManager.test.ts
+++ b/apps/server/src/git/Layers/GitManager.test.ts
@@ -459,7 +459,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           _tag: "GitManagerError",
           operation: "summarizeDiff",
         });
-        expect(result.failure.detail).toContain("truncated diff");
+        expect(result.failure.message).toContain("truncated diff");
       }
     }),
   );

--- a/apps/server/src/git/Layers/GitManager.test.ts
+++ b/apps/server/src/git/Layers/GitManager.test.ts
@@ -425,6 +425,45 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
+  it.effect("refuses to summarize a working-tree patch whose capture was truncated", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("synara-truncated-summary-");
+      yield* initRepo(repoDir);
+      yield* Effect.sync(() => {
+        fs.writeFileSync(path.join(repoDir, "oversized.txt"), "generated line\n".repeat(100_000));
+      });
+      let generationCalls = 0;
+      const { manager } = yield* makeManager({
+        textGeneration: {
+          generateDiffSummary: () => {
+            generationCalls += 1;
+            return Effect.succeed({ summary: "## Summary\n- Partial input" });
+          },
+        },
+      });
+
+      const captured = yield* manager.readWorkingTreeDiff({
+        cwd: repoDir,
+        scope: "workingTree",
+      });
+      expect(captured.truncated).toBe(true);
+
+      const result = yield* Effect.result(
+        manager.summarizeDiff({ cwd: repoDir, scope: "workingTree" }),
+      );
+
+      expect(result._tag).toBe("Failure");
+      expect(generationCalls).toBe(0);
+      if (result._tag === "Failure") {
+        expect(result.failure).toMatchObject({
+          _tag: "GitManagerError",
+          operation: "summarizeDiff",
+        });
+        expect(result.failure.detail).toContain("truncated diff");
+      }
+    }),
+  );
+
   it.effect("status includes PR metadata when branch already has an open PR", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("synara-git-manager-");

--- a/apps/server/src/git/Layers/GitManager.ts
+++ b/apps/server/src/git/Layers/GitManager.ts
@@ -1480,9 +1480,18 @@ export const makeGitManager = Effect.gen(function* () {
 
   // Resolve the patch server-side so large repository data never makes a client→RPC round trip.
   const summarizeDiff: GitManagerShape["summarizeDiff"] = Effect.fnUntraced(function* (input) {
-    const { patch } = yield* readWorkingTreeDiff({ cwd: input.cwd, scope: input.scope });
+    const { patch, truncated } = yield* readWorkingTreeDiff({
+      cwd: input.cwd,
+      scope: input.scope,
+    });
     if (patch.length === 0) {
       return yield* gitManagerError("summarizeDiff", "Cannot summarize an empty diff.");
+    }
+    if (truncated) {
+      return yield* gitManagerError(
+        "summarizeDiff",
+        "Cannot summarize a truncated diff. Narrow the changes and try again.",
+      );
     }
 
     const generated = yield* textGeneration.generateDiffSummary({

--- a/apps/server/src/git/Services/GitCore.ts
+++ b/apps/server/src/git/Services/GitCore.ts
@@ -55,6 +55,8 @@ export interface ExecuteGitResult {
   readonly code: number;
   readonly stdout: string;
   readonly stderr: string;
+  readonly stdoutTruncated?: boolean;
+  readonly stderrTruncated?: boolean;
 }
 
 export interface GitStatusDetails extends Omit<GitStatusResult, "pr"> {
@@ -123,6 +125,7 @@ export interface GitRangeContext {
 
 export interface GitWorkingTreePatch {
   patch: string;
+  truncated: boolean;
 }
 
 export interface GitRenameBranchInput {

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -95,6 +95,7 @@ import { DiffLineBlamePopover, type DiffLineBlameTarget } from "./DiffLineBlameP
 import { DiffPanelCompareRefMenuSection } from "./DiffPanelCompareRefMenuSection";
 import { DiffPanelPatchViewport } from "./DiffPanelPatchViewport";
 import { DiffPanelToolbar } from "./DiffPanelToolbar";
+import { DiffTruncationWarning } from "./DiffTruncationWarning";
 import { ReviewFileTreePanel } from "./ReviewFileTreePanel";
 import { ComposerPickerMenuPopup } from "./chat/ComposerPickerMenuPopup";
 import { closestThroughShadow } from "./chat/chatSelectionActions";
@@ -154,7 +155,7 @@ function EditorDiffOptionsMenu(props: {
   diffWordWrap: boolean;
   diffIgnoreWhitespace: boolean;
   diffCopyText: string | null;
-  isDiffCopied: boolean;
+  diffCopyLabel: string;
   allFilesCollapsed: boolean;
   changeMarkersEnabled: boolean;
   diffRenderMode: DiffRenderMode;
@@ -324,7 +325,7 @@ function EditorDiffOptionsMenu(props: {
               }}
             >
               <CopyIcon className={EDITOR_DIFF_OPTIONS_MENU_ICON_CLASS_NAME} />
-              <span>{props.isDiffCopied ? "Copied diff" : "Copy diff"}</span>
+              <span>{props.diffCopyLabel}</span>
             </MenuItem>
           ) : null}
           {props.renderableFiles.length > 0 ? (
@@ -358,7 +359,7 @@ function EditorDiffControls(props: {
   diffWordWrap: boolean;
   diffIgnoreWhitespace: boolean;
   diffCopyText: string | null;
-  isDiffCopied: boolean;
+  diffCopyLabel: string;
   allFilesCollapsed: boolean;
   changeMarkersEnabled: boolean;
   changeNavigation: DiffPanelChangeNavigation;
@@ -394,7 +395,7 @@ function EditorDiffControls(props: {
         diffWordWrap={props.diffWordWrap}
         diffIgnoreWhitespace={props.diffIgnoreWhitespace}
         diffCopyText={props.diffCopyText}
-        isDiffCopied={props.isDiffCopied}
+        diffCopyLabel={props.diffCopyLabel}
         allFilesCollapsed={props.allFilesCollapsed}
         changeMarkersEnabled={props.changeMarkersEnabled}
         diffRenderMode={props.diffRenderMode}
@@ -801,6 +802,7 @@ export default function DiffPanel({
     [diffViewKind, repoDiffScope, selectedTurnId],
   );
   const activeReviewPatch = diffViewKind === "repo" ? repoPatch : selectedPatch;
+  const activeReviewTruncated = diffViewKind === "repo" && repoDiffQuery.data?.truncated === true;
   const activeReviewError = diffViewKind === "repo" ? repoDiffError : checkpointDiffError;
   const activeReviewIsLoading =
     diffViewKind === "repo" ? repoDiffQuery.isLoading : isLoadingCheckpointDiff;
@@ -816,7 +818,17 @@ export default function DiffPanel({
   // theme). Keeping `resolvedTheme` out of the parse cache scope and these deps
   // avoids re-parsing the whole patch on every light/dark toggle.
   const renderablePatch = useMemo(() => getRenderablePatch(activeReviewPatch), [activeReviewPatch]);
-  const diffCopyText = useMemo(() => resolveDiffCopyText(activeReviewPatch), [activeReviewPatch]);
+  const diffCopyText = useMemo(
+    () => resolveDiffCopyText(activeReviewPatch, activeReviewTruncated),
+    [activeReviewPatch, activeReviewTruncated],
+  );
+  const diffCopyLabel = isDiffCopied
+    ? activeReviewTruncated
+      ? "Copied partial diff"
+      : "Copied diff"
+    : activeReviewTruncated
+      ? "Copy partial diff"
+      : "Copy diff";
   const renderableFiles = useMemo(() => {
     if (!renderablePatch || renderablePatch.kind !== "files") {
       return [];
@@ -1283,7 +1295,7 @@ export default function DiffPanel({
           diffWordWrap={diffWordWrap}
           diffIgnoreWhitespace={diffIgnoreWhitespace}
           diffCopyText={diffCopyText}
-          isDiffCopied={isDiffCopied}
+          diffCopyLabel={diffCopyLabel}
           allFilesCollapsed={allFilesCollapsed}
           changeMarkersEnabled={changeMarkersEnabled}
           changeNavigation={changeNavigation}
@@ -1307,12 +1319,12 @@ export default function DiffPanel({
       changeNavigation,
       copyDiff,
       diffCopyText,
+      diffCopyLabel,
       diffIgnoreWhitespace,
       diffRenderMode,
       diffWordWrap,
       hideHeader,
       inferredCheckpointTurnCountByTurnId,
-      isDiffCopied,
       orderedTurnDiffSummaries,
       renderableFiles,
       repoDiffCompareRef,
@@ -1373,7 +1385,7 @@ export default function DiffPanel({
           diffWordWrap={diffWordWrap}
           diffIgnoreWhitespace={diffIgnoreWhitespace}
           diffCopyText={diffCopyText}
-          isDiffCopied={isDiffCopied}
+          diffCopyLabel={diffCopyLabel}
           reloading={activeDiffIsFetching}
           allFilesCollapsed={allFilesCollapsed}
           changeMarkersEnabled={changeMarkersEnabled}
@@ -1422,13 +1434,13 @@ export default function DiffPanel({
       changeNavigation,
       copyDiff,
       diffCopyText,
+      diffCopyLabel,
       diffIgnoreWhitespace,
       diffRenderMode,
       diffWordWrap,
       fileTreeOpen,
       hideHeader,
       inferredCheckpointTurnCountByTurnId,
-      isDiffCopied,
       handleScopePickerOpenChange,
       handleDiffReload,
       onClosePanel,
@@ -1484,6 +1496,7 @@ export default function DiffPanel({
             className="diff-panel-viewport relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
             onMouseUp={diffSelectionAction.onContainerMouseUp}
           >
+            {activeReviewTruncated ? <DiffTruncationWarning className="m-2 mb-0" /> : null}
             <DiffPanelPatchViewport
               renderablePatch={renderablePatch}
               renderableFiles={renderableFiles}

--- a/apps/web/src/components/DiffPanelToolbar.tsx
+++ b/apps/web/src/components/DiffPanelToolbar.tsx
@@ -105,7 +105,7 @@ interface DiffPanelToolbarProps {
   diffWordWrap: boolean;
   diffIgnoreWhitespace: boolean;
   diffCopyText: string | null;
-  isDiffCopied: boolean;
+  diffCopyLabel: string;
   reloading: boolean;
   allFilesCollapsed: boolean;
   changeMarkersEnabled: boolean;
@@ -398,7 +398,7 @@ export const DiffPanelToolbar = function DiffPanelToolbar(props: DiffPanelToolba
                     }}
                   >
                     <CopyIcon className={DIFF_PANEL_MENU_ICON_CLASS_NAME} />
-                    <span>{props.isDiffCopied ? "Copied diff" : "Copy diff"}</span>
+                    <span>{props.diffCopyLabel}</span>
                   </MenuItem>
                 ) : null}
                 {props.renderableFiles.length > 0 ? (

--- a/apps/web/src/components/DiffTruncationWarning.browser.tsx
+++ b/apps/web/src/components/DiffTruncationWarning.browser.tsx
@@ -1,0 +1,15 @@
+import "../index.css";
+
+import { page } from "vitest/browser";
+import { expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { DiffTruncationWarning } from "./DiffTruncationWarning";
+
+it("clearly identifies a size-bounded patch as a partial diff", async () => {
+  await render(<DiffTruncationWarning />);
+
+  await expect.element(page.getByRole("alert")).toBeVisible();
+  await expect.element(page.getByText("Partial diff", { exact: true })).toBeVisible();
+  await expect.element(page.getByText(/some files or changes may be missing/i)).toBeVisible();
+});

--- a/apps/web/src/components/DiffTruncationWarning.tsx
+++ b/apps/web/src/components/DiffTruncationWarning.tsx
@@ -1,0 +1,26 @@
+// FILE: DiffTruncationWarning.tsx
+// Purpose: Shared warning for repository diff surfaces backed by size-bounded patch reads.
+// Layer: Web diff presentation
+
+import type { HTMLAttributes } from "react";
+
+import { TriangleAlertIcon } from "~/lib/icons";
+import { cn } from "~/lib/utils";
+import { Alert, AlertDescription, AlertTitle } from "./ui/alert";
+
+export const DEFAULT_DIFF_TRUNCATION_MESSAGE =
+  "Synara stopped reading at the diff size limit. Some files or changes may be missing.";
+
+export function DiffTruncationWarning({
+  className,
+  children = DEFAULT_DIFF_TRUNCATION_MESSAGE,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <Alert {...props} variant="warning" size="sm" className={cn("shrink-0", className)}>
+      <TriangleAlertIcon aria-hidden="true" />
+      <AlertTitle>Partial diff</AlertTitle>
+      <AlertDescription>{children}</AlertDescription>
+    </Alert>
+  );
+}

--- a/apps/web/src/components/WorkspaceFilePreview.editing.browser.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.editing.browser.tsx
@@ -88,7 +88,7 @@ afterEach(async () => {
 it("requests only the resolved preview file for gutters and refreshes it on file events", async () => {
   const resolvedPath = "packages/app/src/app.ts";
   const readFile = vi.fn().mockResolvedValue(loadedFile({ relativePath: resolvedPath }));
-  const readWorkingTreeDiff = vi.fn().mockResolvedValue({ patch: "" });
+  const readWorkingTreeDiff = vi.fn().mockResolvedValue({ patch: "", truncated: false });
   const subscription: { listener?: (event: ProjectFileChangeEvent) => void } = {};
   const onFileChange = vi.fn(
     (_input: ProjectWatchFileInput, listener: (event: ProjectFileChangeEvent) => void) => {
@@ -121,6 +121,31 @@ it("requests only the resolved preview file for gutters and refreshes it on file
       filePath: resolvedPath,
     });
     await view.unmount();
+  } finally {
+    restoreNativeApi();
+  }
+});
+
+it("warns when a file's working-tree change markers come from a partial diff", async () => {
+  const readFile = vi.fn().mockResolvedValue(loadedFile());
+  const readWorkingTreeDiff = vi.fn().mockResolvedValue({
+    patch: "diff --git a/src/app.ts b/src/app.ts\n+partial\n",
+    truncated: true,
+  });
+  const restoreNativeApi = installNativeApi({
+    projects: { readFile, onFileChange: () => () => undefined },
+    git: { readWorkingTreeDiff },
+  } as unknown as NativeApi);
+
+  try {
+    await render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <WorkspaceFilePreview workspaceRoot={WORKSPACE_ROOT} filePath={FILE_PATH} />
+      </QueryClientProvider>,
+    );
+
+    await expect.element(page.getByText("Partial diff", { exact: true })).toBeVisible();
+    await expect.element(page.getByText(/change markers may be incomplete/i)).toBeVisible();
   } finally {
     restoreNativeApi();
   }

--- a/apps/web/src/components/WorkspaceFilePreview.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.tsx
@@ -86,6 +86,7 @@ import { cn } from "~/lib/utils";
 import { resolveWorkspaceFileEditorReadOnlyReason } from "~/lib/workspaceFileEditor";
 import { readNativeApi } from "~/nativeApi";
 import ChatMarkdown from "./ChatMarkdown";
+import { DiffTruncationWarning } from "./DiffTruncationWarning";
 import { FileLineCommentBox } from "./chat/FileLineCommentBox";
 import { PanelStateMessage } from "./chat/PanelStateMessage";
 import { useFileLineCommenting } from "./chat/useFileLineCommenting";
@@ -1269,6 +1270,12 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
               ? fileReadError.message
               : "Could not refresh file."}
         </div>
+      ) : null}
+      {changeGutterEnabled && workingTreeDiffQuery.data?.truncated === true ? (
+        <DiffTruncationWarning className="rounded-none border-x-0 border-t-0">
+          Only part of this file&apos;s working-tree diff is available. Change markers may be
+          incomplete.
+        </DiffTruncationWarning>
       ) : null}
       {locatingOutOfRootFile ? (
         <FilePreviewLoadingState />

--- a/apps/web/src/components/chat/GitPanel.tsx
+++ b/apps/web/src/components/chat/GitPanel.tsx
@@ -35,6 +35,7 @@ import { createProjectSelector, createThreadSelector } from "~/storeSelectors";
 import { Alert } from "../ui/alert";
 import { Button } from "../ui/button";
 import { IconButton } from "../ui/icon-button";
+import { DiffTruncationWarning } from "../DiffTruncationWarning";
 import { DOCK_HEADER_ICON_BUTTON_CLASS } from "./chatHeaderControls";
 import { DiffStat } from "./DiffStatLabel";
 import { DockPaneHeader } from "./DockPaneHeader";
@@ -270,6 +271,7 @@ export function GitPanel(props: {
   const selectedPath = selected?.path ?? null;
 
   const isLoading = stagedQuery.isLoading || unstagedQuery.isLoading;
+  const truncated = stagedQuery.data?.truncated === true || unstagedQuery.data?.truncated === true;
   const error =
     stagedQuery.error instanceof Error
       ? stagedQuery.error.message
@@ -303,6 +305,12 @@ export function GitPanel(props: {
       />
 
       <div className="flex max-h-[48%] min-h-0 shrink-0 flex-col gap-2 overflow-auto px-1.5 py-2">
+        {truncated ? (
+          <DiffTruncationWarning>
+            Synara stopped reading source-control changes at the diff size limit. Some files or
+            changes may be missing; bulk actions only affect the files shown.
+          </DiffTruncationWarning>
+        ) : null}
         {error ? (
           <Alert variant="error" size="sm" className="text-destructive">
             {error}

--- a/apps/web/src/lib/diffRendering.test.ts
+++ b/apps/web/src/lib/diffRendering.test.ts
@@ -12,6 +12,7 @@ import {
   getRenderablePatch,
   hasUneditableGitMode,
   resolveDiffCopyText,
+  PARTIAL_DIFF_COPY_NOTICE,
   resolveFileDiffStatByChangedPath,
   resolveFileDiffPath,
   resolveFileDiffPrevPath,
@@ -170,6 +171,12 @@ describe("resolveDiffCopyText", () => {
     ].join("\n");
 
     expect(resolveDiffCopyText(patch)).toBe(patch);
+  });
+
+  it("marks truncated clipboard content as a partial diff", () => {
+    const patch = "diff --git a/a.ts b/a.ts\n+partial  ";
+
+    expect(resolveDiffCopyText(patch, true)).toBe(`${patch}\n\n${PARTIAL_DIFF_COPY_NOTICE}\n`);
   });
 
   it("does not expose empty or missing patches as copyable", () => {

--- a/apps/web/src/lib/diffRendering.ts
+++ b/apps/web/src/lib/diffRendering.ts
@@ -208,12 +208,21 @@ export function buildPatchCacheKey(patch: string, scope = "diff-panel"): string 
   return `${scope}:${normalizedPatch.length}:${primary}:${secondary}`;
 }
 
+export const PARTIAL_DIFF_COPY_NOTICE =
+  "[Synara: partial diff. Output was truncated at the size limit; some files or changes may be missing.]";
+
 // Returns copyable source text for diff surfaces without depending on virtualized DOM rows.
-export function resolveDiffCopyText(patch: string | undefined): string | null {
+// A truncation notice travels with partial clipboard content so it cannot be mistaken for a
+// complete patch after it leaves Synara.
+export function resolveDiffCopyText(patch: string | undefined, truncated = false): string | null {
   if (typeof patch !== "string") {
     return null;
   }
-  return patch.trim().length > 0 ? patch : null;
+  if (patch.trim().length === 0) {
+    return null;
+  }
+  const noticeSeparator = patch.endsWith("\n") ? "\n" : "\n\n";
+  return truncated ? `${patch}${noticeSeparator}${PARTIAL_DIFF_COPY_NOTICE}\n` : patch;
 }
 
 export type RenderablePatch =

--- a/apps/web/src/lib/gitReactQuery.test.ts
+++ b/apps/web/src/lib/gitReactQuery.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 const { readWorkingTreeDiff } = vi.hoisted(() => ({
   readWorkingTreeDiff: vi.fn(async (input: { filePath?: string }) => ({
     patch: input.filePath ?? "all",
+    truncated: false,
   })),
 }));
 vi.mock("../nativeApi", () => ({ ensureNativeApi: () => ({ git: { readWorkingTreeDiff } }) }));
@@ -36,9 +37,15 @@ describe("file-scoped working tree diffs", () => {
   it("keeps each file separate from other files and the repository-wide cache", async () => {
     const client = new QueryClient();
     const query = (filePath?: string) => gitWorkingTreeDiffQueryOptions({ cwd: "/repo", filePath });
-    expect(await client.fetchQuery(query())).toEqual({ patch: "all" });
-    expect(await client.fetchQuery(query("src/a.ts"))).toEqual({ patch: "src/a.ts" });
-    expect(await client.fetchQuery(query("src/b.ts"))).toEqual({ patch: "src/b.ts" });
+    expect(await client.fetchQuery(query())).toEqual({ patch: "all", truncated: false });
+    expect(await client.fetchQuery(query("src/a.ts"))).toEqual({
+      patch: "src/a.ts",
+      truncated: false,
+    });
+    expect(await client.fetchQuery(query("src/b.ts"))).toEqual({
+      patch: "src/b.ts",
+      truncated: false,
+    });
     expect(readWorkingTreeDiff).toHaveBeenCalledWith({
       cwd: "/repo",
       scope: "workingTree",

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -472,6 +472,7 @@ export type GitStatusStreamEvent = typeof GitStatusStreamEvent.Type;
 
 export const GitReadWorkingTreeDiffResult = Schema.Struct({
   patch: Schema.String,
+  truncated: Schema.Boolean,
 });
 export type GitReadWorkingTreeDiffResult = typeof GitReadWorkingTreeDiffResult.Type;
 


### PR DESCRIPTION
Supersedes #1134 for integration and automated review only.

This owner-authored replacement preserves the original commit authors and the contribution from @santhiprakash; see #1134. It began from the exact repaired #1134 head. During replacement validation, two additional PR-scoped correctness fixes were independently reproduced and added: valid untracked diffs that also emit Git line-ending warnings remain readable, and truncated working-tree patches are rejected before summary generation can present partial input as complete.

Why this replacement exists: Cursor Bugbot could not certify the contributor-authored fork PR because the GitHub account linked to Cursor did not match the PR author. #1134 remains open while this replacement validates.

Validation on the final exact head:
- focused GitCore and GitManager tests: 204 passed
- focused web unit tests: 56 passed
- focused browser tests: 22 passed
- scoped formatter check passed
- git diff --check passed
- full GitHub CI passed
- automatic Cursor Bugbot passed with no issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core git output handling and patch assembly used across review, source control, and summarization; truncation could hide changes from users or skip summaries until they narrow scope.
> 
> **Overview**
> Large repo diffs no longer blow up patch reads: **GitCore** caps output (default 1MB, higher for branch/ref scopes), returns `{ patch, truncated }`, and uses UTF-8-safe truncation plus a shared byte budget across tracked and untracked segments. Untracked `--no-index` diffs are built **sequentially** in sorted order so truncation is deterministic; stderr warnings (e.g. line endings) no longer fail valid diffs.
> 
> **GitManager** blocks AI diff summarization when the capture was truncated. The web surfaces show a **Partial diff** alert (Diff panel, Git panel, file preview change markers), adjust copy-to-clipboard labels/text with a truncation notice, and the contract/RPC type for working-tree diffs now includes `truncated`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57efc6e8485e8a6bef7c587bb38ed9b5031b90c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->