### PR TITLE
feat(desktop): add safe AppSnap window picker

### DIFF
--- a/apps/desktop/native/appsnap/AppSnapProtocol.swift
+++ b/apps/desktop/native/appsnap/AppSnapProtocol.swift
@@ -25,6 +25,29 @@ struct AppSnapOptions {
         var externalTrigger = false
         var index = 0
 
+        // Consumes the value token after a flag, keeping the "--flag requires
+        // …" usage errors identical across flags.
+        func readValue(_ flag: String, _ what: String) throws -> String {
+            index += 1
+            guard index < arguments.count else {
+                throw AppSnapFailure(
+                    code: "invalid_arguments",
+                    message: "\(flag) requires \(what)."
+                )
+            }
+            return arguments[index]
+        }
+
+        // Watch-only flags are invalid in every non-watch mode.
+        func rejectWatchArguments(_ message: String) throws {
+            guard outputDirectory == nil, excludedBundleIdentifier == nil, !externalTrigger else {
+                throw AppSnapFailure(
+                    code: "invalid_arguments",
+                    message: message
+                )
+            }
+        }
+
         while index < arguments.count {
             let argument = arguments[index]
             switch argument {
@@ -37,23 +60,9 @@ struct AppSnapOptions {
                 }
                 requestedMode = argument
             case "--output-dir":
-                index += 1
-                guard index < arguments.count else {
-                    throw AppSnapFailure(
-                        code: "invalid_arguments",
-                        message: "--output-dir requires a path."
-                    )
-                }
-                outputDirectory = arguments[index]
+                outputDirectory = try readValue("--output-dir", "a path")
             case "--excluded-bundle-id":
-                index += 1
-                guard index < arguments.count else {
-                    throw AppSnapFailure(
-                        code: "invalid_arguments",
-                        message: "--excluded-bundle-id requires a bundle identifier."
-                    )
-                }
-                excludedBundleIdentifier = arguments[index]
+                excludedBundleIdentifier = try readValue("--excluded-bundle-id", "a bundle identifier")
             case "--external-trigger":
                 externalTrigger = true
             default:
@@ -67,20 +76,10 @@ struct AppSnapOptions {
 
         switch requestedMode {
         case "--check-permissions":
-            guard outputDirectory == nil, excludedBundleIdentifier == nil, !externalTrigger else {
-                throw AppSnapFailure(
-                    code: "invalid_arguments",
-                    message: "Permission checks do not accept watch arguments."
-                )
-            }
+            try rejectWatchArguments("Permission checks do not accept watch arguments.")
             return AppSnapOptions(mode: .checkPermissions)
         case "--request-permissions":
-            guard outputDirectory == nil, excludedBundleIdentifier == nil, !externalTrigger else {
-                throw AppSnapFailure(
-                    code: "invalid_arguments",
-                    message: "Permission requests do not accept watch arguments."
-                )
-            }
+            try rejectWatchArguments("Permission requests do not accept watch arguments.")
             return AppSnapOptions(mode: .requestPermissions)
         case "--watch":
             guard let outputDirectory, !outputDirectory.isEmpty else {
@@ -178,7 +177,12 @@ final class NDJSONEmitter {
         emit(payload)
     }
 
-    func emitError(_ failure: AppSnapFailure, capturedAt: String, id: String? = nil) {
+    func emitError(
+        _ failure: AppSnapFailure,
+        capturedAt: String,
+        id: String? = nil,
+        requestId: String? = nil
+    ) {
         var payload: [String: Any] = [
             "type": "error",
             "code": failure.code,
@@ -188,7 +192,18 @@ final class NDJSONEmitter {
         if let id {
             payload["id"] = id
         }
+        if let requestId {
+            payload["requestId"] = requestId
+        }
         emit(payload)
+    }
+
+    func emitWindows(requestId: String, windows: [[String: Any]]) {
+        emit([
+            "type": "windows",
+            "requestId": requestId,
+            "windows": windows,
+        ])
     }
 
     func emitPermissions(inputMonitoring: Bool, screenRecording: Bool) {

--- a/apps/desktop/native/appsnap/ExternalTriggerListener.swift
+++ b/apps/desktop/native/appsnap/ExternalTriggerListener.swift
@@ -1,16 +1,31 @@
+import CoreGraphics
 import Foundation
 
-/// Fires the capture gesture when the parent process writes a `trigger` line
-/// to stdin. Used when Electron owns shortcut detection via its global
-/// accelerator registration, so the helper needs no keyboard event tap.
+/// Reads request lines from the parent process on stdin. `trigger` fires the
+/// capture gesture (used when Electron owns shortcut detection via its global
+/// accelerator registration, so the helper needs no keyboard event tap).
+/// `list-windows` and `capture-window` serve the composer window picker and
+/// work in every watch mode.
 final class ExternalTriggerListener {
     private let emitter: NDJSONEmitter
+    private let emitsReady: Bool
     private let onTrigger: () -> Void
+    private let onListWindows: (String) -> Void
+    private let onCaptureWindow: (String, CGWindowID) -> Void
     private var buffer = Data()
 
-    init(emitter: NDJSONEmitter, onTrigger: @escaping () -> Void) {
+    init(
+        emitter: NDJSONEmitter,
+        emitsReady: Bool,
+        onTrigger: @escaping () -> Void,
+        onListWindows: @escaping (String) -> Void,
+        onCaptureWindow: @escaping (String, CGWindowID) -> Void
+    ) {
         self.emitter = emitter
+        self.emitsReady = emitsReady
         self.onTrigger = onTrigger
+        self.onListWindows = onListWindows
+        self.onCaptureWindow = onCaptureWindow
     }
 
     func start() {
@@ -24,19 +39,73 @@ final class ExternalTriggerListener {
             }
             self.consume(data)
         }
-        emitter.emitReady()
+        if emitsReady {
+            emitter.emitReady()
+        }
     }
 
     private func consume(_ data: Data) {
         buffer.append(data)
         while let newlineIndex = buffer.firstIndex(of: UInt8(ascii: "\n")) {
-            let line = String(data: buffer[buffer.startIndex ..< newlineIndex], encoding: .utf8)
+            let line = String(data: buffer[buffer.startIndex ..< newlineIndex], encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
             buffer.removeSubrange(buffer.startIndex ... newlineIndex)
-            if line?.trimmingCharacters(in: .whitespacesAndNewlines) == "trigger" {
-                DispatchQueue.main.async { [onTrigger] in
-                    onTrigger()
-                }
+            guard let line, !line.isEmpty else {
+                continue
             }
+            handle(line: line)
+        }
+    }
+
+    private func emitInvalidRequest(
+        message: String,
+        id: String? = nil,
+        requestId: String? = nil
+    ) {
+        emitter.emitError(
+            AppSnapFailure(
+                code: "invalid_request",
+                message: message
+            ),
+            capturedAt: appSnapTimestamp(),
+            id: id,
+            requestId: requestId
+        )
+    }
+
+    private func handle(line: String) {
+        let parts = line.split(
+            separator: " ",
+            maxSplits: 2,
+            omittingEmptySubsequences: true
+        ).map(String.init)
+
+        switch parts.first {
+        case "trigger" where parts.count == 1:
+            DispatchQueue.main.async { [onTrigger] in
+                onTrigger()
+            }
+        case "list-windows" where parts.count == 2:
+            let requestId = parts[1]
+            DispatchQueue.main.async { [onListWindows] in
+                onListWindows(requestId)
+            }
+        case "capture-window" where parts.count == 3:
+            guard let windowID = UInt32(parts[2]) else {
+                emitInvalidRequest(
+                    message: "capture-window requires a numeric window id.",
+                    id: parts[1]
+                )
+                return
+            }
+            let requestId = parts[1]
+            DispatchQueue.main.async { [onCaptureWindow] in
+                onCaptureWindow(requestId, CGWindowID(windowID))
+            }
+        default:
+            // A well-formed `list-windows <id>` line always matches the case
+            // above, so unknown lines carry no requestId to correlate with.
+            emitInvalidRequest(message: "Unknown AppSnap helper request.")
         }
     }
 }

--- a/apps/desktop/native/appsnap/WindowCapture.swift
+++ b/apps/desktop/native/appsnap/WindowCapture.swift
@@ -19,6 +19,16 @@ struct SelectedWindow {
     let sourceWindowTitle: String?
 }
 
+struct WindowListEntry {
+    let windowID: CGWindowID
+    let appName: String?
+    let bundleIdentifier: String?
+    let windowTitle: String?
+    let appIconDataURL: String?
+}
+
+private let maximumListedWindows = 50
+
 private func appIconDataURL(for application: NSRunningApplication) -> String? {
     guard let bundleURL = application.bundleURL else {
         return nil
@@ -52,6 +62,42 @@ private func number(
     dictionary[key as String] as? NSNumber
 }
 
+private let windowListUnavailableFailure = AppSnapFailure(
+    code: "window_list_unavailable",
+    message: "macOS did not provide a window list."
+)
+
+private let excludedFrontmostApplicationFailure = AppSnapFailure(
+    code: "excluded_frontmost_application",
+    message: "Synara cannot capture its own window."
+)
+
+private func onScreenWindowInfo() -> [[String: Any]]? {
+    CGWindowListCopyWindowInfo(
+        [.optionOnScreenOnly, .excludeDesktopElements],
+        kCGNullWindowID
+    ) as? [[String: Any]]
+}
+
+/// Shared layer-0 window eligibility predicate: on-screen, visible, shareable,
+/// and large enough to capture. Pure reads of the window dictionary.
+private func eligibleWindow(_ candidate: [String: Any]) -> (windowID: CGWindowID, bounds: CGRect)? {
+    guard number(in: candidate, forKey: kCGWindowLayer)?.intValue == 0,
+          number(in: candidate, forKey: kCGWindowAlpha)?.doubleValue ?? 1 > 0,
+          number(in: candidate, forKey: kCGWindowIsOnscreen)?.boolValue ?? true,
+          number(in: candidate, forKey: kCGWindowSharingState)?.uint32Value !=
+              CGWindowSharingType.none.rawValue,
+          let windowID = number(in: candidate, forKey: kCGWindowNumber)?.uint32Value,
+          let boundsDictionary = candidate[kCGWindowBounds as String] as? [String: Any],
+          let bounds = CGRect(dictionaryRepresentation: boundsDictionary as CFDictionary),
+          bounds.width >= 2,
+          bounds.height >= 2
+    else {
+        return nil
+    }
+    return (windowID, bounds)
+}
+
 func selectFrontmostWindow(excludedBundleIdentifier: String) -> Result<SelectedWindow, AppSnapFailure> {
     guard let application = NSWorkspace.shared.frontmostApplication, !application.isTerminated else {
         return .failure(
@@ -63,24 +109,11 @@ func selectFrontmostWindow(excludedBundleIdentifier: String) -> Result<SelectedW
     }
 
     if application.bundleIdentifier == excludedBundleIdentifier {
-        return .failure(
-            AppSnapFailure(
-                code: "excluded_frontmost_application",
-                message: "Synara cannot capture its own window."
-            )
-        )
+        return .failure(excludedFrontmostApplicationFailure)
     }
 
-    guard let windowInfo = CGWindowListCopyWindowInfo(
-        [.optionOnScreenOnly, .excludeDesktopElements],
-        kCGNullWindowID
-    ) as? [[String: Any]] else {
-        return .failure(
-            AppSnapFailure(
-                code: "window_list_unavailable",
-                message: "macOS did not provide a window list."
-            )
-        )
+    guard let windowInfo = onScreenWindowInfo() else {
+        return .failure(windowListUnavailableFailure)
     }
 
     // The on-screen window list is ordered front to back, so the first
@@ -88,31 +121,21 @@ func selectFrontmostWindow(excludedBundleIdentifier: String) -> Result<SelectedW
     // can still expose untitled auxiliary layer-0 windows (overlays, buffers)
     // above the focused document window, so prefer the frontmost *titled*
     // window and only fall back to the frontmost untitled candidate.
-    let processIdentifier = application.processIdentifier
     var chosen: (windowID: CGWindowID, bounds: CGRect, title: String?)?
     for candidate in windowInfo {
-        guard number(in: candidate, forKey: kCGWindowOwnerPID)?.int32Value == processIdentifier,
-              number(in: candidate, forKey: kCGWindowLayer)?.intValue == 0,
-              number(in: candidate, forKey: kCGWindowAlpha)?.doubleValue ?? 1 > 0,
-              number(in: candidate, forKey: kCGWindowIsOnscreen)?.boolValue ?? true,
-              number(in: candidate, forKey: kCGWindowSharingState)?.uint32Value !=
-                  CGWindowSharingType.none.rawValue,
-              let windowID = number(in: candidate, forKey: kCGWindowNumber)?.uint32Value,
-              let boundsDictionary = candidate[kCGWindowBounds as String] as? [String: Any],
-              let bounds = CGRect(dictionaryRepresentation: boundsDictionary as CFDictionary),
-              bounds.width >= 2,
-              bounds.height >= 2
+        guard number(in: candidate, forKey: kCGWindowOwnerPID)?.int32Value == application.processIdentifier,
+              let eligible = eligibleWindow(candidate)
         else {
             continue
         }
 
         let title = candidate[kCGWindowName as String] as? String
         if let title, !title.isEmpty {
-            chosen = (windowID, bounds, title)
+            chosen = (eligible.windowID, eligible.bounds, title)
             break
         }
         if chosen == nil {
-            chosen = (windowID, bounds, title)
+            chosen = (eligible.windowID, eligible.bounds, title)
         }
     }
 
@@ -133,6 +156,100 @@ func selectFrontmostWindow(excludedBundleIdentifier: String) -> Result<SelectedW
             sourceBundleIdentifier: application.bundleIdentifier,
             sourceAppIconDataURL: appIconDataURL(for: application),
             sourceWindowTitle: chosen.title
+        )
+    )
+}
+
+func listVisibleWindows(
+    excludedBundleIdentifier: String
+) -> Result<[WindowListEntry], AppSnapFailure> {
+    guard let windowInfo = onScreenWindowInfo() else {
+        return .failure(windowListUnavailableFailure)
+    }
+
+    var entries: [WindowListEntry] = []
+    var loadedIconKeys = Set<String>()
+    var iconDataURLByKey: [String: String] = [:]
+    for candidate in windowInfo {
+        if entries.count >= maximumListedWindows {
+            break
+        }
+        guard let eligible = eligibleWindow(candidate),
+              let ownerPID = number(in: candidate, forKey: kCGWindowOwnerPID)?.int32Value
+        else {
+            continue
+        }
+
+        let application = NSRunningApplication(processIdentifier: ownerPID)
+        let bundleIdentifier = application?.bundleIdentifier
+        guard bundleIdentifier != excludedBundleIdentifier else {
+            continue
+        }
+
+        let title = candidate[kCGWindowName as String] as? String
+        let iconKey = bundleIdentifier ?? "pid:\(ownerPID)"
+        if loadedIconKeys.insert(iconKey).inserted,
+           let application,
+           let iconDataURL = appIconDataURL(for: application) {
+            iconDataURLByKey[iconKey] = iconDataURL
+        }
+
+        entries.append(
+            WindowListEntry(
+                windowID: eligible.windowID,
+                appName: application?.localizedName,
+                bundleIdentifier: bundleIdentifier,
+                windowTitle: title,
+                appIconDataURL: iconDataURLByKey[iconKey]
+            )
+        )
+    }
+    return .success(entries)
+}
+
+func selectWindow(
+    withID windowID: CGWindowID,
+    excludedBundleIdentifier: String
+) -> Result<SelectedWindow, AppSnapFailure> {
+    guard let windowInfo = onScreenWindowInfo() else {
+        return .failure(windowListUnavailableFailure)
+    }
+
+    for candidate in windowInfo {
+        guard number(in: candidate, forKey: kCGWindowNumber)?.uint32Value == windowID else {
+            continue
+        }
+        guard let eligible = eligibleWindow(candidate),
+              let ownerPID = number(in: candidate, forKey: kCGWindowOwnerPID)?.int32Value,
+              let application = NSRunningApplication(processIdentifier: ownerPID)
+        else {
+            return .failure(
+                AppSnapFailure(
+                    code: "window_not_eligible",
+                    message: "The requested window is no longer visible or shareable."
+                )
+            )
+        }
+        if application.bundleIdentifier == excludedBundleIdentifier {
+            return .failure(excludedFrontmostApplicationFailure)
+        }
+
+        return .success(
+            SelectedWindow(
+                windowID: windowID,
+                bounds: eligible.bounds,
+                sourceAppName: application.localizedName,
+                sourceBundleIdentifier: application.bundleIdentifier,
+                sourceAppIconDataURL: appIconDataURL(for: application),
+                sourceWindowTitle: candidate[kCGWindowName as String] as? String
+            )
+        )
+    }
+
+    return .failure(
+        AppSnapFailure(
+            code: "window_unavailable",
+            message: "The requested window disappeared before it could be captured."
         )
     )
 }
@@ -375,6 +492,7 @@ final class OneFrameWindowCapture: NSObject, SCStreamOutput, SCStreamDelegate {
         }
         completed = true
         let activeStream = stream
+        stream = nil
         completionLock.unlock()
 
         if let activeStream {
@@ -495,19 +613,70 @@ final class AppSnapCaptureCoordinator {
 
     func handleGesture() {
         queue.async { [weak self] in
-            self?.beginCapture()
+            guard let self else { return }
+            // Resolve the target before notifying Electron. That prevents any focus
+            // response to `triggered` from changing which application is captured.
+            let selection = DispatchQueue.main.sync {
+                selectFrontmostWindow(excludedBundleIdentifier: self.excludedBundleIdentifier)
+            }
+            self.beginCapture(selection: selection)
         }
     }
 
-    private func beginCapture() {
-        let id = UUID().uuidString.lowercased()
-        let capturedAt = appSnapTimestamp()
-
-        // Resolve the target before notifying Electron. That prevents any focus
-        // response to `triggered` from changing which application is captured.
-        let selection = DispatchQueue.main.sync {
-            selectFrontmostWindow(excludedBundleIdentifier: excludedBundleIdentifier)
+    func handleListWindows(requestId: String) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            let result = DispatchQueue.main.sync {
+                listVisibleWindows(excludedBundleIdentifier: self.excludedBundleIdentifier)
+            }
+            switch result {
+            case let .failure(failure):
+                self.emitter.emitError(
+                    failure,
+                    capturedAt: appSnapTimestamp(),
+                    requestId: requestId
+                )
+            case let .success(windows):
+                self.emitter.emitWindows(
+                    requestId: requestId,
+                    windows: windows.map { entry in
+                        var payload: [String: Any] = [
+                            "windowId": entry.windowID,
+                            "appName": entry.appName ?? NSNull(),
+                            "bundleIdentifier": entry.bundleIdentifier ?? NSNull(),
+                            "windowTitle": entry.windowTitle ?? NSNull(),
+                        ]
+                        if let appIconDataURL = entry.appIconDataURL {
+                            payload["appIconDataUrl"] = appIconDataURL
+                        }
+                        return payload
+                    }
+                )
+            }
         }
+    }
+
+    func handleCaptureWindow(windowID: CGWindowID, requestId: String) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            // Resolve the target before notifying Electron. That prevents any focus
+            // response to `triggered` from changing which application is captured.
+            let selection = DispatchQueue.main.sync {
+                selectWindow(
+                    withID: windowID,
+                    excludedBundleIdentifier: self.excludedBundleIdentifier
+                )
+            }
+            self.beginCapture(selection: selection, requestedID: requestId)
+        }
+    }
+
+    private func beginCapture(
+        selection: Result<SelectedWindow, AppSnapFailure>,
+        requestedID: String? = nil
+    ) {
+        let id = requestedID ?? UUID().uuidString.lowercased()
+        let capturedAt = appSnapTimestamp()
 
         // Overlapping chords report only the overlap error; emitting `triggered`
         // first would mis-order protocol semantics for consumers correlating ids.

--- a/apps/desktop/native/appsnap/main.swift
+++ b/apps/desktop/native/appsnap/main.swift
@@ -32,13 +32,21 @@ do {
         let parentProcessMonitor = ParentProcessMonitor()
         parentProcessMonitor.start()
 
+        let requestListener = ExternalTriggerListener(
+            emitter: emitter,
+            emitsReady: externalTrigger
+        ) {
+            coordinator.handleGesture()
+        } onListWindows: { requestId in
+            coordinator.handleListWindows(requestId: requestId)
+        } onCaptureWindow: { requestId, windowID in
+            coordinator.handleCaptureWindow(windowID: windowID, requestId: requestId)
+        }
+        requestListener.start()
+
         let gestureSource: AnyObject
         if externalTrigger {
-            let listener = ExternalTriggerListener(emitter: emitter) {
-                coordinator.handleGesture()
-            }
-            listener.start()
-            gestureSource = listener
+            gestureSource = requestListener
         } else {
             let monitor = OptionChordMonitor(emitter: emitter) {
                 coordinator.handleGesture()
@@ -47,7 +55,7 @@ do {
             gestureSource = monitor
         }
 
-        withExtendedLifetime((coordinator, gestureSource, parentProcessMonitor)) {
+        withExtendedLifetime((coordinator, gestureSource, requestListener, parentProcessMonitor)) {
             RunLoop.main.run()
         }
     }

--- a/apps/desktop/src/appSnapIpc.ts
+++ b/apps/desktop/src/appSnapIpc.ts
@@ -13,6 +13,8 @@ import type {
 import type { DesktopAppSnapManager } from "./appSnapManager";
 import { APPSNAP_IPC_CHANNELS } from "./ipcChannels";
 
+const MAX_MACOS_WINDOW_ID = 0xffff_ffff;
+
 export function sendAppSnapState(
   webContents: WebContents | null | undefined,
   state: DesktopAppSnapState,
@@ -64,5 +66,25 @@ export function registerAppSnapIpcHandlers(ipcMain: IpcMain, manager: DesktopApp
   ipcMain.removeHandler(APPSNAP_IPC_CHANNELS.acknowledgeCapture);
   ipcMain.handle(APPSNAP_IPC_CHANNELS.acknowledgeCapture, async (_event, captureId: unknown) => {
     if (typeof captureId === "string") await manager.acknowledgeCapture(captureId);
+  });
+
+  ipcMain.removeHandler(APPSNAP_IPC_CHANNELS.listWindows);
+  ipcMain.handle(APPSNAP_IPC_CHANNELS.listWindows, async () => manager.listWindows());
+
+  ipcMain.removeHandler(APPSNAP_IPC_CHANNELS.captureWindow);
+  ipcMain.handle(APPSNAP_IPC_CHANNELS.captureWindow, async (_event, input: unknown) => {
+    const windowId =
+      typeof input === "object" && input !== null
+        ? (input as { windowId?: unknown }).windowId
+        : undefined;
+    if (
+      typeof windowId !== "number" ||
+      !Number.isInteger(windowId) ||
+      windowId <= 0 ||
+      windowId > MAX_MACOS_WINDOW_ID
+    ) {
+      throw new Error("captureWindow requires a valid macOS window id.");
+    }
+    return manager.captureWindow(windowId);
   });
 }

--- a/apps/desktop/src/appSnapManager.test.ts
+++ b/apps/desktop/src/appSnapManager.test.ts
@@ -8,7 +8,7 @@ import { PassThrough } from "node:stream";
 
 import { PROVIDER_SEND_TURN_MAX_ATTACHMENTS } from "@synara/contracts";
 import { SYNARA_DEVELOPMENT_BUNDLE_ID } from "@synara/shared/desktopIdentity";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, type Mock } from "vitest";
 
 import {
   DesktopAppSnapManager,
@@ -909,5 +909,389 @@ describe("AppSnap capture path guard", () => {
     expect(isPathInsideDirectory("/tmp/appsnap", "/tmp/appsnap/capture.png")).toBe(true);
     expect(isPathInsideDirectory("/tmp/appsnap", "/tmp/appsnap")).toBe(false);
     expect(isPathInsideDirectory("/tmp/appsnap", "/tmp/other/capture.png")).toBe(false);
+  });
+});
+
+describe("AppSnap window picker requests", () => {
+  async function createEnabledManager(): Promise<{
+    manager: DesktopAppSnapManager;
+    watchChild: FakeChildProcess;
+    captureDirectory: string;
+    onCaptured: Mock;
+    onError: Mock;
+    dispose: () => void;
+  }> {
+    const captureDirectory = mkdtempSync(join(tmpdir(), "synara-appsnap-picker-"));
+    const checkChild = createFakeChildProcess();
+    const watchChild = createFakeChildProcess();
+    const spawn = vi
+      .fn()
+      .mockReturnValueOnce(checkChild)
+      .mockReturnValueOnce(watchChild) as unknown as typeof ChildProcess.spawn;
+    const onCaptured = vi.fn();
+    const onError = vi.fn();
+    const manager = new DesktopAppSnapManager({
+      platform: "darwin",
+      helperPath: process.execPath,
+      captureDirectory,
+      excludedBundleId: SYNARA_DEVELOPMENT_BUNDLE_ID,
+      spawn,
+      onState: vi.fn(),
+      onCaptured,
+      onError,
+    });
+    const enable = manager.setEnabled(true);
+    await flushPromises();
+    checkChild.stdout.end(
+      `${JSON.stringify({ type: "permissions", inputMonitoring: "granted", screenRecording: "granted" })}\n`,
+    );
+    checkChild.stderr.end();
+    checkChild.emit("close", 0, null);
+    await enable;
+    return {
+      manager,
+      watchChild,
+      captureDirectory,
+      onCaptured,
+      onError,
+      dispose: () => {
+        manager.dispose();
+        rmSync(captureDirectory, { recursive: true, force: true });
+      },
+    };
+  }
+
+  function lastStdinLine(child: FakeChildProcess): string {
+    return child.stdin.read()?.toString().trimEnd() ?? "";
+  }
+
+  it("lists windows through a correlated request", async () => {
+    const { manager, watchChild, dispose } = await createEnabledManager();
+    try {
+      const listing = manager.listWindows();
+      await flushPromises();
+      const requestId = lastStdinLine(watchChild).slice("list-windows ".length);
+      watchChild.stdout.write(
+        `${JSON.stringify({
+          type: "windows",
+          requestId,
+          windows: [
+            {
+              windowId: 42,
+              appName: "Ghostty",
+              bundleIdentifier: "com.mitchellh.ghostty",
+              windowTitle: "dev",
+            },
+          ],
+        })}\n`,
+      );
+      expect(await listing).toEqual([
+        {
+          windowId: 42,
+          appName: "Ghostty",
+          bundleIdentifier: "com.mitchellh.ghostty",
+          windowTitle: "dev",
+          appIconDataUrl: null,
+        },
+      ]);
+    } finally {
+      dispose();
+    }
+  });
+
+  it("times out listWindows when the helper never answers", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      const { manager, dispose } = await createEnabledManager();
+      try {
+        const listing = manager.listWindows();
+        const assertion = expect(listing).rejects.toThrow(
+          "Timed out while listing capturable windows.",
+        );
+        await vi.advanceTimersByTimeAsync(5_000);
+        await assertion;
+      } finally {
+        dispose();
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("captures a specific window and keeps a pending record until acknowledged", async () => {
+    const { manager, watchChild, captureDirectory, dispose } = await createEnabledManager();
+    try {
+      const capturing = manager.captureWindow(77);
+      await flushPromises();
+      const requestId = lastStdinLine(watchChild).slice("capture-window ".length, -3);
+      expect(requestId).toMatch(/^picker-[a-f0-9-]+$/);
+      const capturePath = join(captureDirectory, "req-capture.png");
+      const captureBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 7]);
+      writeFileSync(capturePath, captureBytes);
+      watchChild.stdout.write(`${JSON.stringify({ type: "triggered", id: requestId })}\n`);
+      watchChild.stdout.write(
+        `${JSON.stringify({
+          type: "captured",
+          id: requestId,
+          path: capturePath,
+          name: "req-capture.png",
+          sourceAppName: "Safari",
+        })}\n`,
+      );
+      const capture = await capturing;
+      expect(capture).toMatchObject({ id: requestId, name: "req-capture.png" });
+      expect(FS.existsSync(capturePath)).toBe(false);
+      expect(await manager.listPendingCaptures()).toHaveLength(1);
+      await manager.acknowledgeCapture(capture.id);
+      expect(await manager.listPendingCaptures()).toHaveLength(0);
+    } finally {
+      dispose();
+    }
+  });
+
+  it("rejects values outside the macOS window id range before writing to the helper", async () => {
+    const { manager, watchChild, dispose } = await createEnabledManager();
+    try {
+      await expect(manager.captureWindow(0x1_0000_0000)).rejects.toThrow(
+        "captureWindow requires a valid macOS window id.",
+      );
+      expect(lastStdinLine(watchChild)).toBe("");
+    } finally {
+      dispose();
+    }
+  });
+
+  it("drops a late capture that arrives after the captureWindow timeout", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      const { manager, watchChild, captureDirectory, onCaptured, onError, dispose } =
+        await createEnabledManager();
+      try {
+        const capturing = manager.captureWindow(77);
+        await flushPromises();
+        const requestId = lastStdinLine(watchChild).slice("capture-window ".length, -3);
+        const assertion = expect(capturing).rejects.toThrow(
+          "Timed out while capturing the requested window.",
+        );
+        await vi.advanceTimersByTimeAsync(20_000);
+        await assertion;
+        const capturePath = join(captureDirectory, "late-capture.png");
+        writeFileSync(
+          capturePath,
+          Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 7]),
+        );
+        watchChild.stdout.write(
+          `${JSON.stringify({
+            type: "captured",
+            id: requestId,
+            path: capturePath,
+            name: "late-capture.png",
+            sourceAppName: "Safari",
+          })}\n`,
+        );
+        watchChild.stdout.write(
+          `${JSON.stringify({
+            type: "error",
+            id: requestId,
+            code: "capture-failed",
+            message: "late helper error",
+          })}\n`,
+        );
+        await vi.waitFor(() => expect(FS.existsSync(capturePath)).toBe(false));
+        await flushPromises();
+        expect(onCaptured).not.toHaveBeenCalled();
+        expect(onError).not.toHaveBeenCalled();
+        expect(await manager.listPendingCaptures()).toHaveLength(0);
+      } finally {
+        dispose();
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("removes a capture whose request times out while durable persistence is in flight", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const { manager, watchChild, captureDirectory, onCaptured, dispose } =
+      await createEnabledManager();
+    const originalRename = FS.promises.rename;
+    let markRenameStarted!: () => void;
+    const renameStarted = new Promise<void>((resolve) => {
+      markRenameStarted = resolve;
+    });
+    let releaseRename!: () => void;
+    const renameRelease = new Promise<void>((resolve) => {
+      releaseRename = resolve;
+    });
+    const renameSpy = vi
+      .spyOn(FS.promises, "rename")
+      .mockImplementationOnce(async (oldPath, newPath) => {
+        markRenameStarted();
+        await renameRelease;
+        return originalRename(oldPath, newPath);
+      });
+
+    try {
+      const capturing = manager.captureWindow(77);
+      await flushPromises();
+      const requestId = lastStdinLine(watchChild).slice("capture-window ".length, -3);
+      const capturePath = join(captureDirectory, `appsnap-${requestId}.png`);
+      writeFileSync(capturePath, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 7]));
+      watchChild.stdout.write(
+        `${JSON.stringify({
+          type: "captured",
+          id: requestId,
+          path: capturePath,
+          name: `appsnap-${requestId}.png`,
+        })}\n`,
+      );
+      await renameStarted;
+
+      const assertion = expect(capturing).rejects.toThrow(
+        "Timed out while capturing the requested window.",
+      );
+      await vi.advanceTimersByTimeAsync(20_000);
+      await assertion;
+      releaseRename();
+      for (let index = 0; index < 6; index += 1) await flushPromises();
+
+      expect(onCaptured).not.toHaveBeenCalled();
+      expect(await manager.listPendingCaptures()).toHaveLength(0);
+      expect(FS.existsSync(capturePath)).toBe(false);
+    } finally {
+      releaseRename();
+      renameSpy.mockRestore();
+      dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not recover an interrupted picker request as an unsolicited capture", async () => {
+    const { manager, watchChild, captureDirectory, dispose } = await createEnabledManager();
+    try {
+      const capturing = manager.captureWindow(77);
+      const assertion = expect(capturing).rejects.toThrow(
+        "AppSnap stopped listening while a request was in flight.",
+      );
+      await flushPromises();
+      const requestId = lastStdinLine(watchChild).slice("capture-window ".length, -3);
+      await manager.setEnabled(false);
+      await assertion;
+
+      const orphanedPickerPath = join(captureDirectory, `appsnap-${requestId}.png`);
+      writeFileSync(
+        orphanedPickerPath,
+        Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 7]),
+      );
+      manager.dispose();
+
+      const restoredManager = new DesktopAppSnapManager({
+        platform: "darwin",
+        helperPath: process.execPath,
+        captureDirectory,
+        excludedBundleId: SYNARA_DEVELOPMENT_BUNDLE_ID,
+        onState: vi.fn(),
+        onCaptured: vi.fn(),
+        onError: vi.fn(),
+      });
+      expect(await restoredManager.listPendingCaptures()).toHaveLength(0);
+      expect(FS.existsSync(orphanedPickerPath)).toBe(false);
+      restoredManager.dispose();
+    } finally {
+      dispose();
+    }
+  });
+
+  it("recovers an unacknowledged request-driven capture after a manager restart", async () => {
+    const captureDirectory = mkdtempSync(join(tmpdir(), "synara-appsnap-request-restart-"));
+    const firstCheckChild = createFakeChildProcess();
+    const watchChild = createFakeChildProcess();
+    const spawn = vi
+      .fn()
+      .mockReturnValueOnce(firstCheckChild)
+      .mockReturnValueOnce(watchChild) as unknown as typeof ChildProcess.spawn;
+    const firstManager = new DesktopAppSnapManager({
+      platform: "darwin",
+      helperPath: process.execPath,
+      captureDirectory,
+      excludedBundleId: SYNARA_DEVELOPMENT_BUNDLE_ID,
+      spawn,
+      onState: vi.fn(),
+      onCaptured: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    try {
+      const enable = firstManager.setEnabled(true);
+      await flushPromises();
+      firstCheckChild.stdout.end(
+        `${JSON.stringify({
+          type: "permissions",
+          inputMonitoring: "granted",
+          screenRecording: "granted",
+        })}\n`,
+      );
+      firstCheckChild.stderr.end();
+      firstCheckChild.emit("close", 0, null);
+      await enable;
+
+      const capturing = firstManager.captureWindow(77);
+      await flushPromises();
+      const requestId = lastStdinLine(watchChild).slice("capture-window ".length, -3);
+      const capturePath = join(captureDirectory, "req-capture.png");
+      const captureBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 7]);
+      writeFileSync(capturePath, captureBytes);
+      watchChild.stdout.write(`${JSON.stringify({ type: "triggered", id: requestId })}\n`);
+      watchChild.stdout.write(
+        `${JSON.stringify({
+          type: "captured",
+          id: requestId,
+          path: capturePath,
+          name: "req-capture.png",
+          sourceAppName: "Safari",
+        })}\n`,
+      );
+      const capture = await capturing;
+      firstManager.dispose();
+
+      const restoredManager = new DesktopAppSnapManager({
+        platform: "darwin",
+        helperPath: process.execPath,
+        captureDirectory,
+        excludedBundleId: SYNARA_DEVELOPMENT_BUNDLE_ID,
+        spawn,
+        onState: vi.fn(),
+        onCaptured: vi.fn(),
+        onError: vi.fn(),
+      });
+      const restored = await restoredManager.listPendingCaptures();
+      expect(restored).toHaveLength(1);
+      expect(restored[0]).toMatchObject({
+        id: requestId,
+        name: "req-capture.png",
+        sourceAppName: "Safari",
+      });
+      expect(Buffer.from(restored[0]!.bytes)).toEqual(captureBytes);
+
+      await restoredManager.acknowledgeCapture(capture.id);
+      expect(await restoredManager.listPendingCaptures()).toHaveLength(0);
+      restoredManager.dispose();
+
+      const finalManager = new DesktopAppSnapManager({
+        platform: "darwin",
+        helperPath: process.execPath,
+        captureDirectory,
+        excludedBundleId: SYNARA_DEVELOPMENT_BUNDLE_ID,
+        spawn,
+        onState: vi.fn(),
+        onCaptured: vi.fn(),
+        onError: vi.fn(),
+      });
+      expect(await finalManager.listPendingCaptures()).toHaveLength(0);
+      finalManager.dispose();
+    } finally {
+      firstManager.dispose();
+      rmSync(captureDirectory, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/desktop/src/appSnapManager.ts
+++ b/apps/desktop/src/appSnapManager.ts
@@ -21,6 +21,7 @@ import {
   type DesktopAppSnapShortcutAvailability,
   type DesktopAppSnapShortcutUpdateResult,
   type DesktopAppSnapState,
+  type DesktopAppSnapWindowEntry,
 } from "@synara/contracts";
 import {
   DEFAULT_APP_SNAP_SHORTCUT,
@@ -38,6 +39,13 @@ const PENDING_CAPTURE_FILE_PATTERN = /^pending-([a-f0-9]{64})\.json$/;
 const PENDING_CAPTURE_IMAGE_PATTERN = /^pending-([a-f0-9]{64})\.png$/;
 const HELPER_CAPTURE_IMAGE_PATTERN =
   /^appsnap-([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\.png$/;
+const ORPHANED_PICKER_IMAGE_PATTERN =
+  /^appsnap-picker-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\.png$/;
+const LIST_WINDOWS_TIMEOUT_MS = 5_000;
+const CAPTURE_WINDOW_TIMEOUT_MS = 20_000;
+const MAX_MACOS_WINDOW_ID = 0xffff_ffff;
+// Late helper answers to timed-out or interrupted picker requests are dropped
+// instead of being consumed as unsolicited hotkey captures.
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
 type AppSnapHelperProcess = ChildProcess.ChildProcessByStdio<Writable | null, Readable, Readable>;
@@ -80,13 +88,21 @@ type AppSnapHelperMessage =
       sourceAppIconDataUrl?: string | null;
       sourceWindowTitle?: string | null;
     }
+  | { type: "windows"; requestId: string; windows: DesktopAppSnapWindowEntry[] }
   | {
       type: "error";
       id?: string;
       code: string;
       message: string;
       capturedAt?: string;
+      requestId?: string;
     };
+
+interface PendingAppSnapRequest<T> {
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+}
 
 export interface DesktopAppSnapManagerOptions {
   platform: NodeJS.Platform;
@@ -312,7 +328,37 @@ export function parseAppSnapHelperMessage(line: string): AppSnapHelperMessage | 
       message: value.message,
       ...(typeof value.id === "string" && value.id.length > 0 ? { id: value.id } : {}),
       ...(typeof value.capturedAt === "string" ? { capturedAt: value.capturedAt } : {}),
+      ...(typeof value.requestId === "string" && value.requestId.length > 0
+        ? { requestId: value.requestId }
+        : {}),
     };
+  }
+  if (
+    value.type === "windows" &&
+    typeof value.requestId === "string" &&
+    Array.isArray(value.windows)
+  ) {
+    const windows: DesktopAppSnapWindowEntry[] = [];
+    for (const candidate of value.windows) {
+      if (!candidate || typeof candidate !== "object") continue;
+      const entry = candidate as Record<string, unknown>;
+      if (
+        typeof entry.windowId !== "number" ||
+        !Number.isInteger(entry.windowId) ||
+        entry.windowId <= 0 ||
+        entry.windowId > MAX_MACOS_WINDOW_ID
+      ) {
+        continue;
+      }
+      windows.push({
+        windowId: entry.windowId,
+        appName: normalizeOptionalText(entry.appName),
+        bundleIdentifier: normalizeOptionalText(entry.bundleIdentifier),
+        windowTitle: normalizeOptionalText(entry.windowTitle),
+        appIconDataUrl: normalizeAppIconDataUrl(entry.appIconDataUrl),
+      });
+    }
+    return { type: "windows", requestId: value.requestId, windows };
   }
   return null;
 }
@@ -366,6 +412,9 @@ export class DesktopAppSnapManager {
   #captureReadQueue: Promise<void> = Promise.resolve();
   #shortcut: DesktopAppSnapShortcut = DEFAULT_APP_SNAP_SHORTCUT;
   #registeredAccelerator: string | null = null;
+  #pendingWindowRequests = new Map<string, PendingAppSnapRequest<DesktopAppSnapWindowEntry[]>>();
+  #pendingCaptureRequests = new Map<string, PendingAppSnapRequest<DesktopAppSnapCapture>>();
+  #timedOutCaptureRequestIds = new Set<string>();
 
   constructor(options: DesktopAppSnapManagerOptions) {
     this.#options = {
@@ -501,6 +550,122 @@ export class DesktopAppSnapManager {
     this.#pendingCaptures = this.#pendingCaptures.filter(({ capture }) => capture.id !== captureId);
   }
 
+  async listWindows(): Promise<DesktopAppSnapWindowEntry[]> {
+    const child = this.#requireWatchProcess();
+    const requestId = Crypto.randomUUID();
+    return await new Promise<DesktopAppSnapWindowEntry[]>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.#pendingWindowRequests.delete(requestId);
+        reject(new Error("Timed out while listing capturable windows."));
+      }, LIST_WINDOWS_TIMEOUT_MS);
+      this.#pendingWindowRequests.set(requestId, { resolve, reject, timer });
+      try {
+        child.stdin?.write(`list-windows ${requestId}\n`);
+      } catch {
+        this.#settleWindowRequest(requestId, null, new Error("AppSnap is not listening."));
+      }
+    });
+  }
+
+  async captureWindow(windowId: number): Promise<DesktopAppSnapCapture> {
+    if (!Number.isInteger(windowId) || windowId <= 0 || windowId > MAX_MACOS_WINDOW_ID) {
+      throw new Error("captureWindow requires a valid macOS window id.");
+    }
+    const child = this.#requireWatchProcess();
+    // The prefix keeps a request-driven helper file distinguishable from an
+    // unsolicited hotkey capture after a crash. Picker requests have already
+    // lost their caller after restart and must not be auto-attached elsewhere.
+    const requestId = `picker-${Crypto.randomUUID()}`;
+    return await new Promise<DesktopAppSnapCapture>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.#pendingCaptureRequests.delete(requestId);
+        this.#tombstoneCaptureRequest(requestId);
+        reject(new Error("Timed out while capturing the requested window."));
+      }, CAPTURE_WINDOW_TIMEOUT_MS);
+      this.#pendingCaptureRequests.set(requestId, { resolve, reject, timer });
+      try {
+        child.stdin?.write(`capture-window ${requestId} ${windowId}\n`);
+      } catch {
+        this.#settleCaptureRequest(requestId, null, new Error("AppSnap is not listening."));
+      }
+    });
+  }
+
+  #requireWatchProcess(): AppSnapHelperProcess {
+    const child = this.#watchProcess;
+    if (!child || this.#disposed || !this.#enabled) {
+      throw new Error("AppSnap is not listening.");
+    }
+    return child;
+  }
+
+  #settleWindowRequest(
+    requestId: string,
+    windows: DesktopAppSnapWindowEntry[] | null,
+    error?: Error,
+  ): void {
+    const request = this.#pendingWindowRequests.get(requestId);
+    if (!request) return;
+    this.#pendingWindowRequests.delete(requestId);
+    clearTimeout(request.timer);
+    if (error) {
+      request.reject(error);
+    } else {
+      request.resolve(windows ?? []);
+    }
+  }
+
+  #settleCaptureRequest(
+    requestId: string,
+    capture: DesktopAppSnapCapture | null,
+    error?: Error,
+  ): boolean {
+    const request = this.#pendingCaptureRequests.get(requestId);
+    if (!request) return false;
+    this.#pendingCaptureRequests.delete(requestId);
+    clearTimeout(request.timer);
+    if (error) {
+      request.reject(error);
+    } else if (capture) {
+      request.resolve(capture);
+    } else {
+      request.reject(new Error("The AppSnap helper returned no capture."));
+    }
+    return true;
+  }
+  // Timed-out request ids are tombstoned for the lifetime of the manager: a
+  // late capture for them must always be dropped, never consumed as a hotkey
+  // capture. The set stays tiny (timeouts are rare) and is cleared on dispose.
+  #tombstoneCaptureRequest(requestId: string): void {
+    this.#timedOutCaptureRequestIds.add(requestId);
+  }
+
+  async #dropLateRequestCapture(
+    message: Extract<AppSnapHelperMessage, { type: "captured" }>,
+  ): Promise<void> {
+    const capturePath = Path.resolve(message.path);
+    if (!isPathInsideDirectory(this.#options.captureDirectory, capturePath)) {
+      return;
+    }
+    await FS.promises.unlink(capturePath).catch(() => undefined);
+  }
+
+  #rejectPendingRequests(message: string): void {
+    const windowRequests = [...this.#pendingWindowRequests.values()];
+    const captureRequests = [...this.#pendingCaptureRequests.entries()];
+    this.#pendingWindowRequests.clear();
+    this.#pendingCaptureRequests.clear();
+    for (const request of windowRequests) {
+      clearTimeout(request.timer);
+      request.reject(new Error(message));
+    }
+    for (const [requestId, request] of captureRequests) {
+      clearTimeout(request.timer);
+      this.#tombstoneCaptureRequest(requestId);
+      request.reject(new Error(message));
+    }
+  }
+
   dispose(): void {
     this.#disposed = true;
     this.#stopWatchProcess();
@@ -508,6 +673,7 @@ export class DesktopAppSnapManager {
     this.#permissionProcess?.kill("SIGTERM");
     this.#permissionProcess = null;
     this.#pendingCaptures = [];
+    this.#timedOutCaptureRequestIds.clear();
   }
 
   async #ensurePendingCapturesLoaded(): Promise<void> {
@@ -537,6 +703,16 @@ export class DesktopAppSnapManager {
     for (const entry of entries) {
       const imageStorageKey = PENDING_CAPTURE_IMAGE_PATTERN.exec(entry)?.[1];
       if (!imageStorageKey || metadataStorageKeys.has(imageStorageKey)) continue;
+      await FS.promises
+        .unlink(Path.join(this.#options.captureDirectory, entry))
+        .catch(() => undefined);
+    }
+
+    // A picker capture belongs to the renderer request that initiated it. If
+    // the desktop process crashed before consuming the helper output, there is
+    // no safe target thread to recover it into on the next launch.
+    for (const entry of entries) {
+      if (!ORPHANED_PICKER_IMAGE_PATTERN.test(entry)) continue;
       await FS.promises
         .unlink(Path.join(this.#options.captureDirectory, entry))
         .catch(() => undefined);
@@ -670,6 +846,27 @@ export class DesktopAppSnapManager {
     });
   }
 
+  async #recordPendingCapture(pendingRecord: PendingAppSnapCaptureRecord): Promise<void> {
+    const nextPendingCaptures = [
+      ...this.#pendingCaptures.filter((entry) => entry.capture.id !== pendingRecord.capture.id),
+      pendingRecord,
+    ];
+    const discardedRecord =
+      nextPendingCaptures.length > MAX_PENDING_CAPTURES ? nextPendingCaptures[0] : null;
+    this.#pendingCaptures = nextPendingCaptures.slice(-MAX_PENDING_CAPTURES);
+    if (discardedRecord) {
+      await this.#deletePendingCaptureFiles(discardedRecord).catch((error) =>
+        console.warn("[desktop-appsnap] Could not delete an overflow pending capture", error),
+      );
+      this.#emitCaptureError(
+        "pending-capture-overflow",
+        `Synara could retain only the latest ${MAX_PENDING_CAPTURES} AppSnaps while the composer was unavailable. The oldest capture was discarded.`,
+        discardedRecord.capture.capturedAt,
+        false,
+      );
+    }
+  }
+
   #emitState(): void {
     this.#options.onState(this.getState());
   }
@@ -794,6 +991,7 @@ export class DesktopAppSnapManager {
       this.#watchProcess = null;
       this.#watchOutputLines?.close();
       this.#watchOutputLines = null;
+      this.#rejectPendingRequests("AppSnap stopped listening while a request was in flight.");
       this.#releaseShortcutReservation();
       const message = `Could not start AppSnap: ${error.message}`;
       this.#setState("error", message);
@@ -804,6 +1002,7 @@ export class DesktopAppSnapManager {
       this.#watchProcess = null;
       this.#watchOutputLines?.close();
       this.#watchOutputLines = null;
+      this.#rejectPendingRequests("AppSnap stopped listening while a request was in flight.");
       if (this.#disposed || this.#intentionalWatchStop || !this.#enabled) return;
       this.#releaseShortcutReservation();
       const message = `The AppSnap helper stopped unexpectedly (${signal ?? `exit ${code ?? "unknown"}`}).`;
@@ -817,6 +1016,7 @@ export class DesktopAppSnapManager {
     this.#watchProcess = null;
     this.#watchOutputLines?.close();
     this.#watchOutputLines = null;
+    this.#rejectPendingRequests("AppSnap stopped listening while a request was in flight.");
     if (!child) return;
     this.#intentionalWatchStop = true;
     child.kill("SIGTERM");
@@ -964,13 +1164,43 @@ export class DesktopAppSnapManager {
       this.#inputMonitoringPermission = message.inputMonitoring;
       this.#screenRecordingPermission = message.screenRecording;
       this.#emitState();
+      // A revocation must stop the helper and flip the picker off; a grant
+      // must start it. Reconcile so the UI follows the live permission state.
+      void this.#reconcileWatchProcess();
       return;
     }
     if (message.type === "triggered") {
-      console.info(`[desktop-appsnap] Option chord triggered (${message.id}).`);
+      if (!this.#pendingCaptureRequests.has(message.id)) {
+        console.info(`[desktop-appsnap] Option chord triggered (${message.id}).`);
+      }
+      return;
+    }
+    if (message.type === "windows") {
+      this.#settleWindowRequest(message.requestId, message.windows);
       return;
     }
     if (message.type === "captured") {
+      if (this.#pendingCaptureRequests.has(message.id)) {
+        this.#captureReadQueue = this.#captureReadQueue
+          .then(() => this.#consumeRequestCapture(message))
+          .catch((error) => {
+            this.#settleCaptureRequest(
+              message.id,
+              null,
+              error instanceof Error ? error : new Error(String(error)),
+            );
+            void this.#dropLateRequestCapture(message);
+          });
+        return;
+      }
+      if (this.#timedOutCaptureRequestIds.has(message.id)) {
+        // The request already failed with a timeout, so the caller was told.
+        // Drop the late file instead of consuming it as a hotkey capture.
+        this.#captureReadQueue = this.#captureReadQueue
+          .then(() => this.#dropLateRequestCapture(message))
+          .catch(() => undefined);
+        return;
+      }
       this.#captureReadQueue = this.#captureReadQueue
         .then(() => this.#consumeCapture(message))
         .catch((error) => {
@@ -983,6 +1213,39 @@ export class DesktopAppSnapManager {
         });
       return;
     }
+
+    if (message.type === "error" && message.requestId !== undefined) {
+      this.#settleWindowRequest(
+        message.requestId,
+        null,
+        new Error(`${message.message} (${message.code})`),
+      );
+      return;
+    }
+    if (
+      message.type === "error" &&
+      message.id !== undefined &&
+      this.#timedOutCaptureRequestIds.has(message.id)
+    ) {
+      // The request already failed with a timeout; a late error must not
+      // surface a second, spurious failure toast.
+      return;
+    }
+
+    if (
+      message.type === "error" &&
+      message.id !== undefined &&
+      this.#pendingCaptureRequests.has(message.id)
+    ) {
+      this.#settleCaptureRequest(
+        message.id,
+        null,
+        new Error(`${message.message} (${message.code})`),
+      );
+      return;
+    }
+
+    if (message.type !== "error") return;
 
     if (message.code === "event_tap_disabled" || message.code === "event-tap-disabled") {
       console.warn(`[desktop-appsnap] ${message.message}`);
@@ -1015,15 +1278,14 @@ export class DesktopAppSnapManager {
     );
   }
 
-  async #consumeCapture(
+  async #readCaptureFromHelperMessage(
     message: Extract<AppSnapHelperMessage, { type: "captured" }>,
-  ): Promise<void> {
+  ): Promise<{ capture: DesktopAppSnapCapture; capturePath: string }> {
     const capturePath = Path.resolve(message.path);
     if (!isPathInsideDirectory(this.#options.captureDirectory, capturePath)) {
       throw new Error("The AppSnap helper returned a capture outside its private directory.");
     }
 
-    await this.#ensurePendingCapturesLoaded();
     const bytes = await readValidatedPendingPng(capturePath);
     const now = this.#options.now();
     const capture: DesktopAppSnapCapture = {
@@ -1040,30 +1302,55 @@ export class DesktopAppSnapManager {
       sourceAppIconDataUrl: normalizeAppIconDataUrl(message.sourceAppIconDataUrl),
       sourceWindowTitle: normalizeOptionalText(message.sourceWindowTitle),
     };
+    return { capture, capturePath };
+  }
+
+  async #consumeCapture(
+    message: Extract<AppSnapHelperMessage, { type: "captured" }>,
+  ): Promise<void> {
+    const { capture, capturePath } = await this.#readCaptureFromHelperMessage(message);
+    await this.#ensurePendingCapturesLoaded();
     const pendingRecord = await this.#persistPendingCapture(capture);
     // Only delete the helper's temporary file once the pending copy durably
     // owns the capture; deleting it earlier would destroy the only on-disk
     // copy when persistence fails transiently.
     await FS.promises.unlink(capturePath).catch(() => undefined);
-    const nextPendingCaptures = [
-      ...this.#pendingCaptures.filter((entry) => entry.capture.id !== capture.id),
-      pendingRecord,
-    ];
-    const discardedRecord =
-      nextPendingCaptures.length > MAX_PENDING_CAPTURES ? nextPendingCaptures[0] : null;
-    this.#pendingCaptures = nextPendingCaptures.slice(-MAX_PENDING_CAPTURES);
-    if (discardedRecord) {
-      await this.#deletePendingCaptureFiles(discardedRecord).catch((error) =>
-        console.warn("[desktop-appsnap] Could not delete an overflow pending capture", error),
-      );
-      this.#emitCaptureError(
-        "pending-capture-overflow",
-        `Synara could retain only the latest ${MAX_PENDING_CAPTURES} AppSnaps while the composer was unavailable. The oldest capture was discarded.`,
-        discardedRecord.capture.capturedAt,
-        false,
-      );
-    }
+    await this.#recordPendingCapture(pendingRecord);
     this.#options.onCaptured(capture);
+  }
+
+  async #consumeRequestCapture(
+    message: Extract<AppSnapHelperMessage, { type: "captured" }>,
+  ): Promise<void> {
+    const { capture, capturePath } = await this.#readCaptureFromHelperMessage(message);
+    await this.#ensurePendingCapturesLoaded();
+    if (!this.#pendingCaptureRequests.has(capture.id)) {
+      await FS.promises.unlink(capturePath).catch(() => undefined);
+      return;
+    }
+    const pendingRecord = await this.#persistPendingCapture(capture);
+    if (!this.#pendingCaptureRequests.has(capture.id)) {
+      await Promise.all([
+        FS.promises.unlink(capturePath).catch(() => undefined),
+        this.#deletePendingCaptureFiles(pendingRecord).catch(() => undefined),
+      ]);
+      return;
+    }
+
+    // Register the durable recovery copy synchronously before resolving the
+    // renderer promise. No timeout callback can interleave between this call
+    // and settlement, so a capture cannot become pending after its caller was
+    // already told that the request failed.
+    const recordPromise = this.#recordPendingCapture(pendingRecord);
+    const settled = this.#settleCaptureRequest(capture.id, capture);
+    await FS.promises.unlink(capturePath).catch(() => undefined);
+    await recordPromise;
+    if (!settled) {
+      this.#pendingCaptures = this.#pendingCaptures.filter(
+        ({ capture: pendingCapture }) => pendingCapture.id !== capture.id,
+      );
+      await this.#deletePendingCaptureFiles(pendingRecord).catch(() => undefined);
+    }
   }
 
   #emitCaptureError(

--- a/apps/desktop/src/ipcChannels.ts
+++ b/apps/desktop/src/ipcChannels.ts
@@ -52,6 +52,8 @@ export const DESKTOP_IPC_CHANNELS = {
     requestPermissions: "desktop:appsnap-request-permissions",
     listPendingCaptures: "desktop:appsnap-list-pending-captures",
     acknowledgeCapture: "desktop:appsnap-acknowledge-capture",
+    listWindows: "desktop:appsnap-list-windows",
+    captureWindow: "desktop:appsnap-capture-window",
     captured: "desktop:appsnap-captured",
     error: "desktop:appsnap-error",
     state: "desktop:appsnap-state",

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -186,6 +186,8 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     listPendingCaptures: () => ipcRenderer.invoke(IPC.appSnap.listPendingCaptures),
     acknowledgeCapture: (captureId) =>
       ipcRenderer.invoke(IPC.appSnap.acknowledgeCapture, captureId),
+    listWindows: () => ipcRenderer.invoke(IPC.appSnap.listWindows),
+    captureWindow: (input) => ipcRenderer.invoke(IPC.appSnap.captureWindow, input),
     onCaptured: (listener) => {
       const wrappedListener = (_event: Electron.IpcRendererEvent, capture: unknown) => {
         if (typeof capture !== "object" || capture === null) return;

--- a/apps/web/src/appSnapAttach.ts
+++ b/apps/web/src/appSnapAttach.ts
@@ -1,0 +1,38 @@
+// FILE: appSnapAttach.ts
+// Purpose: Shared completion flow for an AppSnap capture once its target thread is known.
+// Layer: Web composer domain
+// Depends on: composer draft image intake, toast notifications, and optional bridge acknowledgement.
+
+import type { DesktopAppSnapCapture, ThreadId } from "@synara/contracts";
+
+import { insertAppSnapCaptureIntoDraft } from "~/appSnapIntake";
+import { toastManager } from "~/components/ui/toast";
+
+export async function attachAppSnapCapture(
+  threadId: ThreadId,
+  capture: DesktopAppSnapCapture,
+  acknowledge?: () => Promise<void>,
+): Promise<"persisted" | "unverified"> {
+  const persistenceResult = await insertAppSnapCaptureIntoDraft(threadId, capture);
+
+  const unverifiedDescription =
+    "The capture is attached, but Synara could not verify its draft metadata. If it is missing after a reload, Synara will attach it again.";
+  const successDescription = capture.sourceAppName
+    ? `Captured ${capture.sourceAppName} and added it to the composer.`
+    : "The window was added to the composer.";
+
+  toastManager.add({
+    type: persistenceResult === "unverified" ? "warning" : "success",
+    title: persistenceResult === "unverified" ? "AppSnap added with a warning" : "AppSnap added",
+    description: persistenceResult === "unverified" ? unverifiedDescription : successDescription,
+    data: { allowCrossThreadVisibility: true },
+  });
+
+  if (persistenceResult === "persisted" && acknowledge) {
+    await acknowledge().catch((error) =>
+      console.warn("[appsnap] Could not acknowledge capture", error),
+    );
+  }
+
+  return persistenceResult;
+}

--- a/apps/web/src/appSnapIntake.test.ts
+++ b/apps/web/src/appSnapIntake.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DesktopAppSnapCapture } from "@synara/contracts";
+
+import { insertAppSnapCaptureIntoDraft } from "./appSnapIntake";
+import { useComposerDraftStore } from "./composerDraftStore";
+
+const prepareComposerImageAttachmentsFromFiles = vi.fn();
+const effectiveComposerAttachmentCount = vi.fn(() => 0);
+const persistComposerImageBlob = vi.fn();
+const deleteComposerImageBlob = vi.fn();
+const persistAppSnapIcon = vi.fn();
+const readAppSnapIcon = vi.fn();
+
+vi.mock("./lib/composerSend", () => ({
+  effectiveComposerAttachmentCount: (...args: unknown[]) =>
+    effectiveComposerAttachmentCount(...(args as [])),
+  prepareComposerImageAttachmentsFromFiles: (...args: unknown[]) =>
+    prepareComposerImageAttachmentsFromFiles(...(args as [])),
+}));
+vi.mock("./lib/composerImageBlobStore", () => ({
+  persistComposerImageBlob: (...args: unknown[]) => persistComposerImageBlob(...(args as [])),
+  deleteComposerImageBlob: (...args: unknown[]) => deleteComposerImageBlob(...(args as [])),
+  readComposerImageBlob: vi.fn(),
+}));
+vi.mock("./lib/appSnapIconStore", () => ({
+  persistAppSnapIcon: (...args: unknown[]) => persistAppSnapIcon(...(args as [])),
+  readAppSnapIcon: (...args: unknown[]) => readAppSnapIcon(...(args as [])),
+}));
+
+function preparedImage(id: string) {
+  const file = new File(["image"], `${id}.png`, { type: "image/png" });
+  return {
+    type: "image" as const,
+    id,
+    name: file.name,
+    mimeType: file.type,
+    sizeBytes: file.size,
+    previewUrl: `blob:${id}`,
+    file,
+  };
+}
+
+function captureFixture(overrides: Partial<DesktopAppSnapCapture> = {}): DesktopAppSnapCapture {
+  return {
+    id: "capture-1",
+    capturedAt: "2026-09-02T10:00:00.000Z",
+    name: "AppSnap-capture-1.png",
+    mimeType: "image/png",
+    sizeBytes: 5,
+    bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d]),
+    sourceAppName: "Ghostty",
+    sourceBundleIdentifier: "com.mitchellh.ghostty",
+    sourceAppIconDataUrl: null,
+    sourceWindowTitle: "dev",
+    ...overrides,
+  };
+}
+
+const threadId = "thread-1" as never;
+
+describe("insertAppSnapCaptureIntoDraft", () => {
+  const setPromptHistorySavedDraft = vi.fn();
+  const addImage = vi.fn((_threadId: unknown, _image: unknown) => true);
+  const syncPersistedAttachments = vi.fn();
+  const removeImage = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prepareComposerImageAttachmentsFromFiles.mockResolvedValue({
+      images: [preparedImage("image-1")],
+      error: null,
+    });
+    persistComposerImageBlob.mockResolvedValue("blob-key-1");
+    deleteComposerImageBlob.mockResolvedValue(undefined);
+    persistAppSnapIcon.mockResolvedValue(undefined);
+    readAppSnapIcon.mockResolvedValue(null);
+    syncPersistedAttachments.mockResolvedValue("persisted");
+    vi.spyOn(useComposerDraftStore, "getState").mockReturnValue({
+      draftsByThreadId: {},
+      setPromptHistorySavedDraft,
+      addImage,
+      syncPersistedAttachments,
+      removeImage,
+    } as never);
+  });
+
+  it("persists the capture into the thread draft with appsnap provenance", async () => {
+    await expect(insertAppSnapCaptureIntoDraft(threadId, captureFixture())).resolves.toBe(
+      "persisted",
+    );
+    expect(addImage).toHaveBeenCalledOnce();
+    expect(addImage.mock.calls[0]?.[1]).toMatchObject({
+      id: "image-1",
+      source: {
+        kind: "appsnap",
+        captureId: "capture-1",
+        appName: "Ghostty",
+        windowTitle: "dev",
+      },
+    });
+    expect(syncPersistedAttachments).toHaveBeenCalledOnce();
+    expect(setPromptHistorySavedDraft).toHaveBeenCalledWith(threadId, null);
+  });
+
+  it("rolls back the image and blob without discarding prompt history when persistence rejects", async () => {
+    syncPersistedAttachments.mockResolvedValue("rejected");
+    await expect(insertAppSnapCaptureIntoDraft(threadId, captureFixture())).rejects.toThrow(
+      "draft metadata was rejected",
+    );
+    expect(addImage).toHaveBeenCalledWith(threadId, expect.anything());
+    expect(setPromptHistorySavedDraft).not.toHaveBeenCalled();
+    expect(removeImage).toHaveBeenCalledWith(threadId, "image-1");
+    expect(deleteComposerImageBlob).toHaveBeenCalledWith("blob-key-1");
+  });
+
+  it("rolls back the prepared image when the draft is already full", async () => {
+    addImage.mockReturnValue(false);
+    const revokeObjectUrl = vi.fn();
+    const originalRevoke = URL.revokeObjectURL;
+    URL.revokeObjectURL = revokeObjectUrl;
+    try {
+      await expect(insertAppSnapCaptureIntoDraft(threadId, captureFixture())).rejects.toThrow(
+        "maximum number of references",
+      );
+      expect(revokeObjectUrl).toHaveBeenCalledWith("blob:image-1");
+      expect(deleteComposerImageBlob).toHaveBeenCalledWith("blob-key-1");
+      expect(setPromptHistorySavedDraft).not.toHaveBeenCalled();
+    } finally {
+      URL.revokeObjectURL = originalRevoke;
+    }
+  });
+});

--- a/apps/web/src/appSnapIntake.ts
+++ b/apps/web/src/appSnapIntake.ts
@@ -1,0 +1,122 @@
+// FILE: appSnapIntake.ts
+// Purpose: Turns a desktop AppSnap capture into a persisted composer image attachment.
+// Layer: Web composer domain
+// Depends on: composer draft store, composer image intake, and AppSnap icon cache.
+
+import type { DesktopAppSnapCapture, ThreadId } from "@synara/contracts";
+
+import { persistAppSnapIcon, readAppSnapIcon } from "./lib/appSnapIconStore";
+import { deleteComposerImageBlob, persistComposerImageBlob } from "./lib/composerImageBlobStore";
+import { type ComposerAppSnapSource } from "./lib/composerImageSource";
+import {
+  effectiveComposerAttachmentCount,
+  prepareComposerImageAttachmentsFromFiles,
+} from "./lib/composerSend";
+import { useComposerDraftStore } from "./composerDraftStore";
+
+export async function sourceWithCachedIcon(
+  source: ComposerAppSnapSource,
+): Promise<ComposerAppSnapSource> {
+  const bundleIdentifier = source.bundleIdentifier?.trim() || null;
+  if (!bundleIdentifier) return source;
+  if (source.appIconDataUrl) {
+    await persistAppSnapIcon({
+      bundleIdentifier,
+      dataUrl: source.appIconDataUrl,
+    }).catch((error) => console.warn("[appsnap] Could not cache source app icon", error));
+    return source;
+  }
+  const appIconDataUrl = await readAppSnapIcon(bundleIdentifier).catch((error) => {
+    console.warn("[appsnap] Could not restore source app icon", error);
+    return null;
+  });
+  return appIconDataUrl ? { ...source, appIconDataUrl } : source;
+}
+
+export async function insertAppSnapCaptureIntoDraft(
+  threadId: ThreadId,
+  capture: DesktopAppSnapCapture,
+): Promise<"persisted" | "unverified"> {
+  const parsedCaptureAt = Date.parse(capture.capturedAt);
+  const captureAtMs = Number.isFinite(parsedCaptureAt) ? parsedCaptureAt : Date.now();
+  const bytes = new Uint8Array(capture.bytes);
+  if (bytes.byteLength === 0) throw new Error("The captured AppSnap is empty.");
+  const file = new File([bytes], capture.name, {
+    type: capture.mimeType,
+    lastModified: captureAtMs,
+  });
+  const draftStore = useComposerDraftStore.getState();
+  const draft = draftStore.draftsByThreadId[threadId];
+  const existingAttachmentCount = effectiveComposerAttachmentCount(draft);
+  const { images, error } = await prepareComposerImageAttachmentsFromFiles({
+    files: [file],
+    existingAttachmentCount,
+  });
+  const image = images[0];
+  if (!image) throw new Error(error ?? "Synara could not attach the captured AppSnap.");
+
+  let imageAddedToDraft = false;
+  let blobKey: string | null = null;
+  let persistenceResult: "persisted" | "unverified" = "persisted";
+  try {
+    const source: ComposerAppSnapSource = {
+      kind: "appsnap",
+      captureId: capture.id,
+      capturedAt: capture.capturedAt,
+      appName: capture.sourceAppName,
+      bundleIdentifier: capture.sourceBundleIdentifier,
+      appIconDataUrl: capture.sourceAppIconDataUrl,
+      windowTitle: capture.sourceWindowTitle,
+    };
+    const sourceWithIcon = await sourceWithCachedIcon(source);
+    const appSnapImage = { ...image, source: sourceWithIcon };
+    blobKey = await persistComposerImageBlob({
+      threadId,
+      imageId: appSnapImage.id,
+      file: appSnapImage.file,
+    });
+
+    if (!draftStore.addImage(threadId, appSnapImage)) {
+      throw new Error(
+        "The AppSnap was prepared, but this message already has the maximum number of references.",
+      );
+    }
+    imageAddedToDraft = true;
+    const currentPersistedAttachments =
+      useComposerDraftStore.getState().draftsByThreadId[threadId]?.persistedAttachments ?? [];
+    const result = await draftStore.syncPersistedAttachments(threadId, [
+      ...currentPersistedAttachments.filter((attachment) => attachment.id !== appSnapImage.id),
+      {
+        id: appSnapImage.id,
+        name: appSnapImage.name,
+        mimeType: appSnapImage.mimeType,
+        sizeBytes: appSnapImage.sizeBytes,
+        blobKey,
+        source: sourceWithIcon,
+      },
+    ]);
+    if (result === "rejected") {
+      draftStore.removeImage(threadId, appSnapImage.id);
+      await deleteComposerImageBlob(blobKey).catch((cleanupError) =>
+        console.warn("[appsnap] Could not roll back rejected capture", cleanupError),
+      );
+      throw new Error("The AppSnap was captured, but its draft metadata was rejected.");
+    }
+    // Clear recalled prompt-history state only after the new attachment has
+    // survived persistence verification. A rejected mutation must leave the
+    // user's prior draft snapshot intact.
+    draftStore.setPromptHistorySavedDraft(threadId, null);
+    persistenceResult = result;
+  } catch (error) {
+    if (!imageAddedToDraft) {
+      URL.revokeObjectURL(image.previewUrl);
+      if (blobKey) {
+        await deleteComposerImageBlob(blobKey).catch((cleanupError) =>
+          console.warn("[appsnap] Could not roll back unattached capture", cleanupError),
+        );
+      }
+    }
+    throw error;
+  }
+  return persistenceResult;
+}

--- a/apps/web/src/components/AppSnapCoordinator.tsx
+++ b/apps/web/src/components/AppSnapCoordinator.tsx
@@ -6,6 +6,7 @@
 import {
   type DesktopAppSnapCapture,
   type DesktopAppSnapShortcut,
+  type DesktopBridge,
   type ThreadId,
 } from "@synara/contracts";
 import { useNavigate } from "@tanstack/react-router";
@@ -21,6 +22,8 @@ import {
   persistedAppSnapCaptureBlobKeys,
   resolveAppSnapTarget,
 } from "../appSnap.logic";
+import { attachAppSnapCapture } from "../appSnapAttach";
+import { sourceWithCachedIcon } from "../appSnapIntake";
 import {
   type ComposerImageAttachment,
   type PersistedComposerImageAttachment,
@@ -31,21 +34,11 @@ import { requestComposerFocus } from "../composerFocusRequestStore";
 import { useFocusedChatContext } from "../focusedChatContext";
 import { useHandleNewChat } from "../hooks/useHandleNewChat";
 import {
-  effectiveComposerAttachmentCount,
-  prepareComposerImageAttachmentsFromFiles,
-} from "../lib/composerSend";
-import {
-  deleteComposerImageBlob,
   deleteOrphanedComposerImageBlobs,
-  persistComposerImageBlob,
   readComposerImageBlob,
 } from "../lib/composerImageBlobStore";
-import { persistAppSnapIcon, readAppSnapIcon } from "../lib/appSnapIconStore";
 import { playAppSnapCaptureSound } from "../lib/appSnapSound";
-import {
-  type ComposerAppSnapSource,
-  isComposerAppSnapCaptureSource,
-} from "../lib/composerImageSource";
+import { isComposerAppSnapCaptureSource } from "../lib/composerImageSource";
 import { resolveRecentThreadSplitActivation } from "../recentViewActivation.logic";
 import { useSplitViewStore } from "../splitViewStore";
 import { useStore } from "../store";
@@ -86,23 +79,6 @@ function rememberCaptureId(captureIds: Map<string, true>, captureId: string): bo
     captureIds.delete(oldest);
   }
   return true;
-}
-
-async function sourceWithCachedIcon(source: ComposerAppSnapSource): Promise<ComposerAppSnapSource> {
-  const bundleIdentifier = source.bundleIdentifier?.trim() || null;
-  if (!bundleIdentifier) return source;
-  if (source.appIconDataUrl) {
-    await persistAppSnapIcon({
-      bundleIdentifier,
-      dataUrl: source.appIconDataUrl,
-    }).catch((error) => console.warn("[appsnap] Could not cache source app icon", error));
-    return source;
-  }
-  const appIconDataUrl = await readAppSnapIcon(bundleIdentifier).catch((error) => {
-    console.warn("[appsnap] Could not restore source app icon", error);
-    return null;
-  });
-  return appIconDataUrl ? { ...source, appIconDataUrl } : source;
 }
 
 // Kept at module scope so its try/finally stays out of the compiled coordinator.
@@ -220,7 +196,11 @@ export function AppSnapCoordinator() {
   const blobHydrationInFlightRef = useRef(new Set<string>());
   const hydratePersistedAppSnapsRef = useRef<(captureId?: string) => Promise<void>>(async () => {});
   const attachCaptureRef = useRef<
-    ((capture: DesktopAppSnapCapture) => Promise<"persisted" | "unverified">) | null
+    | ((
+        capture: DesktopAppSnapCapture,
+        bridge: DesktopBridge["appSnap"],
+      ) => Promise<"persisted" | "unverified">)
+    | null
   >(null);
   // Read through a ref so toggling the sound preference doesn't resubscribe the
   // capture listener (which would re-deliver pending captures).
@@ -359,7 +339,7 @@ export function AppSnapCoordinator() {
   );
 
   const attachCapture = useCallback(
-    async (capture: DesktopAppSnapCapture) => {
+    async (capture: DesktopAppSnapCapture, bridge: DesktopBridge["appSnap"]) => {
       const captureAtMs = captureTimestampMs(capture);
       const resolvedTarget = resolveAppSnapTarget({
         captureAtMs,
@@ -389,98 +369,11 @@ export function AppSnapCoordinator() {
         }
       }
 
-      const bytes = new Uint8Array(capture.bytes);
-      if (bytes.byteLength === 0) throw new Error("The captured AppSnap is empty.");
-      const file = new File([bytes], capture.name, {
-        type: capture.mimeType,
-        lastModified: captureAtMs,
-      });
-      const draftStore = useComposerDraftStore.getState();
-      const draft = draftStore.draftsByThreadId[target.threadId];
-      const existingAttachmentCount = effectiveComposerAttachmentCount(draft);
-      const { images, error } = await prepareComposerImageAttachmentsFromFiles({
-        files: [file],
-        existingAttachmentCount,
-      });
-      const image = images[0];
-      if (!image) throw new Error(error ?? "Synara could not attach the captured AppSnap.");
-
-      let imageAddedToDraft = false;
-      let blobKey: string | null = null;
-      let persistenceResult: "persisted" | "unverified" = "persisted";
-      try {
-        const source: ComposerAppSnapSource = {
-          kind: "appsnap",
-          captureId: capture.id,
-          capturedAt: capture.capturedAt,
-          appName: capture.sourceAppName,
-          bundleIdentifier: capture.sourceBundleIdentifier,
-          appIconDataUrl: capture.sourceAppIconDataUrl,
-          windowTitle: capture.sourceWindowTitle,
-        };
-        const sourceWithIcon = await sourceWithCachedIcon(source);
-        const appSnapImage = { ...image, source: sourceWithIcon };
-        blobKey = await persistComposerImageBlob({
-          threadId: target.threadId,
-          imageId: appSnapImage.id,
-          file: appSnapImage.file,
-        });
-
-        // Match ordinary composer mutations: recalled prompt-history state no longer owns the draft.
-        draftStore.setPromptHistorySavedDraft(target.threadId, null);
-        if (!draftStore.addImage(target.threadId, appSnapImage)) {
-          throw new Error(
-            "The AppSnap was prepared, but this message already has the maximum number of references.",
-          );
-        }
-        imageAddedToDraft = true;
-        const currentPersistedAttachments =
-          useComposerDraftStore.getState().draftsByThreadId[target.threadId]
-            ?.persistedAttachments ?? [];
-        const result = await draftStore.syncPersistedAttachments(target.threadId, [
-          ...currentPersistedAttachments.filter((attachment) => attachment.id !== appSnapImage.id),
-          {
-            id: appSnapImage.id,
-            name: appSnapImage.name,
-            mimeType: appSnapImage.mimeType,
-            sizeBytes: appSnapImage.sizeBytes,
-            blobKey,
-            source: sourceWithIcon,
-          },
-        ]);
-        if (result === "rejected") {
-          draftStore.removeImage(target.threadId, appSnapImage.id);
-          await deleteComposerImageBlob(blobKey).catch((error) =>
-            console.warn("[appsnap] Could not roll back rejected capture", error),
-          );
-          throw new Error("The AppSnap was captured, but its draft metadata was rejected.");
-        }
-        persistenceResult = result;
-      } catch (error) {
-        if (!imageAddedToDraft) {
-          URL.revokeObjectURL(image.previewUrl);
-          if (blobKey) {
-            await deleteComposerImageBlob(blobKey).catch((cleanupError) =>
-              console.warn("[appsnap] Could not roll back unattached capture", cleanupError),
-            );
-          }
-        }
-        throw error;
-      }
+      const persistenceResult = await attachAppSnapCapture(target.threadId, capture, () =>
+        bridge.acknowledgeCapture(capture.id),
+      );
       lastAppSnapRef.current = { ...target, atMs: captureAtMs };
       requestComposerFocus(target.threadId);
-      toastManager.add({
-        type: persistenceResult === "unverified" ? "warning" : "success",
-        title:
-          persistenceResult === "unverified" ? "AppSnap added with a warning" : "AppSnap added",
-        description:
-          persistenceResult === "unverified"
-            ? "The capture is attached, but Synara could not verify its draft metadata. If it is missing after a reload, Synara will attach it again."
-            : capture.sourceAppName
-              ? `Captured ${capture.sourceAppName} and added it to the composer.`
-              : "The frontmost window was added to the composer.",
-        data: { allowCrossThreadVisibility: true },
-      });
       return persistenceResult;
     },
     [activateExistingTarget, handleNewChat, openChatThreadPage],
@@ -526,7 +419,6 @@ export function AppSnapCoordinator() {
               }
             }
           }
-          let persistence: "persisted" | "unverified";
           try {
             // Missing blob bytes make the old metadata unusable. Purge every
             // row for this capture (including prompt-history snapshots) before
@@ -534,7 +426,7 @@ export function AppSnapCoordinator() {
             useComposerDraftStore.getState().removeAppSnapCapture(capture.id);
             const attach = attachCaptureRef.current;
             if (!attach) throw new Error("The AppSnap composer is not ready yet.");
-            persistence = await attach(capture);
+            await attach(capture, bridge);
           } catch (error) {
             toastManager.add({
               type: "error",
@@ -551,12 +443,6 @@ export function AppSnapCoordinator() {
             });
             return;
           }
-          // An unverified draft may vanish on reload; keeping the capture
-          // pending lets the next mount re-deliver it.
-          if (persistence !== "persisted") return;
-          await bridge
-            .acknowledgeCapture(capture.id)
-            .catch((error) => console.warn("[appsnap] Could not acknowledge capture", error));
         })
         .catch(() => undefined);
     };

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -11477,6 +11477,7 @@ export default function ChatView({
         interactionMode={interactionMode}
         supportsFastMode={composerTraitSelection.caps.supportsFastMode}
         fastModeEnabled={composerTraitSelection.fastModeEnabled}
+        threadId={threadId}
         onAddAttachments={addComposerAttachments}
         onToggleFastMode={toggleFastMode}
         onInteractionModeChange={handleInteractionModeChange}

--- a/apps/web/src/components/chat/ComposerExtrasMenu.browser.tsx
+++ b/apps/web/src/components/chat/ComposerExtrasMenu.browser.tsx
@@ -76,6 +76,7 @@ function appSnapBridge(overrides: {
   >;
   captureWindow?: (input: { windowId: number }) => Promise<DesktopAppSnapCapture>;
   acknowledgeCapture?: (captureId: string) => Promise<void>;
+  onState?: (listener: (state: DesktopAppSnapState) => void) => () => void;
 }) {
   return {
     appSnap: {
@@ -101,6 +102,7 @@ function appSnapBridge(overrides: {
           ])),
       captureWindow: overrides.captureWindow ?? (() => Promise.resolve(CAPTURE)),
       acknowledgeCapture: overrides.acknowledgeCapture ?? (() => Promise.resolve()),
+      onState: overrides.onState ?? (() => () => undefined),
     },
   };
 }
@@ -289,5 +291,45 @@ describe("ComposerExtrasMenu", () => {
 
     await expect.element(page.getByText("Enable AppSnap in Settings")).toBeVisible();
     expect(listWindows).not.toHaveBeenCalled();
+  });
+
+  it("lists windows when AppSnap becomes ready while the picker is open", async () => {
+    let emitState: ((state: DesktopAppSnapState) => void) | undefined;
+    const unsubscribe = vi.fn();
+    const listWindows = vi.fn(() =>
+      Promise.resolve([
+        {
+          windowId: 42,
+          appName: "Ghostty",
+          bundleIdentifier: "com.mitchellh.ghostty",
+          windowTitle: "dev",
+          appIconDataUrl: null,
+        },
+      ]),
+    );
+    setDesktopBridge(
+      appSnapBridge({
+        getState: () => Promise.resolve({ ...READY_STATE, status: "starting" }),
+        listWindows,
+        onState: (listener) => {
+          emitState = listener;
+          return unsubscribe;
+        },
+      }),
+    );
+    const menu = await mountMenu({ threadId });
+
+    await page.getByLabelText("Composer extras").click();
+    await page.getByText("Attach window").click();
+    await expect.element(page.getByText("AppSnap is starting…")).toBeVisible();
+    expect(listWindows).not.toHaveBeenCalled();
+
+    emitState?.(READY_STATE);
+
+    await expect.element(page.getByText("Ghostty")).toBeVisible();
+    expect(listWindows).toHaveBeenCalledOnce();
+
+    await menu.cleanup();
+    expect(unsubscribe).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/components/chat/ComposerExtrasMenu.browser.tsx
+++ b/apps/web/src/components/chat/ComposerExtrasMenu.browser.tsx
@@ -1,21 +1,115 @@
 // FILE: ComposerExtrasMenu.browser.tsx
-// Purpose: Verifies the composer `+` menu exposes generic file uploads and quick mode toggles.
+// Purpose: Verifies the composer `+` menu exposes generic file uploads, quick mode toggles, and the AppSnap window picker.
 // Layer: Browser UI test
 // Depends on: vitest browser rendering helpers and the ComposerExtrasMenu component.
 
 import "../../index.css";
 
 import { page } from "vitest/browser";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
-import type { ProviderInteractionMode } from "@synara/contracts";
+import type {
+  DesktopAppSnapCapture,
+  DesktopAppSnapState,
+  ProviderInteractionMode,
+  ThreadId,
+} from "@synara/contracts";
+
+const harness = vi.hoisted(() => ({
+  insertAppSnapCaptureIntoDraft: vi.fn(),
+  toastAdd: vi.fn(),
+}));
+
+vi.mock("~/appSnapIntake", () => ({
+  insertAppSnapCaptureIntoDraft: harness.insertAppSnapCaptureIntoDraft,
+}));
+
+vi.mock("~/components/ui/toast", () => ({
+  toastManager: { add: harness.toastAdd },
+}));
 
 import { ComposerExtrasMenu } from "./ComposerExtrasMenu";
+
+const threadId = "thread-1" as ThreadId;
+
+const READY_STATE: DesktopAppSnapState = {
+  platform: "macos",
+  supported: true,
+  enabled: true,
+  status: "ready",
+  shortcut: { kind: "both-option-keys" },
+  inputMonitoringPermission: "granted",
+  screenRecordingPermission: "granted",
+  message: null,
+};
+
+const CAPTURE: DesktopAppSnapCapture = {
+  id: "capture-1",
+  capturedAt: "2026-09-02T10:00:00.000Z",
+  name: "AppSnap-capture-1.png",
+  mimeType: "image/png",
+  sizeBytes: 5,
+  bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d]),
+  sourceAppName: "Ghostty",
+  sourceBundleIdentifier: "com.mitchellh.ghostty",
+  sourceAppIconDataUrl: null,
+  sourceWindowTitle: "dev",
+};
+
+function setDesktopBridge(value: unknown): void {
+  Object.defineProperty(window, "desktopBridge", {
+    configurable: true,
+    value,
+  });
+}
+
+function appSnapBridge(overrides: {
+  getState?: () => Promise<DesktopAppSnapState>;
+  listWindows?: () => Promise<
+    Array<{
+      windowId: number;
+      appName: string | null;
+      bundleIdentifier: string | null;
+      windowTitle: string | null;
+      appIconDataUrl: string | null;
+    }>
+  >;
+  captureWindow?: (input: { windowId: number }) => Promise<DesktopAppSnapCapture>;
+  acknowledgeCapture?: (captureId: string) => Promise<void>;
+}) {
+  return {
+    appSnap: {
+      getState: overrides.getState ?? (() => Promise.resolve(READY_STATE)),
+      listWindows:
+        overrides.listWindows ??
+        (() =>
+          Promise.resolve([
+            {
+              windowId: 42,
+              appName: "Ghostty",
+              bundleIdentifier: "com.mitchellh.ghostty",
+              windowTitle: "dev",
+              appIconDataUrl: null,
+            },
+            {
+              windowId: 43,
+              appName: "Finder",
+              bundleIdentifier: "com.apple.finder",
+              windowTitle: null,
+              appIconDataUrl: null,
+            },
+          ])),
+      captureWindow: overrides.captureWindow ?? (() => Promise.resolve(CAPTURE)),
+      acknowledgeCapture: overrides.acknowledgeCapture ?? (() => Promise.resolve()),
+    },
+  };
+}
 
 async function mountMenu(props?: {
   fastModeEnabled?: boolean;
   interactionMode?: ProviderInteractionMode;
   supportsFastMode?: boolean;
+  threadId?: ThreadId;
 }) {
   const onAddAttachments = vi.fn();
   const onToggleFastMode = vi.fn();
@@ -27,6 +121,7 @@ async function mountMenu(props?: {
       interactionMode={props?.interactionMode ?? "default"}
       supportsFastMode={props?.supportsFastMode ?? true}
       fastModeEnabled={props?.fastModeEnabled ?? false}
+      {...(props?.threadId !== undefined ? { threadId: props.threadId } : {})}
       onAddAttachments={onAddAttachments}
       onToggleFastMode={onToggleFastMode}
       onInteractionModeChange={onInteractionModeChange}
@@ -49,8 +144,14 @@ async function mountMenu(props?: {
 }
 
 describe("ComposerExtrasMenu", () => {
+  beforeEach(() => {
+    harness.insertAppSnapCaptureIntoDraft.mockReset().mockResolvedValue("persisted");
+    harness.toastAdd.mockReset();
+  });
+
   afterEach(() => {
     document.body.innerHTML = "";
+    setDesktopBridge(undefined);
   });
 
   it("uses an unrestricted file picker and forwards every selected file", async () => {
@@ -108,5 +209,85 @@ describe("ComposerExtrasMenu", () => {
     await page.getByRole("menuitemradio", { name: "Fast" }).click();
 
     expect(menu.onToggleFastMode).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the AppSnap window picker without a desktop bridge", async () => {
+    await using _ = await mountMenu({ threadId });
+
+    await page.getByLabelText("Composer extras").click();
+
+    await vi.waitFor(() => {
+      const text = document.body.textContent ?? "";
+      expect(text).toContain("Add files");
+      expect(text).not.toContain("Attach window");
+    });
+  });
+
+  it("lists windows and captures the picked window into the composer draft", async () => {
+    const captureWindow = vi.fn(() => Promise.resolve(CAPTURE));
+    const acknowledgeCapture = vi.fn(() => Promise.resolve());
+    setDesktopBridge(appSnapBridge({ captureWindow, acknowledgeCapture }));
+    await using _ = await mountMenu({ threadId });
+
+    await page.getByLabelText("Composer extras").click();
+    await page.getByText("Attach window").click();
+
+    await vi.waitFor(() => {
+      const text = document.body.textContent ?? "";
+      expect(text).toContain("Ghostty");
+      expect(text).toContain("Finder");
+    });
+    await page.getByText("Ghostty").click();
+
+    await vi.waitFor(() => {
+      expect(captureWindow).toHaveBeenCalledWith({ windowId: 42 });
+      expect(harness.insertAppSnapCaptureIntoDraft).toHaveBeenCalledWith(threadId, CAPTURE);
+      expect(acknowledgeCapture).toHaveBeenCalledWith("capture-1");
+      expect(harness.toastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "success", title: "AppSnap added" }),
+      );
+    });
+  });
+
+  it("keeps the desktop recovery copy when draft persistence is unverified", async () => {
+    harness.insertAppSnapCaptureIntoDraft.mockResolvedValue("unverified");
+    const acknowledgeCapture = vi.fn(() => Promise.resolve());
+    setDesktopBridge(appSnapBridge({ acknowledgeCapture }));
+    await using _ = await mountMenu({ threadId });
+
+    await page.getByLabelText("Composer extras").click();
+    await page.getByText("Attach window").click();
+    await expect.element(page.getByText("Ghostty")).toBeVisible();
+    await page.getByText("Ghostty").click();
+
+    await vi.waitFor(() => {
+      expect(harness.insertAppSnapCaptureIntoDraft).toHaveBeenCalledWith(threadId, CAPTURE);
+      expect(acknowledgeCapture).not.toHaveBeenCalled();
+      expect(harness.toastAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "warning", title: "AppSnap added with a warning" }),
+      );
+    });
+  });
+
+  it("does not send a list request while AppSnap is disabled", async () => {
+    const listWindows = vi.fn(() => Promise.resolve([]));
+    setDesktopBridge(
+      appSnapBridge({
+        getState: () =>
+          Promise.resolve({
+            ...READY_STATE,
+            enabled: false,
+            status: "disabled",
+          }),
+        listWindows,
+      }),
+    );
+    await using _ = await mountMenu({ threadId });
+
+    await page.getByLabelText("Composer extras").click();
+    await page.getByText("Attach window").click();
+
+    await expect.element(page.getByText("Enable AppSnap in Settings")).toBeVisible();
+    expect(listWindows).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/chat/ComposerExtrasMenu.browser.tsx
+++ b/apps/web/src/components/chat/ComposerExtrasMenu.browser.tsx
@@ -332,4 +332,68 @@ describe("ComposerExtrasMenu", () => {
     await menu.cleanup();
     expect(unsubscribe).toHaveBeenCalledOnce();
   });
+
+  it("retries a failed window list once on a later ready state", async () => {
+    let emitState: ((state: DesktopAppSnapState) => void) | undefined;
+    const listWindows = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Could not list windows."))
+      .mockResolvedValueOnce([
+        {
+          windowId: 42,
+          appName: "Ghostty",
+          bundleIdentifier: "com.mitchellh.ghostty",
+          windowTitle: "dev",
+          appIconDataUrl: null,
+        },
+      ]);
+    setDesktopBridge(
+      appSnapBridge({
+        listWindows,
+        onState: (listener) => {
+          emitState = listener;
+          return () => undefined;
+        },
+      }),
+    );
+    await using _ = await mountMenu({ threadId });
+
+    await page.getByLabelText("Composer extras").click();
+    await page.getByText("Attach window").click();
+    await expect.element(page.getByText("Could not list windows.")).toBeVisible();
+
+    emitState?.(READY_STATE);
+
+    await expect.element(page.getByText("Ghostty")).toBeVisible();
+    expect(listWindows).toHaveBeenCalledTimes(2);
+    emitState?.(READY_STATE);
+    expect(listWindows).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the list error after the bounded ready-state retry is exhausted", async () => {
+    let emitState: ((state: DesktopAppSnapState) => void) | undefined;
+    const listWindows = vi.fn(() => Promise.reject(new Error("Could not list windows.")));
+    setDesktopBridge(
+      appSnapBridge({
+        listWindows,
+        onState: (listener) => {
+          emitState = listener;
+          return () => undefined;
+        },
+      }),
+    );
+    await using _ = await mountMenu({ threadId });
+
+    await page.getByLabelText("Composer extras").click();
+    await page.getByText("Attach window").click();
+    await expect.element(page.getByText("Could not list windows.")).toBeVisible();
+
+    emitState?.(READY_STATE);
+    await vi.waitFor(() => expect(listWindows).toHaveBeenCalledTimes(2));
+    await expect.element(page.getByText("Could not list windows.")).toBeVisible();
+
+    emitState?.(READY_STATE);
+    expect(listWindows).toHaveBeenCalledTimes(2);
+    await expect.element(page.getByText("Could not list windows.")).toBeVisible();
+  });
 });

--- a/apps/web/src/components/chat/ComposerExtrasMenu.tsx
+++ b/apps/web/src/components/chat/ComposerExtrasMenu.tsx
@@ -35,6 +35,7 @@ import {
 } from "../ui/menu";
 
 const APP_SNAP_MAX_WINDOWS_HEIGHT_CLASS = "max-h-80 overflow-y-auto";
+const APP_SNAP_WINDOW_LIST_ATTEMPT_LIMIT = 2;
 
 function appSnapUnavailableMessage(state: DesktopAppSnapState): string {
   if (!state.enabled || state.status === "disabled") return "Enable AppSnap in Settings";
@@ -98,22 +99,28 @@ export const ComposerExtrasMenu = function ComposerExtrasMenu(props: {
 
     let disposed = false;
     let listedForReadyState = false;
+    let windowListAttempts = 0;
 
     const applyState = (state: DesktopAppSnapState) => {
       if (disposed) return;
       setAppSnapState(state);
-      setAppSnapError(null);
 
       if (state.status !== "ready") {
         listedForReadyState = false;
+        windowListAttempts = 0;
         appSnapRequestIdRef.current += 1;
+        setAppSnapError(null);
         setAppSnapWindows([]);
         return;
       }
-      if (listedForReadyState) return;
+      if (listedForReadyState || windowListAttempts >= APP_SNAP_WINDOW_LIST_ATTEMPT_LIMIT) {
+        return;
+      }
       listedForReadyState = true;
+      windowListAttempts += 1;
 
       const requestId = ++appSnapRequestIdRef.current;
+      setAppSnapError(null);
       setAppSnapWindows(null);
       void appSnapBridge
         .listWindows()
@@ -124,6 +131,7 @@ export const ComposerExtrasMenu = function ComposerExtrasMenu(props: {
         })
         .catch((error) => {
           if (!disposed && appSnapRequestIdRef.current === requestId) {
+            listedForReadyState = false;
             setAppSnapError(error instanceof Error ? error.message : "Could not list windows.");
           }
         });

--- a/apps/web/src/components/chat/ComposerExtrasMenu.tsx
+++ b/apps/web/src/components/chat/ComposerExtrasMenu.tsx
@@ -93,31 +93,61 @@ export const ComposerExtrasMenu = function ComposerExtrasMenu(props: {
     };
   }, []);
 
-  const loadAppSnapWindows = () => {
-    const bridge = window.desktopBridge?.appSnap;
-    if (!bridge) return;
+  useEffect(() => {
+    if (!appSnapSubmenuOpen || !appSnapBridge) return;
+
+    let disposed = false;
+    let listedForReadyState = false;
+
+    const applyState = (state: DesktopAppSnapState) => {
+      if (disposed) return;
+      setAppSnapState(state);
+      setAppSnapError(null);
+
+      if (state.status !== "ready") {
+        listedForReadyState = false;
+        appSnapRequestIdRef.current += 1;
+        setAppSnapWindows([]);
+        return;
+      }
+      if (listedForReadyState) return;
+      listedForReadyState = true;
+
+      const requestId = ++appSnapRequestIdRef.current;
+      setAppSnapWindows(null);
+      void appSnapBridge
+        .listWindows()
+        .then((windows) => {
+          if (!disposed && appSnapRequestIdRef.current === requestId) {
+            setAppSnapWindows(windows);
+          }
+        })
+        .catch((error) => {
+          if (!disposed && appSnapRequestIdRef.current === requestId) {
+            setAppSnapError(error instanceof Error ? error.message : "Could not list windows.");
+          }
+        });
+    };
+
+    const unsubscribe = appSnapBridge.onState(applyState);
     const requestId = ++appSnapRequestIdRef.current;
-    setAppSnapWindows(null);
-    setAppSnapError(null);
-    setAppSnapState(null);
-    void bridge
+    void appSnapBridge
       .getState()
-      .then(async (state) => {
-        if (appSnapRequestIdRef.current !== requestId) return;
-        setAppSnapState(state);
-        if (state.status !== "ready") {
-          setAppSnapWindows([]);
-          return;
-        }
-        const windows = await bridge.listWindows();
-        if (appSnapRequestIdRef.current !== requestId) return;
-        setAppSnapWindows(windows);
+      .then((state) => {
+        if (!disposed && appSnapRequestIdRef.current === requestId) applyState(state);
       })
       .catch((error) => {
-        if (appSnapRequestIdRef.current !== requestId) return;
-        setAppSnapError(error instanceof Error ? error.message : "Could not list windows.");
+        if (!disposed && appSnapRequestIdRef.current === requestId) {
+          setAppSnapError(error instanceof Error ? error.message : "Could not list windows.");
+        }
       });
-  };
+
+    return () => {
+      disposed = true;
+      appSnapRequestIdRef.current += 1;
+      unsubscribe();
+    };
+  }, [appSnapBridge, appSnapSubmenuOpen]);
 
   const captureAppSnapWindow = (windowId: number) => {
     const bridge = window.desktopBridge?.appSnap;
@@ -192,7 +222,9 @@ export const ComposerExtrasMenu = function ComposerExtrasMenu(props: {
               onOpenChange={(open) => {
                 setAppSnapSubmenuOpen(open);
                 if (open) {
-                  loadAppSnapWindows();
+                  setAppSnapWindows(null);
+                  setAppSnapError(null);
+                  setAppSnapState(null);
                 } else {
                   appSnapRequestIdRef.current += 1;
                 }

--- a/apps/web/src/components/chat/ComposerExtrasMenu.tsx
+++ b/apps/web/src/components/chat/ComposerExtrasMenu.tsx
@@ -3,10 +3,24 @@
 // Layer: Chat composer presentation
 // Depends on: shared menu primitives, icon buttons, and caller-owned composer state callbacks.
 
-import { type ProviderInteractionMode } from "@synara/contracts";
-import { useId, useRef, type ChangeEvent } from "react";
+import type {
+  DesktopAppSnapState,
+  DesktopAppSnapWindowEntry,
+  ProviderInteractionMode,
+  ThreadId,
+} from "@synara/contracts";
+import { useEffect, useId, useRef, useState, type ChangeEvent } from "react";
 
-import { BugIcon, ListTodoIcon, MessageCircleIcon, PaperclipIcon, PlusIcon } from "~/lib/icons";
+import { attachAppSnapCapture } from "~/appSnapAttach";
+import {
+  BugIcon,
+  ListTodoIcon,
+  MessageCircleIcon,
+  PaperclipIcon,
+  PlusIcon,
+  WindowIcon,
+} from "~/lib/icons";
+import { toastManager } from "../ui/toast";
 import { ComposerPickerMenuPopup, ComposerPickerMenuSubPopup } from "./ComposerPickerMenuPopup";
 import { Button } from "../ui/button";
 import {
@@ -20,16 +34,113 @@ import {
   MenuTrigger,
 } from "../ui/menu";
 
+const APP_SNAP_MAX_WINDOWS_HEIGHT_CLASS = "max-h-80 overflow-y-auto";
+
+function appSnapUnavailableMessage(state: DesktopAppSnapState): string {
+  if (!state.enabled || state.status === "disabled") return "Enable AppSnap in Settings";
+  if (state.status === "permission-required") return "Finish AppSnap permissions in Settings";
+  if (state.status === "starting") return "AppSnap is starting…";
+  return state.message?.trim() || "AppSnap is unavailable.";
+}
+
+function AppSnapWindowRowContent(props: { window: DesktopAppSnapWindowEntry }) {
+  const appName = props.window.appName?.trim() || "Captured app";
+  const windowTitle = props.window.windowTitle?.trim() || null;
+  return (
+    <span className="flex min-w-0 items-center gap-2">
+      {props.window.appIconDataUrl ? (
+        <img src={props.window.appIconDataUrl} alt="" className="size-4 shrink-0 rounded-[4px]" />
+      ) : (
+        <WindowIcon className="size-4 shrink-0" />
+      )}
+      <span className="min-w-0">
+        <span className="block truncate">{appName}</span>
+        {windowTitle ? (
+          <span className="block truncate text-xs text-muted-foreground">{windowTitle}</span>
+        ) : null}
+      </span>
+    </span>
+  );
+}
+
 export const ComposerExtrasMenu = function ComposerExtrasMenu(props: {
   interactionMode: ProviderInteractionMode;
   supportsFastMode: boolean;
   fastModeEnabled: boolean;
+  threadId?: ThreadId;
   onAddAttachments: (files: File[]) => void;
   onToggleFastMode: () => void;
   onInteractionModeChange: (mode: ProviderInteractionMode) => void;
 }) {
   const inputId = useId();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const appSnapRequestIdRef = useRef(0);
+  const mountedRef = useRef(false);
+  const [appSnapSubmenuOpen, setAppSnapSubmenuOpen] = useState(false);
+  const [appSnapWindows, setAppSnapWindows] = useState<DesktopAppSnapWindowEntry[] | null>(null);
+  const [appSnapState, setAppSnapState] = useState<DesktopAppSnapState | null>(null);
+  const [appSnapError, setAppSnapError] = useState<string | null>(null);
+  const [appSnapBusy, setAppSnapBusy] = useState(false);
+
+  const appSnapBridge = window.desktopBridge?.appSnap;
+  const appSnapAvailable = Boolean(props.threadId && appSnapBridge);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      appSnapRequestIdRef.current += 1;
+    };
+  }, []);
+
+  const loadAppSnapWindows = () => {
+    const bridge = window.desktopBridge?.appSnap;
+    if (!bridge) return;
+    const requestId = ++appSnapRequestIdRef.current;
+    setAppSnapWindows(null);
+    setAppSnapError(null);
+    setAppSnapState(null);
+    void bridge
+      .getState()
+      .then(async (state) => {
+        if (appSnapRequestIdRef.current !== requestId) return;
+        setAppSnapState(state);
+        if (state.status !== "ready") {
+          setAppSnapWindows([]);
+          return;
+        }
+        const windows = await bridge.listWindows();
+        if (appSnapRequestIdRef.current !== requestId) return;
+        setAppSnapWindows(windows);
+      })
+      .catch((error) => {
+        if (appSnapRequestIdRef.current !== requestId) return;
+        setAppSnapError(error instanceof Error ? error.message : "Could not list windows.");
+      });
+  };
+
+  const captureAppSnapWindow = (windowId: number) => {
+    const bridge = window.desktopBridge?.appSnap;
+    const threadId = props.threadId;
+    if (!bridge || !threadId || appSnapBusy) return;
+    setAppSnapBusy(true);
+    void bridge
+      .captureWindow({ windowId })
+      .then(async (capture) => {
+        await attachAppSnapCapture(threadId, capture, () => bridge.acknowledgeCapture(capture.id));
+      })
+      .catch((error) => {
+        toastManager.add({
+          type: "error",
+          title: "AppSnap failed",
+          description: error instanceof Error ? error.message : "Could not capture the window.",
+          data: { allowCrossThreadVisibility: true },
+        });
+      })
+      .finally(() => {
+        if (mountedRef.current) setAppSnapBusy(false);
+      });
+  };
 
   // Reset the hidden input so selecting the same file twice still emits a change event.
   const handleFileInputChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -39,6 +150,8 @@ export const ComposerExtrasMenu = function ComposerExtrasMenu(props: {
     }
     event.target.value = "";
   };
+
+  const appSnapListening = appSnapState?.status === "ready";
 
   return (
     <>
@@ -73,6 +186,49 @@ export const ComposerExtrasMenu = function ComposerExtrasMenu(props: {
             <PaperclipIcon className="size-4 shrink-0" />
             Add files
           </MenuItem>
+
+          {appSnapAvailable ? (
+            <MenuSub
+              onOpenChange={(open) => {
+                setAppSnapSubmenuOpen(open);
+                if (open) {
+                  loadAppSnapWindows();
+                } else {
+                  appSnapRequestIdRef.current += 1;
+                }
+              }}
+            >
+              <MenuSubTrigger>
+                <WindowIcon className="size-4 shrink-0" />
+                Attach window
+              </MenuSubTrigger>
+              <ComposerPickerMenuSubPopup className={APP_SNAP_MAX_WINDOWS_HEIGHT_CLASS}>
+                {appSnapSubmenuOpen ? (
+                  appSnapError ? (
+                    <MenuItem disabled>{appSnapError}</MenuItem>
+                  ) : appSnapState && !appSnapListening ? (
+                    <MenuItem disabled>{appSnapUnavailableMessage(appSnapState)}</MenuItem>
+                  ) : appSnapWindows === null ? (
+                    <MenuItem disabled>Loading windows…</MenuItem>
+                  ) : appSnapWindows.length === 0 ? (
+                    <MenuItem disabled>No other app windows are visible.</MenuItem>
+                  ) : (
+                    appSnapWindows.map((window) => (
+                      <MenuItem
+                        key={window.windowId}
+                        disabled={appSnapBusy}
+                        onClick={() => {
+                          captureAppSnapWindow(window.windowId);
+                        }}
+                      >
+                        <AppSnapWindowRowContent window={window} />
+                      </MenuItem>
+                    ))
+                  )
+                ) : null}
+              </ComposerPickerMenuSubPopup>
+            </MenuSub>
+          ) : null}
 
           <MenuSeparator />
           <MenuSub>

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -482,6 +482,14 @@ export interface DesktopAppSnapErrorEvent {
   capturedAt: string;
 }
 
+export interface DesktopAppSnapWindowEntry {
+  windowId: number;
+  appName: string | null;
+  bundleIdentifier: string | null;
+  windowTitle: string | null;
+  appIconDataUrl: string | null;
+}
+
 // Pushed from the desktop main process when the in-app browser copy-link chord fires
 // while the native page (not the React chrome) holds keyboard focus.
 export interface BrowserCopyLinkEvent {
@@ -661,6 +669,8 @@ export interface DesktopBridge {
     requestPermissions: () => Promise<DesktopAppSnapState>;
     listPendingCaptures: () => Promise<DesktopAppSnapCapture[]>;
     acknowledgeCapture: (captureId: string) => Promise<void>;
+    listWindows: () => Promise<DesktopAppSnapWindowEntry[]>;
+    captureWindow: (input: { windowId: number }) => Promise<DesktopAppSnapCapture>;
     onCaptured: (listener: (capture: DesktopAppSnapCapture) => void) => () => void;
     onError: (listener: (error: DesktopAppSnapErrorEvent) => void) => () => void;
     onState: (listener: (state: DesktopAppSnapState) => void) => () => void;


### PR DESCRIPTION
## Summary\n\n- reconstructs the valuable AppSnap window-picker subset from #913 as one coherent feature on current Synara architecture\n- retains native listWindows and captureWindow support, the composer picker/selection flow, durable draft intake and acknowledgement, and late-result tombstones\n- removes the superseded GrantCoach, bare global Escape hotkey, 80 ms full-system polling, and duplicate permission-guide/settings/restart architecture\n- hardens request correlation, timeout/interruption cleanup, stale picker results, rejected persistence rollback, window ID validation, capture teardown, helper-file startup cleanup, and picker readiness/error recovery\n\n## Attribution\n\nThis is the owner-authored integration replacement for #913, whose original implementation was authored by @kartikkabadi. It preserves Kartik's product direction and contribution credit while reconstructing the feature for the current codebase.\n\nThe replacement exists solely because Cursor Bugbot cannot certify the contributor-authored PR: it reports a GitHub account mismatch between the linked Cursor account and the original PR author. Original #913 remains open as a draft while this replacement is validated.\n\n## Validation\n\nThe reconstructed feature commit passed the full GitHub CI matrix on #913, including format, lint, typecheck, all unit suites, all three stable browser shards, desktop build, Windows process regression, migration lineage, and release smoke.\n\nThe final head additionally contains two Cursor-driven picker readiness fixes. Focused final-head browser validation passes all 11 ComposerExtrasMenu tests, including starting-to-ready state delivery, bounded retry, retry exhaustion, stale-result cleanup, durable acknowledgement, and disabled-state behavior. Scoped formatting and git diff checks also pass. Cursor Bugbot reviewed the final exact head and found no new issues.\n\nEarlier focused validation passed for desktop AppSnap manager tests, web AppSnap intake/shortcut/icon-store logic, server prompt attachments, native Swift helper compile plus ad-hoc signing verification, and the composer picker browser flow.\n\n## Live macOS boundary\n\nAutomated validation does not prove packaged release-signature TCC ownership, live Screen Recording/Input Monitoring grant and revocation, physical HID shortcut handling, or ScreenCaptureKit behavior across spaces, fullscreen windows, and window churn. The unsafe coach/global-hotkey code is intentionally not retained.