### PR TITLE
Optimize CI test parallelism and reduce critical-path runtime

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -32,7 +32,10 @@ runs:
     # electron input: Install Electron test runtime extracts the binary into
     # apps/desktop/node_modules/electron/dist INSIDE node_modules, so the
     # electron lane's tree differs from other lanes and must not share a blob.
+    # Windows cache restores can leave Bun's isolated dependency links missing.
+    # Recreate that tree from the package cache instead of restoring node_modules.
     - name: Cache node_modules
+      if: ${{ runner.os != 'Windows' }}
       uses: actions/cache@v5
       with:
         path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # Lane rule: static-fast is fast checks with no special runtime, static-typecheck is tsc,
-# unit is bun test per package, browser owns Playwright (stable only, sharded) and is the long pole,
+# unit runs Vitest through Turbo, browser owns Playwright (stable only, sharded),
 # build owns Electron and desktop output. Geometry quarantine lives in ci-nightly.yml.
 # Gate (quality) aggregates only: add no run steps there. A new fast check with no runtime goes to static-fast.
 # Setup-workspace runs once per lane, not once for all: never put checks in the shared action.
@@ -105,10 +105,9 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
-  # Phase 2f: one shard per workspace package via --filter. Going through turbo
-  # keeps the ^build contract (test dependsOn ^build) working per shard. The
-  # server package script keeps its serial flags (--maxWorkers=1
-  # --no-file-parallelism) inside its own shard.
+  # Group short suites to share setup and leave runner capacity for other PRs.
+  # Server files are split across two runners, retaining their serial worker
+  # flags within each shard. Turbo still runs each package's build prerequisites.
   unit:
     name: Unit Tests (${{ matrix.pkg }})
     runs-on: ubuntu-24.04
@@ -121,19 +120,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - pkg: contracts
-            filter: "@synara/contracts"
-          - pkg: shared
-            filter: "@synara/shared"
-          - pkg: scripts
-            filter: "@synara/scripts"
-          - pkg: desktop
-            filter: "@synara/desktop"
+          - pkg: core
+            filters: "--filter=@synara/contracts --filter=@synara/shared --filter=@synara/scripts --filter=@synara/desktop"
+            test-args: ""
           - pkg: web
-            filter: "@synara/web"
+            filters: "--filter=@synara/web"
+            test-args: ""
           # Server lane tests the CLI package (package name @synara/cli).
-          - pkg: server
-            filter: "@synara/cli"
+          - pkg: server 1/2
+            filters: "--filter=@synara/cli"
+            test-args: "--shard=1/2"
+          - pkg: server 2/2
+            filters: "--filter=@synara/cli"
+            test-args: "--shard=2/2"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -142,18 +141,17 @@ jobs:
         uses: ./.github/actions/setup-workspace
 
       - name: Verify Linux terminal PTY native dependency
-        if: matrix.pkg == 'server'
+        if: matrix.filters == '--filter=@synara/cli'
         run: node scripts/node-pty-smoke.mjs
 
       - name: Test (${{ matrix.pkg }})
-        run: bunx turbo run test --filter=${{ matrix.filter }}
+        run: bunx turbo run test ${{ matrix.filters }} -- ${{ matrix.test-args }}
 
-  # Phase 2e: stable browser suite split 3 ways. fileParallelism:false stays in
-  # vitest.browser.stable.config.ts (untouched); --shard splits test FILES
-  # across shards, never parallelizes within a file. Each shard provisions its
-  # own chromium on its own runner.
+  # File sharding cannot split the large ChatView suite. Run its follow matrix
+  # and remaining cases separately, plus two shards of all other browser files.
+  # Every runner retains the stable suite's serial execution and quarantine.
   browser:
-    name: Browser Tests (stable ${{ matrix.shard }}/3)
+    name: Browser Tests (${{ matrix.project }} ${{ matrix.shard }})
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs: [changes]
@@ -163,9 +161,15 @@ jobs:
       # shards, so every lane reports complete signal for the gate.
       fail-fast: false
       matrix:
-        # Single source of the shard count: resharding must also update the /3
-        # in the job name above and the --shard arg in the run step below.
-        shard: [1, 2, 3]
+        include:
+          - project: chat-follow
+            shard: 1/1
+          - project: chat-workflows
+            shard: 1/1
+          - project: components
+            shard: 1/2
+          - project: components
+            shard: 2/2
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -190,9 +194,9 @@ jobs:
           cd apps/web
           ./node_modules/.bin/playwright install --with-deps chromium
 
