### PR TITLE
Canonicalize model display names through one shared humanizer

### DIFF
--- a/apps/server/src/provider/Layers/DevinAdapter.test.ts
+++ b/apps/server/src/provider/Layers/DevinAdapter.test.ts
@@ -1617,6 +1617,24 @@ describe("Devin CLI model discovery", () => {
     });
   });
 
+  it("humanizes family slugs when the CLI omits a label", () => {
+    const [model] = mergeDevinModelDescriptors([
+      parseDevinCliModelList(
+        JSON.stringify({
+          families: [
+            {
+              family_uid: "swe-1-7",
+              slug: "swe-1-7",
+              variants: [{ model_uid: "swe-1-7" }],
+            },
+          ],
+        }),
+      ),
+    ]);
+
+    expect(model?.name).toBe("SWE 1.7");
+  });
+
   it("exposes thinking and long-context toggles for Claude-style variants", () => {
     const models = parseDevinCliModelList(
       JSON.stringify({

--- a/apps/server/src/provider/Layers/DevinAdapter.test.ts
+++ b/apps/server/src/provider/Layers/DevinAdapter.test.ts
@@ -1617,8 +1617,8 @@ describe("Devin CLI model discovery", () => {
     });
   });
 
-  it("humanizes family slugs when the CLI omits a label", () => {
-    const [model] = mergeDevinModelDescriptors([
+  it("humanizes family slugs when the CLI omits labels", () => {
+    const models = mergeDevinModelDescriptors([
       parseDevinCliModelList(
         JSON.stringify({
           families: [
@@ -1627,12 +1627,17 @@ describe("Devin CLI model discovery", () => {
               slug: "swe-1-7",
               variants: [{ model_uid: "swe-1-7" }],
             },
+            {
+              family_uid: "claude-opus-4-9-20260715",
+              slug: "claude-opus-4-9-20260715",
+              variants: [{ model_uid: "claude-opus-4-9-20260715" }],
+            },
           ],
         }),
       ),
     ]);
 
-    expect(model?.name).toBe("SWE 1.7");
+    expect(models.map(({ name }) => name)).toEqual(["SWE 1.7", "Claude Opus 4.9 20260715"]);
   });
 
   it("exposes thinking and long-context toggles for Claude-style variants", () => {

--- a/apps/server/src/provider/Layers/DevinAdapter.ts
+++ b/apps/server/src/provider/Layers/DevinAdapter.ts
@@ -34,6 +34,7 @@ import {
   getDevinStaticModelVariants,
   getModelCapabilities,
   getProviderOptionDescriptors,
+  humanizeModelSlug,
   normalizeModelSlug,
   resolveDevinModelVariant,
   trimOrNull,
@@ -724,10 +725,6 @@ function isDevinAcpDebugEnabled(): boolean {
   );
 }
 
-function formatDevinModelName(slug: string): string {
-  return slug.replace(/[-_/]+/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
-}
-
 interface DevinModelDescriptorSeed {
   readonly slug: string;
   readonly name?: string;
@@ -984,7 +981,7 @@ export function mergeDevinModelDescriptors(
       const key = slug.toLowerCase();
       if (!slug || seen.has(key)) continue;
       seen.add(key);
-      const name = model.name?.trim() || formatDevinModelName(slug);
+      const name = model.name?.trim() || humanizeModelSlug(slug);
       const rawVariants = model.variants ?? [];
       const effortValues = uniqueStrings(rawVariants.map(inferDevinReasoningEffort)).toSorted(
         (left, right) => DEVIN_EFFORT_ORDER.indexOf(left) - DEVIN_EFFORT_ORDER.indexOf(right),
@@ -1043,7 +1040,7 @@ export function mergeDevinModelDescriptors(
           ? {
               supportedReasoningEfforts: effortValues.map((value) => ({
                 value,
-                label: DEVIN_EFFORT_LABELS[value] ?? formatDevinModelName(value),
+                label: DEVIN_EFFORT_LABELS[value] ?? humanizeModelSlug(value),
               })),
               ...(defaultReasoningEffort ? { defaultReasoningEffort } : {}),
             }

--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -366,6 +366,11 @@ describe("GrokAdapter runtime event scoping", () => {
     ]);
   });
 
+  it("humanizes an unknown future Grok family through the shared formatter", () => {
+    const [model] = mergeGrokModelDescriptors([[{ slug: "grok-4-7", name: "" }]]);
+    expect(model?.name).toBe("Grok 4.7");
+  });
+
   it("keeps the live Grok CLI catalog instead of retired xAI API slugs", () => {
     const models = mergeGrokModelDescriptors(
       selectGrokDiscoveredModelGroups({

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -24,6 +24,7 @@ import {
 import {
   getDefaultEffort,
   getModelCapabilities,
+  humanizeModelSlug,
   normalizeGrokModelOptions,
 } from "@synara/shared/model";
 import { decodeOutboundJson, decodeOutboundText, outboundHttp } from "@synara/shared/outboundHttp";
@@ -451,7 +452,7 @@ function formatGrokModelName(slug: string): string {
   if (slug === "grok-build") {
     return "Grok 4.3";
   }
-  return slug.replace(/[-_/]+/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+  return humanizeModelSlug(slug);
 }
 
 function isGrokBuildApiModelSlug(slug: string): boolean {

--- a/apps/web/src/providerModelOptions.test.ts
+++ b/apps/web/src/providerModelOptions.test.ts
@@ -96,6 +96,11 @@ describe("mergeDynamicModelOptions", () => {
     (provider) => {
       const dynamicModels = [
         { slug: "zai/glm-5.3-flash", name: "GLM-5.3-Flash", expected: "GLM 5.3 Flash" },
+        {
+          slug: "anthropic/claude-opus-4-9-20260715",
+          name: "claude-opus-4-9-20260715",
+          expected: "Claude Opus 4.9 20260715",
+        },
         { slug: "zai/glm-5.3-fast", name: "GLM-5.3 Highspeed", expected: "GLM 5.3 Highspeed" },
         {
           slug: "deepseek/deepseek-v4-flash",
@@ -311,7 +316,6 @@ describe("mergeDynamicModelOptions", () => {
         dynamicModels: [
           { slug: "swe-1.7", name: "SWE-1.7" },
           { slug: "swe-1.7-lightning", name: "SWE-1.7 Lightning" },
-          { slug: "swe-1.6-fast", name: "SWE-1.6 Fast" },
           { slug: "swe-2", name: "SWE-2" },
           { slug: "gpt-5.6-sol", name: "GPT-5.6 Sol" },
           { slug: "glm-5.2", name: "GLM-5.2" },
@@ -321,7 +325,6 @@ describe("mergeDynamicModelOptions", () => {
     ).toEqual([
       { slug: "swe-1-7", name: "SWE 1.7" },
       { slug: "swe-1.7-lightning", name: "SWE 1.7 Lightning" },
-      { slug: "swe-1.6-fast", name: "SWE 1.6 Fast" },
       { slug: "swe-2", name: "SWE 2" },
       { slug: "gpt-5.6-sol", name: "GPT-5.6 Sol" },
       { slug: "glm-5.2", name: "GLM 5.2" },

--- a/apps/web/src/providerModelOptions.test.ts
+++ b/apps/web/src/providerModelOptions.test.ts
@@ -299,6 +299,34 @@ describe("mergeDynamicModelOptions", () => {
     ).toEqual(["claude-opus-6", "claude-fable-5", "claude-opus-5"]);
   });
 
+  it("normalizes Devin family labels to canonical brand casing", () => {
+    expect(
+      mergeDynamicModelOptions({
+        provider: "devin",
+        staticOptions: [
+          { slug: "adaptive", name: "Adaptive" },
+          { slug: "swe-1-6", name: "SWE 1.6" },
+          { slug: "swe-1-7", name: "SWE 1.7" },
+        ],
+        dynamicModels: [
+          { slug: "swe-1.7", name: "SWE-1.7" },
+          { slug: "swe-1.7-lightning", name: "SWE-1.7 Lightning" },
+          { slug: "swe-2", name: "SWE-2" },
+          { slug: "gpt-5.6-sol", name: "GPT-5.6 Sol" },
+          { slug: "glm-5.2", name: "GLM-5.2" },
+          { slug: "claude-opus-5", name: "Claude Opus 5" },
+        ],
+      }).map((option) => ({ slug: option.slug, name: option.name })),
+    ).toEqual([
+      { slug: "swe-1-7", name: "SWE 1.7" },
+      { slug: "swe-1.7-lightning", name: "SWE 1.7 Lightning" },
+      { slug: "swe-2", name: "SWE 2" },
+      { slug: "gpt-5.6-sol", name: "GPT-5.6 Sol" },
+      { slug: "glm-5.2", name: "GLM 5.2" },
+      { slug: "claude-opus-5", name: "Claude Opus 5" },
+    ]);
+  });
+
   it("treats the live Grok CLI catalog as authoritative", () => {
     expect(
       mergeDynamicModelOptions({

--- a/apps/web/src/providerModelOptions.test.ts
+++ b/apps/web/src/providerModelOptions.test.ts
@@ -311,6 +311,7 @@ describe("mergeDynamicModelOptions", () => {
         dynamicModels: [
           { slug: "swe-1.7", name: "SWE-1.7" },
           { slug: "swe-1.7-lightning", name: "SWE-1.7 Lightning" },
+          { slug: "swe-1.6-fast", name: "SWE-1.6 Fast" },
           { slug: "swe-2", name: "SWE-2" },
           { slug: "gpt-5.6-sol", name: "GPT-5.6 Sol" },
           { slug: "glm-5.2", name: "GLM-5.2" },
@@ -320,6 +321,7 @@ describe("mergeDynamicModelOptions", () => {
     ).toEqual([
       { slug: "swe-1-7", name: "SWE 1.7" },
       { slug: "swe-1.7-lightning", name: "SWE 1.7 Lightning" },
+      { slug: "swe-1.6-fast", name: "SWE 1.6 Fast" },
       { slug: "swe-2", name: "SWE 2" },
       { slug: "gpt-5.6-sol", name: "GPT-5.6 Sol" },
       { slug: "glm-5.2", name: "GLM 5.2" },

--- a/apps/web/src/providerModelOptions.ts
+++ b/apps/web/src/providerModelOptions.ts
@@ -1,6 +1,7 @@
 import {
   formatModelDisplayName,
   humanizeModelSlug,
+  normalizeModelDisplayName,
   normalizeModelSlug,
 } from "@synara/shared/model";
 import {
@@ -46,13 +47,10 @@ export interface ProviderModelOptionGroup {
   options: ProviderModelOption[];
 }
 
-// Normalize only known families, keeping the provider's variant wording and casing.
+// Normalize known families to their canonical casing, keeping the provider's
+// variant wording. Unknown or freeform names pass through unchanged.
 function normalizeCatalogModelName(name: string): string {
-  return name.replace(
-    /^(glm|deepseek)([-_\s]+)([^()]*)/iu,
-    (_, family: string, _separator: string, suffix: string) =>
-      `${family.toLowerCase() === "glm" ? "GLM" : "DeepSeek"} ${suffix.replace(/[-_]+/gu, " ")}`,
-  );
+  return normalizeModelDisplayName(name);
 }
 
 /**

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -1283,6 +1283,9 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Record<ProviderKind, Record<string,
   },
   opencode: {},
   pi: {},
+  // Mirrors the aliases `devin models list` declares (swe→SWE-2, opus→Claude
+  // Opus 5, gpt→GPT-6 Astra, ...). Dotted SWE spellings stay mapped to the
+  // canonical dashed slugs used by the static catalog.
   devin: {
     adaptive: "adaptive",
     auto: "adaptive",
@@ -1290,12 +1293,17 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Record<ProviderKind, Record<string,
     "swe-1.6-fast": "swe-1-6",
     "swe-1.6": "swe-1-6",
     "swe-1.7": "swe-1-7",
-    swe: "swe-1-6",
+    swe: "swe-2",
     "swe-1-6": "swe-1-6",
     "swe-1-7": "swe-1-7",
-    opus: "claude-opus-4-8",
+    claude: "claude-sonnet-5",
     sonnet: "claude-sonnet-5",
+    opus: "claude-opus-5",
+    haiku: "claude-haiku-4.5",
     fable: "claude-fable-5",
+    gemini: "gemini-3.8-flash",
+    gpt: "gpt-6-astra",
+    codex: "gpt-5.3-codex",
   },
 };
 

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -1283,27 +1283,19 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Record<ProviderKind, Record<string,
   },
   opencode: {},
   pi: {},
-  // Mirrors the aliases `devin models list` declares (swe→SWE-2, opus→Claude
-  // Opus 5, gpt→GPT-6 Astra, ...). Dotted SWE spellings stay mapped to the
-  // canonical dashed slugs used by the static catalog; "swe-1.6-fast" is its
-  // own upstream family and must not fold into swe-1-6.
   devin: {
     adaptive: "adaptive",
     auto: "adaptive",
     fast: "swe-1-6",
+    "swe-1.6-fast": "swe-1-6",
     "swe-1.6": "swe-1-6",
     "swe-1.7": "swe-1-7",
-    swe: "swe-2",
+    swe: "swe-1-6",
     "swe-1-6": "swe-1-6",
     "swe-1-7": "swe-1-7",
-    claude: "claude-sonnet-5",
+    opus: "claude-opus-4-8",
     sonnet: "claude-sonnet-5",
-    opus: "claude-opus-5",
-    haiku: "claude-haiku-4.5",
     fable: "claude-fable-5",
-    gemini: "gemini-3.8-flash",
-    gpt: "gpt-6-astra",
-    codex: "gpt-5.3-codex",
   },
 };
 

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -1285,12 +1285,12 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Record<ProviderKind, Record<string,
   pi: {},
   // Mirrors the aliases `devin models list` declares (swe→SWE-2, opus→Claude
   // Opus 5, gpt→GPT-6 Astra, ...). Dotted SWE spellings stay mapped to the
-  // canonical dashed slugs used by the static catalog.
+  // canonical dashed slugs used by the static catalog; "swe-1.6-fast" is its
+  // own upstream family and must not fold into swe-1-6.
   devin: {
     adaptive: "adaptive",
     auto: "adaptive",
     fast: "swe-1-6",
-    "swe-1.6-fast": "swe-1-6",
     "swe-1.6": "swe-1-6",
     "swe-1.7": "swe-1-7",
     swe: "swe-2",

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -173,7 +173,7 @@ describe("normalizeModelSlug", () => {
   it("resolves devin aliases to canonical swe-1-6 / swe-1-7 slugs", () => {
     expect(normalizeModelSlug("swe-1.7", "devin")).toBe("swe-1-7");
     expect(normalizeModelSlug("swe-1.6", "devin")).toBe("swe-1-6");
-    expect(normalizeModelSlug("swe-1.6-fast", "devin")).toBe("swe-1-6");
+    expect(normalizeModelSlug("swe-1.6-fast", "devin")).toBe("swe-1.6-fast");
     expect(normalizeModelSlug("fast", "devin")).toBe("swe-1-6");
   });
 

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -22,6 +22,7 @@ import {
   getDefaultModel,
   getModelCapabilities,
   getModelOptions,
+  humanizeModelSlug,
   hasContextWindowOption,
   hasAutoCompactWindowOption,
   isClaudeUltrathinkPrompt,
@@ -173,20 +174,13 @@ describe("normalizeModelSlug", () => {
   it("resolves devin aliases to canonical swe-1-6 / swe-1-7 slugs", () => {
     expect(normalizeModelSlug("swe-1.7", "devin")).toBe("swe-1-7");
     expect(normalizeModelSlug("swe-1.6", "devin")).toBe("swe-1-6");
-    expect(normalizeModelSlug("swe-1.6-fast", "devin")).toBe("swe-1.6-fast");
+    expect(normalizeModelSlug("swe-1.6-fast", "devin")).toBe("swe-1-6");
     expect(normalizeModelSlug("fast", "devin")).toBe("swe-1-6");
-  });
-
-  it("mirrors the family aliases declared by `devin models list`", () => {
-    expect(normalizeModelSlug("swe", "devin")).toBe("swe-2");
-    expect(normalizeModelSlug("opus", "devin")).toBe("claude-opus-5");
-    expect(normalizeModelSlug("claude", "devin")).toBe("claude-sonnet-5");
+    expect(normalizeModelSlug("swe", "devin")).toBe("swe-1-6");
+    expect(normalizeModelSlug("opus", "devin")).toBe("claude-opus-4-8");
     expect(normalizeModelSlug("sonnet", "devin")).toBe("claude-sonnet-5");
-    expect(normalizeModelSlug("haiku", "devin")).toBe("claude-haiku-4.5");
     expect(normalizeModelSlug("fable", "devin")).toBe("claude-fable-5");
-    expect(normalizeModelSlug("gemini", "devin")).toBe("gemini-3.8-flash");
-    expect(normalizeModelSlug("gpt", "devin")).toBe("gpt-6-astra");
-    expect(normalizeModelSlug("codex", "devin")).toBe("gpt-5.3-codex");
+    expect(normalizeModelSlug("gpt", "devin")).toBe("gpt");
   });
 });
 
@@ -781,9 +775,11 @@ describe("formatModelDisplayName", () => {
     expect(formatModelDisplayName("deepseek-v4-1-flash")).toBe("DeepSeek V4.1 Flash");
   });
 
-  it("keeps zero-prefixed date and build suffixes separate", () => {
+  it("keeps provider date and build suffixes separate", () => {
     expect(formatModelDisplayName("grok-code-fast-1-0825")).toBe("Grok Code Fast 1 0825");
     expect(formatModelDisplayName("deepseek-v4-flash-0731")).toBe("DeepSeek V4 Flash 0731");
+    expect(formatModelDisplayName("claude-opus-4-9-20260715")).toBe("Claude Opus 4.9 20260715");
+    expect(humanizeModelSlug("claude-opus-4-5-20251101")).toBe("Claude Opus 4.5 20251101");
   });
 
   it("humanizes model tokens that match inherited object properties", () => {
@@ -814,6 +810,7 @@ describe("normalizeModelDisplayName", () => {
   it("rejoins digit fragments into versions", () => {
     expect(normalizeModelDisplayName("Swe 1 6")).toBe("SWE 1.6");
     expect(normalizeModelDisplayName("Claude Opus 4 8")).toBe("Claude Opus 4.8");
+    expect(normalizeModelDisplayName("Claude Opus 4 9 20260715")).toBe("Claude Opus 4.9 20260715");
   });
 
   it("leaves already-canonical and unknown names unchanged", () => {

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -29,6 +29,7 @@ import {
   normalizeClaudeModelOptions,
   normalizeCursorModelOptions,
   normalizeGrokModelOptions,
+  normalizeModelDisplayName,
   normalizeModelSlug,
   normalizePiModelOptions,
   parseCursorCliReasoningEffort,
@@ -174,6 +175,18 @@ describe("normalizeModelSlug", () => {
     expect(normalizeModelSlug("swe-1.6", "devin")).toBe("swe-1-6");
     expect(normalizeModelSlug("swe-1.6-fast", "devin")).toBe("swe-1-6");
     expect(normalizeModelSlug("fast", "devin")).toBe("swe-1-6");
+  });
+
+  it("mirrors the family aliases declared by `devin models list`", () => {
+    expect(normalizeModelSlug("swe", "devin")).toBe("swe-2");
+    expect(normalizeModelSlug("opus", "devin")).toBe("claude-opus-5");
+    expect(normalizeModelSlug("claude", "devin")).toBe("claude-sonnet-5");
+    expect(normalizeModelSlug("sonnet", "devin")).toBe("claude-sonnet-5");
+    expect(normalizeModelSlug("haiku", "devin")).toBe("claude-haiku-4.5");
+    expect(normalizeModelSlug("fable", "devin")).toBe("claude-fable-5");
+    expect(normalizeModelSlug("gemini", "devin")).toBe("gemini-3.8-flash");
+    expect(normalizeModelSlug("gpt", "devin")).toBe("gpt-6-astra");
+    expect(normalizeModelSlug("codex", "devin")).toBe("gpt-5.3-codex");
   });
 });
 
@@ -754,6 +767,23 @@ describe("formatModelDisplayName", () => {
   it("restores known model-family casing while humanizing non-GPT slugs", () => {
     expect(formatModelDisplayName("glm-5.3-flash")).toBe("GLM 5.3 Flash");
     expect(formatModelDisplayName("deepseek-v4-flash")).toBe("DeepSeek V4 Flash");
+    expect(formatModelDisplayName("swe-2")).toBe("SWE 2");
+    expect(formatModelDisplayName("swe-1-7-lightning")).toBe("SWE 1.7 Lightning");
+    expect(formatModelDisplayName("minimax-m3")).toBe("MiniMax M3");
+    expect(formatModelDisplayName("openai-gpt-5")).toBe("OpenAI GPT-5");
+  });
+
+  it("rejoins version fragments split on dashes", () => {
+    expect(formatModelDisplayName("swe-1-8")).toBe("SWE 1.8");
+    expect(formatModelDisplayName("claude-opus-4-9")).toBe("Claude Opus 4.9");
+    expect(formatModelDisplayName("kimi-k2-6")).toBe("Kimi K2.6");
+    expect(formatModelDisplayName("gpt-5-7-sol")).toBe("GPT-5.7 Sol");
+    expect(formatModelDisplayName("deepseek-v4-1-flash")).toBe("DeepSeek V4.1 Flash");
+  });
+
+  it("keeps zero-prefixed date and build suffixes separate", () => {
+    expect(formatModelDisplayName("grok-code-fast-1-0825")).toBe("Grok Code Fast 1 0825");
+    expect(formatModelDisplayName("deepseek-v4-flash-0731")).toBe("DeepSeek V4 Flash 0731");
   });
 
   it("humanizes model tokens that match inherited object properties", () => {
@@ -763,6 +793,41 @@ describe("formatModelDisplayName", () => {
 
   it("leaves non-GPT custom slugs unchanged", () => {
     expect(formatModelDisplayName("custom/internal-model")).toBe("custom/internal-model");
+  });
+});
+
+describe("normalizeModelDisplayName", () => {
+  it("restores canonical brand casing and separators for known families", () => {
+    expect(normalizeModelDisplayName("SWE-1.7 Lightning")).toBe("SWE 1.7 Lightning");
+    expect(normalizeModelDisplayName("Swe 1.7")).toBe("SWE 1.7");
+    expect(normalizeModelDisplayName("SWE-2")).toBe("SWE 2");
+    expect(normalizeModelDisplayName("GLM-5.3-Flash")).toBe("GLM 5.3 Flash");
+    expect(normalizeModelDisplayName("Deepseek V4 Flash")).toBe("DeepSeek V4 Flash");
+    expect(normalizeModelDisplayName("MiniMax-M2.5-Free")).toBe("MiniMax M2.5 Free");
+  });
+
+  it("keeps the GPT version hyphen", () => {
+    expect(normalizeModelDisplayName("GPT-5.3-Codex")).toBe("GPT-5.3 Codex");
+    expect(normalizeModelDisplayName("GPT-5.6 Sol")).toBe("GPT-5.6 Sol");
+  });
+
+  it("rejoins digit fragments into versions", () => {
+    expect(normalizeModelDisplayName("Swe 1 6")).toBe("SWE 1.6");
+    expect(normalizeModelDisplayName("Claude Opus 4 8")).toBe("Claude Opus 4.8");
+  });
+
+  it("leaves already-canonical and unknown names unchanged", () => {
+    expect(normalizeModelDisplayName("Claude Opus 5")).toBe("Claude Opus 5");
+    expect(normalizeModelDisplayName("Kimi K3")).toBe("Kimi K3");
+    expect(normalizeModelDisplayName("Adaptive")).toBe("Adaptive");
+    expect(normalizeModelDisplayName("MyModel")).toBe("MyModel");
+    expect(normalizeModelDisplayName("K2P6")).toBe("K2P6");
+    expect(normalizeModelDisplayName("Custom model")).toBe("Custom model");
+    expect(normalizeModelDisplayName("Default (recommended)")).toBe("Default (recommended)");
+  });
+
+  it("keeps a parenthesized tail verbatim", () => {
+    expect(normalizeModelDisplayName("GLM-5.2 (beta)")).toBe("GLM 5.2 (beta)");
   });
 });
 

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -85,32 +85,30 @@ const MODEL_TOKEN_DISPLAY_NAMES: Readonly<Record<string, string>> = {
   gpt: "GPT",
   minimax: "MiniMax",
   openai: "OpenAI",
+  opencode: "OpenCode",
   swe: "SWE",
+  xai: "xAI",
   xhigh: "XHigh",
 };
 
 // First tokens that mark a provider-supplied label as a model-family name
-// worth normalizing. Anything else (custom names like "MyModel", "K2P6")
-// keeps its original casing untouched.
+// worth normalizing: the brand tokens plus families whose casing is already
+// title-case. Anything else (custom names like "MyModel", "K2P6") keeps its
+// original casing untouched.
 const MODEL_FAMILY_TOKENS: ReadonlySet<string> = new Set([
+  ...Object.keys(MODEL_TOKEN_DISPLAY_NAMES),
   "adaptive",
   "auto",
   "claude",
   "codex",
   "composer",
   "cursor",
-  "deepseek",
   "devin",
   "gemini",
-  "glm",
-  "gpt",
   "grok",
   "inkling",
   "kimi",
-  "minimax",
   "nemotron",
-  "openai",
-  "swe",
 ]);
 
 function humanizeModelToken(token: string): string {
@@ -175,7 +173,8 @@ export function normalizeModelDisplayName(name: string): string {
   const head = parenIndex >= 0 ? trimmed.slice(0, parenIndex).trimEnd() : trimmed;
   const tail = parenIndex >= 0 ? trimmed.slice(parenIndex) : "";
   const tokens = head.split(/[-_\s]+/u).filter(Boolean);
-  if (tokens.length === 0 || !MODEL_FAMILY_TOKENS.has(tokens[0]!.toLowerCase())) {
+  const [firstToken] = tokens;
+  if (firstToken === undefined || !MODEL_FAMILY_TOKENS.has(firstToken.toLowerCase())) {
     return trimmed;
   }
   const normalized = joinModelVersionTokens(tokens)

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -119,11 +119,12 @@ function humanizeModelToken(token: string): string {
   return displayName ?? token.charAt(0).toUpperCase() + token.slice(1);
 }
 
+const MODEL_DATE_OR_BUILD_TOKEN_PATTERN = /^\d{8}$/u;
+
 // Rejoins version fragments split on "-"/"_": a pure-digit token merges onto a
 // preceding token that already ends in a digit, so "swe-1-6" reads as 1.6,
-// "claude-opus-4-8" as 4.8, and "kimi-k2-6" as K2.6. Zero-prefixed tokens stay
-// separate: they are date/build suffixes (grok-code-fast-1-0825,
-// deepseek-v4-flash-0731), never version minors.
+// "claude-opus-4-8" as 4.8, and "kimi-k2-6" as K2.6. Zero-prefixed tokens and
+// eight-digit provider date/build stamps stay separate, never version minors.
 function joinModelVersionTokens(tokens: string[]): string[] {
   const merged: string[] = [];
   for (const token of tokens) {
@@ -131,6 +132,7 @@ function joinModelVersionTokens(tokens: string[]): string[] {
     if (
       /^\d+$/u.test(token) &&
       (token === "0" || !token.startsWith("0")) &&
+      !MODEL_DATE_OR_BUILD_TOKEN_PATTERN.test(token) &&
       previous !== undefined &&
       /\d$/u.test(previous)
     ) {

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -82,7 +82,36 @@ const MODEL_NAME_BY_SLUG = new Map(
 const MODEL_TOKEN_DISPLAY_NAMES: Readonly<Record<string, string>> = {
   deepseek: "DeepSeek",
   glm: "GLM",
+  gpt: "GPT",
+  minimax: "MiniMax",
+  openai: "OpenAI",
+  swe: "SWE",
+  xhigh: "XHigh",
 };
+
+// First tokens that mark a provider-supplied label as a model-family name
+// worth normalizing. Anything else (custom names like "MyModel", "K2P6")
+// keeps its original casing untouched.
+const MODEL_FAMILY_TOKENS: ReadonlySet<string> = new Set([
+  "adaptive",
+  "auto",
+  "claude",
+  "codex",
+  "composer",
+  "cursor",
+  "deepseek",
+  "devin",
+  "gemini",
+  "glm",
+  "gpt",
+  "grok",
+  "inkling",
+  "kimi",
+  "minimax",
+  "nemotron",
+  "openai",
+  "swe",
+]);
 
 function humanizeModelToken(token: string): string {
   const key = token.toLowerCase();
@@ -92,20 +121,75 @@ function humanizeModelToken(token: string): string {
   return displayName ?? token.charAt(0).toUpperCase() + token.slice(1);
 }
 
-// Turns a raw model slug into a readable label when no built-in name exists.
-// GPT slugs keep their canonical "GPT-x" casing; provider-scoped custom ids
-// ("vendor/model") stay verbatim; everything else is title-cased on -/_ with
-// known model-family brands restored to their canonical casing.
-export function humanizeModelSlug(slug: string): string {
-  if (slug.toLowerCase().startsWith("gpt-")) {
-    const [, version, ...rest] = slug.split("-");
-    if (rest.length === 0) return `GPT-${version}`;
-    return `GPT-${version} ${rest.map(humanizeModelToken).join(" ")}`;
+// Rejoins version fragments split on "-"/"_": a pure-digit token merges onto a
+// preceding token that already ends in a digit, so "swe-1-6" reads as 1.6,
+// "claude-opus-4-8" as 4.8, and "kimi-k2-6" as K2.6. Zero-prefixed tokens stay
+// separate: they are date/build suffixes (grok-code-fast-1-0825,
+// deepseek-v4-flash-0731), never version minors.
+function joinModelVersionTokens(tokens: string[]): string[] {
+  const merged: string[] = [];
+  for (const token of tokens) {
+    const previous = merged[merged.length - 1];
+    if (
+      /^\d+$/u.test(token) &&
+      (token === "0" || !token.startsWith("0")) &&
+      previous !== undefined &&
+      /\d$/u.test(previous)
+    ) {
+      merged[merged.length - 1] = `${previous}.${token}`;
+    } else {
+      merged.push(token);
+    }
   }
+  return merged;
+}
+
+// Canonical brand shapes that differ from plain space-joined words.
+function restoreModelNameSeparators(name: string): string {
+  return name.replace(/\bGPT (\d)/gu, "GPT-$1");
+}
+
+// Turns a raw model slug into a readable label when no built-in name exists.
+// Provider-scoped custom ids ("vendor/model") stay verbatim; everything else is
+// tokenized on -/_, version fragments rejoined with ".", known model-family
+// brands restored to their canonical casing, and GPT versions rehyphenated.
+export function humanizeModelSlug(slug: string): string {
   if (slug.includes("/")) {
     return slug;
   }
-  return slug.split(/[-_]+/g).map(humanizeModelToken).join(" ");
+  const tokens = joinModelVersionTokens(slug.split(/[-_]+/g)).map(humanizeModelToken);
+  return restoreModelNameSeparators(tokens.join(" "));
+}
+
+/**
+ * Normalizes a provider-supplied display name to Synara's canonical casing:
+ * known brand tokens are re-cased ("Swe" → "SWE", "Deepseek" → "DeepSeek"),
+ * slug separators become spaces ("GLM-5.3-Flash" → "GLM 5.3 Flash"), digit
+ * fragments rejoin as versions, and GPT versions keep their hyphen. Gated on a
+ * known family first token so freeform names keep their casing; non-brand
+ * tokens and a parenthesized tail pass through unchanged.
+ */
+export function normalizeModelDisplayName(name: string): string {
+  const trimmed = name.trim();
+  const parenIndex = trimmed.indexOf("(");
+  const head = parenIndex >= 0 ? trimmed.slice(0, parenIndex).trimEnd() : trimmed;
+  const tail = parenIndex >= 0 ? trimmed.slice(parenIndex) : "";
+  const tokens = head.split(/[-_\s]+/u).filter(Boolean);
+  if (tokens.length === 0 || !MODEL_FAMILY_TOKENS.has(tokens[0]!.toLowerCase())) {
+    return trimmed;
+  }
+  const normalized = joinModelVersionTokens(tokens)
+    .map((token) => {
+      const displayName = Object.prototype.hasOwnProperty.call(
+        MODEL_TOKEN_DISPLAY_NAMES,
+        token.toLowerCase(),
+      )
+        ? MODEL_TOKEN_DISPLAY_NAMES[token.toLowerCase()]
+        : undefined;
+      return displayName ?? token;
+    })
+    .join(" ");
+  return `${restoreModelNameSeparators(normalized)}${tail ? ` ${tail}` : ""}`;
 }
 
 export function formatModelDisplayName(model: string | null | undefined): string | undefined {


### PR DESCRIPTION
Supersedes #1133 for integration while preserving its original commits and authorship. Credit to @kartikkabadi for the shared humanizer consolidation.

A replacement PR is necessary only because #1133 has maintainer edits disabled and the fork author does not match the owner GitHub account used by Cursor, which prevents exact-head review certification. The original PR remains open.

## Summary

- consolidate provider fallback labels through the shared model humanizer
- normalize known model-family casing without rewriting unknown or freeform labels
- preserve eight-digit provider date/build suffixes while still joining versions such as `4-9` into `4.9`
- keep Devin saved-model normalization and dispatch aliases unchanged from `main`
- add focused cross-provider coverage for Devin, Grok, Pi, OpenCode, and future catalog entries

## Verification

- `bun run --cwd packages/shared test src/model.test.ts`
- `bun run --cwd apps/server test src/provider/Layers/DevinAdapter.test.ts src/provider/Layers/GrokAdapter.test.ts`
- `bun run --cwd apps/web test src/providerModelOptions.test.ts`
- scoped `oxfmt` on the eight changed files
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-label formatting only across model catalogs and pickers; no runtime model selection or session behavior changes beyond how names render.
> 
> **Overview**
> **Centralizes how model names are shown** when catalogs omit labels or ship inconsistent casing. Devin and Grok adapters drop local title-case helpers and call shared `humanizeModelSlug` for fallback names; the web model picker routes catalog normalization through new `normalizeModelDisplayName` instead of a GLM/DeepSeek-only regex.
> 
> **Shared `@synara/shared/model` logic grows** to join dash-split version fragments (e.g. `4-9` → `4.9`), restore canonical brand tokens (SWE, GLM, DeepSeek, MiniMax, GPT hyphenation), and leave eight-digit date/build suffixes separate. `normalizeModelDisplayName` only rewrites names that start with a known family token so freeform labels like `MyModel` stay untouched.
> 
> Tests cover Devin CLI discovery without `family_label`, Grok unknown slugs, Pi/OpenCode merge behavior, and Devin dynamic option casing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 382eb47a388cfd6c190fed9d87c6d2bf0143bf54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->