-      - name: Browser test (stable shard ${{ matrix.shard }}/3)
+      - name: Browser test (${{ matrix.project }} ${{ matrix.shard }})
         timeout-minutes: 20
-        run: bun run --cwd apps/web test:browser:stable -- --shard=${{ matrix.shard }}/3
+        run: bun run --cwd apps/web test:browser:ci -- --project=${{ matrix.project }} --shard=${{ matrix.shard }}
 
   build:
     name: Desktop Build
@@ -294,20 +298,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version-file: package.json
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: package.json
-
-      - name: Install dependencies
-        env:
-          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
-        run: bun install --frozen-lockfile
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
 
       - name: Verify Windows terminal PTY native dependency under Bun
         run: bun scripts/node-pty-smoke.mjs

--- a/apps/server/turbo.jsonc
+++ b/apps/server/turbo.jsonc
@@ -2,6 +2,11 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
+    "test": {
+      // Server tests import web source and create their own static fixtures.
+      // The desktop build lane validates the production web bundle separately.
+      "dependsOn": ["@synara/contracts#build"],
+    },
     "start": {
       "dependsOn": ["build"],
       "cache": false,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run --passWithNoTests",
     "test:browser": "vitest run --config vitest.browser.config.ts",
     "test:browser:stable": "vitest run --config vitest.browser.stable.config.ts",
+    "test:browser:ci": "vitest run --config vitest.browser.ci.config.ts",
     "test:browser:geometry": "vitest run --config vitest.browser.geometry.config.ts",
     "test:electron:e2e": "playwright test --config playwright.electron.config.ts",
     "test:browser:install": "playwright install --with-deps chromium",

--- a/apps/web/src/components/EventRouter.browser.tsx
+++ b/apps/web/src/components/EventRouter.browser.tsx
@@ -69,6 +69,9 @@ import { resetThreadDetailResumeCursorsForTests } from "../threadDetailResumeCur
 import { useWorkspacePathsStore } from "../workspacePathsStore";
 import { resetWsNativeApiForTest } from "../wsNativeApi";
 import { registerTerminalRuntimeCleanup } from "../lib/terminalStateCleanup";
+// Pre-transform the compiler-heavy component before the first hydration deadline.
+// This suite runs on its own CI shard, so ChatView's suite cannot warm it first.
+import "./ChatView";
 
 const THREAD_ID = ThreadId.makeUnsafe("thread-root-browser-test");
 const OTHER_THREAD_ID = ThreadId.makeUnsafe("thread-other-browser-test");

--- a/apps/web/vitest.browser.ci.config.ts
+++ b/apps/web/vitest.browser.ci.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig } from "vitest/config";
+
+import stableConfig from "./vitest.browser.stable.config";
+
+const chatViewFile = "src/components/ChatView.browser.tsx";
+const { testNamePattern, ...stableTestConfig } = stableConfig.test!;
+const stablePattern = testNamePattern as RegExp;
+// This parameterized full-app matrix costs about 100s on hosted runners.
+// Complementary patterns keep every new stable ChatView case in exactly one lane.
+const followPattern = "restores streaming follow";
+
+export default defineConfig({
+  ...stableConfig,
+  test: {
+    // A root testNamePattern overrides project patterns at runtime in Vitest.
+    // Keep the quarantine in each project so the ChatView split also applies.
+    ...stableTestConfig,
+    // Project inheritance concatenates include arrays. Give each project sole
+    // ownership of its files instead of inheriting the full browser glob set.
+    include: [],
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "chat-follow",
+          include: [chatViewFile],
+          testNamePattern: new RegExp(`${stablePattern.source}(?=.*${followPattern})`),
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "chat-workflows",
+          include: [chatViewFile],
+          testNamePattern: new RegExp(`${stablePattern.source}(?!.*${followPattern})`),
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "components",
+          include: stableTestConfig.include!,
+          exclude: [chatViewFile],
+          testNamePattern: stablePattern,
+        },
+      },
+    ],
+  },
+});

--- a/docs/ci-performance.md
+++ b/docs/ci-performance.md
@@ -1,0 +1,79 @@
+# CI critical path audit — 2026-09-11
+
+The target is a 20–30% reduction in pull-request CI wall time without removing required checks.
+
+## Hosted baseline
+
+Eight successful, first-attempt code-change runs from September 10–11 had a median wall time of **10m 51s**, ranging from **9m 31s to 12m 37s**. Seven are PR runs and one is a main push. Wall time is workflow creation through completion, including runner queueing; job durations below are execution time.
+
+| Run                                                                              | Wall time | Longest job                |
+| -------------------------------------------------------------------------------- | --------- | -------------------------- |
+| [34601479519](https://github.com/Emanuele-web04/synara/actions/runs/34601479519) | 10m 40s   | Browser Tests (stable 3/3) |
+| [34600331685](https://github.com/Emanuele-web04/synara/actions/runs/34600331685) | 10m 03s   | Unit Tests (server)        |
+| [34598565030](https://github.com/Emanuele-web04/synara/actions/runs/34598565030) | 11m 16s   | Browser Tests (stable 3/3) |
+| [34593171942](https://github.com/Emanuele-web04/synara/actions/runs/34593171942) | 10m 54s   | Browser Tests (stable 3/3) |
+| [34589969875](https://github.com/Emanuele-web04/synara/actions/runs/34589969875) | 10m 54s   | Browser Tests (stable 3/3) |
+| [34543900804](https://github.com/Emanuele-web04/synara/actions/runs/34543900804) | 10m 48s   | Windows Process Regression |
+| [34543102075](https://github.com/Emanuele-web04/synara/actions/runs/34543102075) | 12m 37s   | Browser Tests (stable 3/3) |
+| [34599928192](https://github.com/Emanuele-web04/synara/actions/runs/34599928192) | 9m 31s    | Unit Tests (server)        |
+
+| Job                | Median  | Range          |
+| ------------------ | ------- | -------------- |
+| Browser stable 3/3 | 10m 10s | 8m 07s–10m 57s |
+| Server unit tests  | 9m 00s  | 6m 35s–9m 15s  |
+| Browser stable 1/3 | 3m 44s  | 3m 13s–3m 59s  |
+| Browser stable 2/3 | 3m 16s  | 2m 49s–3m 28s  |
+| Windows regression | 3m 39s  | 3m 05s–10m 28s |
+| Web unit tests     | 3m 12s  | 2m 58s–3m 28s  |
+| Desktop build      | 2m 56s  | 43s–3m 09s     |
+| Typecheck          | 1m 12s  | 1m 02s–1m 17s  |
+| Fast static        | 39s     | 32s–44s        |
+
+The short jobs usually restore and install their workspace in 20–35 seconds. Faster setup alone cannot deliver the target.
+
+## What dominates
+
+- **Browser file imbalance.** In run 34601479519, shard 3 spent 348.2s running ChatView and 69.6s running EventRouter, plus 128.6s importing modules across its files. Other shards finished much earlier. Vitest's built-in sharding distributes files and cannot subdivide the 133-case ChatView file.
+- **Unnecessary server prerequisite.** In run 34600331685, the server test step took 518s, but Vitest itself took 370.4s. Turbo built the web production bundle first because the server declares the web workspace as a development dependency and inherited `test.dependsOn: ^build`. The desktop build job already checks that bundle.
+- **Serial server execution.** More than 400 server files run with one worker. This protects integration-test isolation, but it makes one runner responsible for the entire suite.
+- **Uncached Windows installation.** Windows installed dependencies from scratch on every run. The sampled install steps ranged from 128s to 511s.
+- **Repeated setup for tiny suites.** Four short unit suites each occupied a separate runner and restored the same workspace.
+
+## Changes
+
+1. Give ChatView's parameterized streaming-follow matrix and its remaining tests separate browser projects. Two additional shards cover every other browser file. Tests stay serial within each runner.
+2. Keep the Linux geometry quarantine in every project's effective test-name pattern. The patterns for the two ChatView projects are complementary, so new stable cases automatically belong to exactly one project.
+3. Split server test files into two hosted jobs while retaining `--maxWorkers=1 --no-file-parallelism`.
+4. Replace the server test task's broad build prerequisite with the contracts build. Server tests consume web source and create their own static fixtures; production output remains covered by the required desktop build.
+5. Group contracts, shared, scripts, and desktop unit tests into one Turbo invocation. Total workflow jobs decrease from **17 to 16**, despite the extra parallelism on the critical path.
+6. Reuse the shared workspace setup on Windows, including OS-scoped caches and the frozen dependency install.
+
+The required aggregate check name, docs-only behavior, failure propagation, and separate desktop build remain intact. Neither tests nor typechecks are cached as passing results.
+
+## Expected impact
+
+**About 7–8 minutes per successful code-change run is a projection**, approximately **26–35% below the 10m 51s baseline**. It is not a measured hosted result.
+
+The latest browser log attributes 86.8s to the streaming-follow matrix. Its other ChatView cases account for about 261.5s. Conservatively retaining the old shard's entire 128.6s import cost, plus setup and scheduling overhead, puts the heavier new ChatView lane near the upper end of that projection. EventRouter and the remaining browser files execute elsewhere.
+
+Removing the redundant ~148s frontend build and dividing server tests removes the second bottleneck. Windows cache hits should reduce install variance; a cold cache, hosted runner queueing, or a failing test can still exceed the projected range. Extra cold browser compilation is a tradeoff, partially offset by fewer setup jobs and the eliminated frontend build.
+
+## Verification
+
+- `actionlint` validates the modified GitHub workflow.
+- The real aggregate shell step passes 51 success/failure/cancellation/docs-only scenarios.
+- `scripts/browser-ci-partitions.test.ts` resolves actual Vitest configurations, verifies complete file ownership, checks the effective runtime patterns, and preserves serial browser execution.
+- All 85 browser files are accounted for: 84 component files plus ChatView.
+- The grouped core suites pass locally: 1,779 tests across 182 passing files.
+- Both server shards pass locally: 4,902 tests across 406 passing files, with the existing skipped cases retained.
+- Both ChatView partitions pass: 105 + 16 active cases. Comparing the actual JSON results to the complete file proves no missing or duplicated active tests; the 12 quarantined cases remain excluded.
+- The complete ChatView file took 214.01s locally; the larger final partition took 161.30s and its complement took 96.22s. That is a 24.6% reduction in this local file's critical path, not a measured whole-workflow or hosted improvement.
+- Both component shards pass: 42 files / 168 tests and 42 files / 193 tests, with the existing quarantined case retained. All four browser jobs pass locally (482 active cases total).
+
+These are local macOS results. Windows cache behavior and the end-to-end speedup require a hosted run. Full workspace format, lint, and typecheck remain pending because AGENTS.md requires an explicit user request before running them.
+
+## Hosted acceptance
+
+After publication, compare at least three successful first-attempt code-change runs against the baseline. Measure creation-to-gate-completion, individual job duration, cache hits, and runner queue delay separately. Confirm both server shards, all four browser jobs, and the aggregate check succeed. Do not treat a rerun's timestamp or a warm local run as proof of the hosted improvement.
+
+The sharding and project configuration use [Vitest's supported sharding](https://vitest.dev/guide/improving-performance) and [test projects](https://vitest.dev/guide/projects).

--- a/docs/ci-performance.md
+++ b/docs/ci-performance.md
@@ -46,7 +46,7 @@ The short jobs usually restore and install their workspace in 20–35 seconds. F
 3. Split server test files into two hosted jobs while retaining `--maxWorkers=1 --no-file-parallelism`.
 4. Replace the server test task's broad build prerequisite with the contracts build. Server tests consume web source and create their own static fixtures; production output remains covered by the required desktop build.
 5. Group contracts, shared, scripts, and desktop unit tests into one Turbo invocation. Total workflow jobs decrease from **17 to 16**, despite the extra parallelism on the critical path.
-6. Reuse the shared workspace setup on Windows, including OS-scoped caches and the frozen dependency install.
+6. Reuse the shared workspace setup on Windows, including the OS-scoped Bun package cache and the frozen dependency install. Recreate `node_modules` on each Windows runner; a restored tree failed to resolve a required dependency during postinstall.
 
 The required aggregate check name, docs-only behavior, failure propagation, and separate desktop build remain intact. Neither tests nor typechecks are cached as passing results.
 
@@ -70,7 +70,7 @@ Removing the redundant ~148s frontend build and dividing server tests removes th
 - The complete ChatView file took 214.01s locally; the larger final partition took 161.30s and its complement took 96.22s. That is a 24.6% reduction in this local file's critical path, not a measured whole-workflow or hosted improvement.
 - Both component shards pass: 42 files / 168 tests and 42 files / 193 tests, with the existing quarantined case retained. All four browser jobs pass locally (482 active cases total).
 
-These are local macOS results. Windows cache behavior and the end-to-end speedup require a hosted run. Full workspace format, lint, and typecheck remain pending because AGENTS.md requires an explicit user request before running them.
+These test timings are local macOS results. Hosted run [34608752703](https://github.com/Emanuele-web04/synara/actions/runs/34608752703) passed all browser, unit, static, and build checks, but Windows failed during dependency setup after restoring `node_modules`: Fumadocs could not resolve its declared `tinyglobby` dependency. The preceding cold Windows install succeeded. Windows now skips the installed-tree cache; this correction still needs a hosted run. The end-to-end speedup remains unverified across successful runs.
 
 ## Hosted acceptance
 

--- a/scripts/browser-ci-partitions.test.ts
+++ b/scripts/browser-ci-partitions.test.ts
@@ -1,0 +1,57 @@
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { createVitest } from "vitest/node";
+
+const webRoot = fileURLToPath(new URL("../apps/web/", import.meta.url));
+
+async function collectPartitions(config: string) {
+  const vitest = await createVitest("test", { root: webRoot, config, watch: false });
+  try {
+    const specifications = await vitest.globTestSpecifications();
+    return specifications.map((specification) => ({
+      file: specification.moduleId,
+      project: specification.project.name,
+      // Vitest applies the root pattern as a runtime override of each project.
+      pattern:
+        vitest.getGlobalTestNamePattern() ?? specification.project.serializedConfig.testNamePattern,
+      fileParallelism: specification.project.config.browser.fileParallelism,
+    }));
+  } finally {
+    await vitest.close();
+  }
+}
+
+describe("browser CI partitions", () => {
+  it("keeps every stable file and partitions ChatView without duplicating other suites", async () => {
+    const stable = await collectPartitions("vitest.browser.stable.config.ts");
+    const partitions = await collectPartitions("vitest.browser.ci.config.ts");
+    const stableFiles = new Set(stable.map(({ file }) => file));
+
+    expect(stableFiles.size).toBeGreaterThan(0);
+    expect(new Set(partitions.map(({ file }) => file))).toEqual(stableFiles);
+    for (const file of stableFiles) {
+      const owners = partitions.filter((partition) => partition.file === file);
+      if (file.endsWith("/ChatView.browser.tsx")) {
+        expect(owners.map(({ project }) => project).sort()).toEqual([
+          "chat-follow (chromium)",
+          "chat-workflows (chromium)",
+        ]);
+        for (const name of [
+          "ChatView transcript geometry (full app) renders the active thread title",
+          "ChatView transcript geometry (full app) restores streaming follow after wheel",
+          "a newly added case",
+          "a newly added restores streaming follow case",
+          "[geometry:linux] a quarantined case",
+          "[geometry:linux] restores streaming follow",
+        ]) {
+          const selected = owners.filter(({ pattern }) => pattern?.test(name));
+          expect(selected.length, name).toBe(stable[0]!.pattern!.test(name) ? 1 : 0);
+        }
+      } else {
+        expect(owners.map(({ project }) => project)).toEqual(["components (chromium)"]);
+        expect(owners[0]!.pattern).toEqual(stable[0]!.pattern);
+      }
+      expect(owners.every(({ fileParallelism }) => fileParallelism === false)).toBe(true);
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

- Split server unit tests across two serial shards and group short core suites.
- Partition browser tests into dedicated ChatView projects plus component shards.
- Add coverage ensuring browser partitions are complete, disjoint, and serial.
- Remove the redundant server web-build prerequisite while retaining the contracts build.
- Reuse shared workspace setup on Windows and document the CI performance baseline and expected impact.

## Testing

- `actionlint` passed.
- Aggregate CI scenarios passed.
- Browser partition validation passed.
- Core unit suites, both server shards, both ChatView partitions, and both component shards passed locally.
- Full format, lint, and typecheck were not run because they were not requested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow geometry and Turbo test prerequisites change how and where the full suite runs; mis-partitioned browser or server shards could hide failures until hosted CI validates.
> 
> **Overview**
> **Rebalances CI parallelism** to shorten the PR critical path while keeping the same required checks.
> 
> **Unit lane:** Contracts, shared, scripts, and desktop now run in one Turbo job; `@synara/cli` runs as **two Vitest file shards** with existing serial worker settings. Server `test` in Turbo now depends only on **`@synara/contracts#build`**, dropping the inherited full web production build before tests.
> 
> **Browser lane:** Replaces three generic file shards with **`vitest.browser.ci.config.ts`** — separate Vitest projects for ChatView’s streaming-follow matrix vs other ChatView cases, plus two shards for remaining browser files. CI invokes `test:browser:ci` with `--project` and `--shard`. **`EventRouter.browser.tsx`** pre-imports `ChatView` so its isolated shard isn’t cold on compile.
> 
> **Windows / setup:** The Windows regression job uses the shared **`setup-workspace`** action; **`node_modules` caching is disabled on Windows** after restore broke Bun’s isolated links. **`scripts/browser-ci-partitions.test.ts`** and **`docs/ci-performance.md`** document baseline, changes, and partition correctness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22afb0d3f910e41e95a8f0547df975395f42a2d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->