### PR TITLE
[codex] Refactor ChatView and speed up warm chat opening

### DIFF
--- a/apps/web/src/components/ChatMarkdown.compiler.test.ts
+++ b/apps/web/src/components/ChatMarkdown.compiler.test.ts
@@ -6,50 +6,21 @@
 //          for the whole component, which renders every chat message.
 // Layer: Web build-integrity test
 
-import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { transformSync } from "@babel/core";
 import { describe, expect, it } from "vitest";
 
-interface CompilerEvent {
-  kind: string;
-  fnName?: string | null;
-  detail?: { reason?: string; description?: string };
-}
-
-function compileEvents(filePath: string): CompilerEvent[] {
-  const events: CompilerEvent[] = [];
-  transformSync(readFileSync(filePath, "utf8"), {
-    filename: filePath,
-    configFile: false,
-    babelrc: false,
-    parserOpts: { plugins: ["typescript", "jsx"] },
-    plugins: [
-      [
-        "babel-plugin-react-compiler",
-        {
-          panicThreshold: "none",
-          logger: {
-            logEvent: (_fn: unknown, event: CompilerEvent) => {
-              events.push(event);
-            },
-          },
-        },
-      ],
-    ],
-  });
-  return events;
-}
+import { compileReactModule } from "../test/reactCompiler";
 
 describe("ChatMarkdown React Compiler coverage", () => {
   it("compiles every function in ChatMarkdown.tsx without bailouts", () => {
-    const events = compileEvents(join(import.meta.dirname, "ChatMarkdown.tsx"));
+    const events = compileReactModule(join(import.meta.dirname, "ChatMarkdown.tsx"));
     const errors = events
       .filter((event) => event.kind === "CompileError")
       .map(
         (event) =>
           `${event.fnName ?? "<anonymous>"}: ${event.detail?.reason ?? event.detail?.description ?? "unknown"}`,
       );
+    expect(events.filter((event) => event.kind === "PipelineError")).toEqual([]);
     expect(errors).toEqual([]);
     expect(events.some((event) => event.kind === "CompileSuccess")).toBe(true);
   });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1,995 +1,368 @@
-import { ComposerExpiredUserInputNotice } from "./chat/ComposerExpiredUserInputNotice";
-import { usePendingUserInputDrafts } from "./chat/usePendingUserInputDrafts";
-import { expiredUserInputDrafts } from "../pendingUserInputRecovery";
+import { type LegendListRef } from "@legendapp/list/react";
 import {
-  type AutomationDefinition,
-  type AutomationSchedule,
-  type ApprovalRequestId,
-  DEFAULT_MODEL_BY_PROVIDER,
-  EventId,
   MessageId,
-  type ModelSelection,
-  type NativeApi,
-  type OrchestrationShellSnapshot,
-  type ProjectScript,
-  type ModelSlug,
-  type ProviderKind,
-  type ProjectEntry,
-  type ProjectId,
-  type ProviderApprovalDecision,
-  type ProviderMentionReference,
-  type ProviderNativeCommandDescriptor,
-  type ProviderPluginDescriptor,
-  type ProviderRequestKind,
-  type ProviderSkillDescriptor,
-  type ProviderSkillReference,
-  type ProviderStartOptions,
-  type ProviderUserInputAnswers,
-  type PinnedMessage,
+  OrchestrationThreadActivity,
   PROVIDER_DISPLAY_NAMES,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
+  ThreadId,
+  type AutomationDefinition,
+  type EditorId,
+  type ModelSelection,
+  type ModelSlug,
+  type PinnedMessage,
+  type ProjectScript,
+  type ProviderKind,
   type ResolvedKeybindingsConfig,
   type ServerProviderStatus,
-  ThreadId,
   type ThreadGoalAchievement,
   type TurnId,
-  type EditorId,
-  type KeybindingCommand,
-  OrchestrationThreadActivity,
-  ProviderInteractionMode,
-  RuntimeMode,
 } from "@synara/contracts";
-import { automationRequiresTargetThread } from "@synara/shared/automationMode";
+import { resolveLatestTailUserMessageEditTarget } from "@synara/shared/conversationEdit";
+import { getModelCapabilities } from "@synara/shared/model";
 import {
-  APPROVAL_ALREADY_ANSWERED_INVARIANT_MARKER,
-  collectErrorMessages,
-  describeErrorMessage,
-} from "@synara/shared/errorMessages";
-import { respondingInteractionReclaimAt } from "@synara/shared/pendingInteractions";
-import { providerSupportsNativeTurnSteering } from "@synara/shared/providerMetadata";
-import { getDefaultModel, getModelCapabilities, normalizeModelSlug } from "@synara/shared/model";
-import {
-  resolveLatestTailUserMessageEditTarget,
-  resolveTailUserMessageEditTarget,
-} from "@synara/shared/conversationEdit";
+  resolveThreadWorkspaceCwd as resolveSharedThreadWorkspaceCwd,
+  resolveThreadBranchSourceCwd,
+  resolveThreadWorkspaceState,
+} from "@synara/shared/threadEnvironment";
 import { threadExportBlockedReason } from "@synara/shared/threadExport";
 import { pendingRequestInstanceKey } from "@synara/shared/threadSummary";
+import { deriveAssociatedWorktreeMetadata } from "@synara/shared/threadWorkspace";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
 import {
-  buildPromptThreadTitleFallback,
-  GENERIC_CHAT_THREAD_TITLE,
-} from "@synara/shared/chatThreads";
-import {
-  resolveThreadWorkspaceState,
-  resolveThreadBranchSourceCwd,
-  resolveThreadWorkspaceCwd as resolveSharedThreadWorkspaceCwd,
-} from "@synara/shared/threadEnvironment";
-import {
-  deriveAssociatedWorktreeMetadata,
-  workspaceRootsEqual,
-} from "@synara/shared/threadWorkspace";
-import {
-  lazy,
   Suspense,
+  lazy,
   useCallback,
   useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
   useState,
-  type MouseEvent,
-  type WheelEvent,
   type ReactNode,
 } from "react";
-import { GoTasklist } from "react-icons/go";
-import { flushSync } from "react-dom";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Debouncer, useDebouncedValue } from "@tanstack/react-pacer";
-import { useNavigate } from "@tanstack/react-router";
-import { type LegendListRef } from "@legendapp/list/react";
-import { buildTemporaryWorktreeBranchName } from "@synara/shared/git";
+import { useCopyThreadIdToClipboard } from "~/hooks/useCopyToClipboard";
+import {
+  useDesktopTopBarTrafficLightGutterClassName,
+  useDesktopTopBarWindowControlsGutterClassName,
+} from "~/hooks/useDesktopTopBarGutter";
+import { useLocalStorage } from "~/hooks/useLocalStorage";
+import { useIsMobile } from "~/hooks/useMediaQuery";
+import { useRefreshProviderStatusesNow } from "~/hooks/useProviderStatusRefresh";
+import { useRepoDiffTotals } from "~/hooks/useRepoDiffTotals";
+import { useThreadRecap } from "~/hooks/useThreadRecap";
+import { SINGLE_CHAT_PANE_SCOPE_ID } from "~/lib/chatPaneScope";
+import { formatComposerMentionToken } from "~/lib/composerMentions";
 import {
   GIT_WORKING_TREE_DIFF_LIVE_REFETCH_INTERVAL_MS,
+  gitBranchesQueryOptions,
   gitCreateDetachedWorktreeMutationOptions,
   gitGithubRepositoryQueryOptions,
-  gitBranchesQueryOptions,
   gitStatusQueryOptions,
 } from "~/lib/gitReactQuery";
-import { resolveProviderDiscoveryCwd } from "~/lib/providerDiscovery";
+import { LoaderCircleIcon, RefreshCwIcon, TemporaryThreadIcon } from "~/lib/icons";
+import { getLocalFolderBrowseRootPath } from "~/lib/localFolderMentions";
+import { findProviderStatus } from "~/lib/providerAvailability";
+import { serverSettingsQueryOptions } from "~/lib/serverReactQuery";
+import { cn, isMacNavigatorPlatform, newCommandId, newThreadId, randomUUID } from "~/lib/utils";
+import { readNativeApi } from "~/nativeApi";
 import {
-  providerComposerCapabilitiesQueryOptions,
-  providerCommandsQueryOptions,
-  providerPluginsQueryOptions,
-  providerSkillsQueryOptions,
-  supportsNativeSlashCommandDiscovery,
-  supportsPluginDiscovery,
-  supportsSkillDiscovery,
-  supportsThreadCompaction,
-} from "~/lib/providerDiscoveryReactQuery";
-import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
+  mergeProjectInstructionsIntoThreadNotes,
+  useProjectInstructionsStore,
+} from "~/projectInstructionsStore";
+import { projectScriptRuntimeEnv } from "~/projectScripts";
 import {
-  hasReconciledServerProviderStatuses,
-  serverConfigQueryOptions,
-  serverQueryKeys,
-  serverSettingsQueryOptions,
-} from "~/lib/serverReactQuery";
-import { useRefreshProviderStatusesNow } from "~/hooks/useProviderStatusRefresh";
-import { useProviderStatusesForLocalConfig } from "~/hooks/useProviderStatusesForLocalConfig";
-import { SINGLE_CHAT_PANE_SCOPE_ID } from "~/lib/chatPaneScope";
+  resolveAppModelSelection,
+  resolveAssistantDeliveryMode,
+  useAppSettings,
+} from "../appSettings";
 import {
-  composerMentionPathNeedsQuoting,
-  formatComposerMentionToken,
-  filterPromptProviderMentionReferences,
-  filterPromptSkillReferences,
-  providerMentionReferencesEqual,
-  providerSkillReferencesEqual,
-  skillMentionPrefix,
-} from "~/lib/composerMentions";
-import { getLocalFolderBrowseRootPath, isLocalFolderMentionQuery } from "~/lib/localFolderMentions";
-import {
-  findProviderStatus,
-  normalizeCustomBinaryPath,
-  normalizeProviderStatusForLocalConfig,
-  resolveProviderSendAvailabilityWithRefresh,
-  resolveAvailableProviderPreference,
-} from "~/lib/providerAvailability";
-import {
-  loadConfirmedCustomBinaryPaths,
-  saveConfirmedCustomBinaryPaths,
-} from "../confirmedCustomBinaryPathStore";
-import { isElectron } from "../env";
-import { isScrollContainerNearBottom } from "../chat-scroll";
-import { stripDiffSearchParams } from "../diffRouteSearch";
-import { resolveSubagentPresentationForThread } from "../lib/subagentPresentation";
-import { ensureHomeChatProject, isHomeChatContainerProject } from "../lib/chatProjects";
-import { ensureStudioProject, isStudioContainerProject } from "../lib/studioProjects";
-import { resolveFirstSendTarget } from "../lib/chatFirstSend";
-import { readActiveSpaceId } from "../spacesUiStore";
-import {
-  createOrRecoverProjectFromPath,
-  PROJECT_CREATE_EXISTING_SYNC_ERROR,
-  PROJECT_CREATE_SYNC_ERROR,
-} from "../lib/projectCreation";
-import {
-  maybeResolveBrowserPromptAttachment,
-  type BrowserPromptAttachmentResolution,
-} from "../lib/browserPromptContext";
-import {
-  maybeResolveDevicePromptAttachment,
-  type DevicePromptAttachmentResolution,
-} from "../lib/devicePromptContext";
-import {
-  buildComposerFileAttachmentsFromFiles,
-  stageUploadComposerAttachments,
-  cloneComposerImageAttachment,
-  effectiveComposerAttachmentCount,
-  findPendingBlobComposerAttachments,
-  formatOutgoingComposerPrompt,
-  hydratePendingBlobComposerAttachments,
-  readFileAsDataUrl,
-} from "../lib/composerSend";
-import { composerImageBlobKey, persistComposerImageBlob } from "../lib/composerImageBlobStore";
-import { reconcileDeletedThreadFromClient } from "../lib/deletedThreadClientReconciliation";
-import {
-  armQueuedComposerSteerGate,
-  claimQueuedComposerAutoDispatch,
-  clearQueuedComposerAutoDispatchRetry,
-  clearQueuedComposerSteerGate,
-  getQueuedComposerAutoDispatchRetryDelay,
-  getQueuedComposerSteerGate,
-  isQueuedComposerAwaitingTurnStart,
-  recordQueuedComposerAutoDispatchFailure,
-  releaseQueuedComposerAutoDispatch,
-  runLockedQueuedComposerAutoDispatch,
-  tryBeginQueuedComposerAutoDispatch,
-} from "../lib/queuedComposerDrain";
-import { extractChatAutomationInvocation } from "../lib/automationIntent";
-import {
-  automationClarificationPrompt,
-  buildComposerAutomationDraft,
-  resolveComposerAutomationRequest,
-} from "../lib/composerAutomation";
-import {
-  acknowledgedRiskIdsForDraft,
-  hasBlockingAutomationDraftWarnings,
-  type AutomationDraftWarning,
-  type AutomationDraftWarningId,
-} from "../lib/automationDraft";
-import { buildDraftThreadRenameCreateInput, dispatchThreadRename } from "../lib/threadRename";
-import { useHandleNewChat } from "../hooks/useHandleNewChat";
-import { splitComposerDropzoneFiles, useComposerDropzone } from "../hooks/useComposerDropzone";
-import { useComposerImageIntake } from "../hooks/useComposerImageIntake";
-import { useDiffRouteSearch } from "../hooks/useDiffRouteSearch";
-import {
-  buildThreadBreadcrumbs,
-  buildTranscriptAutoFollowSignal,
-  buildTranscriptTailKey,
-  commitAfterRuntimeModePersistence,
-  createRuntimeModePersistenceQueue,
-  derivePromptHistoryFromMessages,
-  enrichSubagentWorkEntries,
-  hasFileUndoSettled,
-  persistModelSelectionBeforeRuntimeMode,
-  promptStillMatchesActiveHistoryBrowse,
-  type PendingFileUndo,
-  type PromptHistoryNavigationState,
-  resolveActiveThreadTitle,
-  resolveActiveTurnLiveDiffState,
-  resolveCommittedProviderModel,
-  resolveComposerStripWorkLogEntries,
-  resolveCycledModelSlug,
-  resolveDefaultEnvironmentPanelOpen,
-  resolveEnvironmentPanelOpen,
-  resolveEnvironmentPanelPreferenceAfterFirstSend,
-  resolveEnvironmentPanelPreferenceUpdate,
-  resolveEnvironmentPanelVisible,
-  resolveGitRepoUiState,
-  resolveProjectScriptTerminalTarget,
-  resolvePromptHistoryNavigation,
-  resolveSettledThreadBranchMismatch,
-  resolveThreadDetailHydration,
-  shouldHandlePromptHistoryNavigationKey,
-  shouldEnableComposerPastedTextCollapse,
-  shouldConsumePendingCustomBinaryConfirmation,
-  shouldShowComposerModelBootstrapSkeleton,
-} from "./ChatView.logic";
-import {
-  createRelevantWorkLogThreadsSelector,
-  createThreadLineageSelector,
-  localSubagentThreadId,
-} from "./ChatView.selectors";
-import {
-  clampCollapsedComposerCursor,
-  type ComposerTrigger,
   collapseExpandedComposerCursor,
   detectComposerTrigger,
   expandCollapsedComposerCursor,
-  replaceTextRange,
   stripComposerTriggerText,
 } from "../composer-logic";
 import {
-  ensureLeadingSpaceForReplacement,
-  extendReplacementRangeForTrailingSpace,
-} from "../composerTriggerInsertion";
-import {
-  createProjectSelector,
-  createComposerThreadMentionSourcesSelector,
-  createSidechatSummariesForSourceSelector,
-  createThreadSelector,
-} from "../storeSelectors";
-import {
-  buildThreadSubscribeInput,
-  clearThreadDetailResumeCursor,
-} from "../threadDetailResumeCursors";
-import { retainThreadDetailSubscription } from "../threadDetailSubscriptionRetention";
+  useComposerDraftStore,
+  type ComposerImageAttachment,
+  type DraftThreadEnvMode,
+} from "../composerDraftStore";
+import { useComposerFocusRequestStore } from "../composerFocusRequestStore";
 import {
   canExecuteSideSlashCommand,
   canOfferForkSlashCommand,
-  canOfferSideSlashCommand,
   canOfferReviewSlashCommand,
-  hasProviderNativeSlashCommand,
-  providerSupportsTextNativeReviewCommand,
+  canOfferSideSlashCommand,
   resolveComposerSlashRootBranch,
 } from "../composerSlashCommands";
-import {
-  derivePendingApprovals,
-  derivePendingUserInputs,
-  derivePhase,
-  deriveTimelineEntries,
-  deriveActiveWorkStartedAt,
-  deriveActiveTaskListState,
-  deriveActiveBackgroundTasksState,
-  findSidebarProposedPlan,
-  findLatestProposedPlan,
-  deriveWorkLogEntries,
-  omitRoutedSubagentWorkEntries,
-  buildSourceProposedPlanReference,
-  hasActionableProposedPlan,
-  hasLiveTurnTailWork,
-  isLatestTurnSettled,
-  type ActiveTaskListState,
-} from "../session-logic";
-import {
-  buildPendingUserInputAnswers,
-  derivePendingUserInputProgress,
-  hasCompletePendingUserInputAnswers,
-  omitNullPendingUserInputAnswers,
-  setPendingUserInputCustomAnswer,
-  togglePendingUserInputOptionSelection,
-  type PendingUserInputDraftAnswer,
-} from "../pendingUserInput";
-import { selectRightDockState, useRightDockStore } from "../rightDockStore";
-import { waitForSidechatCreator } from "../lib/sidechatCreatorRegistry";
-import { useProjectEnvironmentStore } from "../projectEnvironmentStore";
-import { useStore } from "../store";
-import { RenameThreadDialog } from "./RenameThreadDialog";
-import { getThreadFromState } from "../threadDerivation";
-import { useWorkspacePathsStore } from "../workspacePathsStore";
-import {
-  buildPlanImplementationThreadTitle,
-  buildPlanImplementationPrompt,
-  proposedPlanTitle,
-  resolvePlanFollowUpSubmission,
-} from "../proposedPlan";
-import { truncateTitle } from "../truncateTitle";
-import {
-  DEFAULT_INTERACTION_MODE,
-  DEFAULT_RUNTIME_MODE,
-  DEFAULT_THREAD_TERMINAL_ID,
-  type ChatMessage,
-  type Thread,
-  type WorktreeSetupResolutionAction,
-} from "../types";
+import { stripDiffSearchParams } from "../diffRouteSearch";
+import { isElectron } from "../env";
+import { useFeatureFlags } from "../featureFlags";
+import { useComposerCommandMenuItems } from "../hooks/useComposerCommandMenuItems";
+import { splitComposerDropzoneFiles, useComposerDropzone } from "../hooks/useComposerDropzone";
+import { useComposerImageIntake } from "../hooks/useComposerImageIntake";
+import { useComposerSlashCommands } from "../hooks/useComposerSlashCommands";
+import { useDiffRouteSearch } from "../hooks/useDiffRouteSearch";
+import { useHandleNewChat } from "../hooks/useHandleNewChat";
+import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { useTheme } from "../hooks/useTheme";
-import { useThreadWorkspaceHandoff } from "../hooks/useThreadWorkspaceHandoff";
-import {
-  buildSearchableModelOptions,
-  useComposerCommandMenuItems,
-} from "../hooks/useComposerCommandMenuItems";
-import { useProviderModelCatalog } from "../hooks/useProviderModelCatalog";
 import { useThreadHandoff } from "../hooks/useThreadHandoff";
 import { useThreadUnblock } from "../hooks/useThreadUnblock";
+import { useThreadWorkspaceHandoff } from "../hooks/useThreadWorkspaceHandoff";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
-import BranchToolbar, { RuntimeUsageControls } from "./BranchToolbar";
-import {
-  normalizeRuntimeModeForProvider,
-  providerModelSupportsAutoRuntimeMode,
-} from "../lib/runtimeMode";
-import { SynaraLogo } from "./SynaraLogo";
-import { ThreadWorktreeHandoffDialog } from "./ThreadWorktreeHandoffDialog";
-import {
-  formatShortcutLabel,
-  resolveShortcutCommand,
-  shortcutLabelForCommand,
-} from "../keybindings";
-import PlanSidebar from "./PlanSidebar";
-import TerminalWorkspaceTabs from "./TerminalWorkspaceTabs";
-import {
-  BugIcon,
-  ChevronDownIcon,
-  ComposerSendArrowIcon,
-  LayoutSidebarIcon,
-  LoaderCircleIcon,
-  RefreshCwIcon,
-  TemporaryThreadIcon,
-} from "~/lib/icons";
-import { ComposerQueuedHeader } from "./chat/ComposerQueuedHeader";
-import { ComposerLiveChangesHeader } from "./chat/ComposerLiveChangesHeader";
-import { ComposerGoalHeader } from "./chat/ComposerGoalHeader";
-import { ComposerPickerMenuPopup } from "./chat/ComposerPickerMenuPopup";
-import { Button } from "./ui/button";
-import { Skeleton } from "./ui/skeleton";
-import { Menu, MenuItem, MenuTrigger } from "./ui/menu";
-import { randomTerminalId } from "./terminal/terminalIds";
-import { cn, isMacNavigatorPlatform, randomUUID } from "~/lib/utils";
-import { toastManager } from "./ui/toast";
-import { decodeProjectScriptKeybindingRule } from "~/lib/projectScriptKeybindings";
-import { type NewProjectScriptInput } from "./ProjectScriptsControl";
-import {
-  commandForProjectScript,
-  nextProjectScriptId,
-  projectScriptRuntimeEnv,
-  projectScriptIdFromCommand,
-  setupProjectScript,
-  type ProjectScriptRunOptions,
-  type ProjectScriptRunResult,
-} from "~/projectScripts";
-import { runProjectCommandInTerminal } from "~/projectTerminalRunner";
-import { newCommandId, newMessageId, newProjectId, newThreadId } from "~/lib/utils";
-import { readNativeApi } from "~/nativeApi";
-import { promoteThreadCreate } from "~/lib/threadCreatePromotion";
-import { readFavoriteModelSlugs } from "~/lib/modelFavorites";
-import {
-  getCustomBinaryPathForProvider,
-  getProviderStartOptions,
-  resolveAppModelSelection,
-  resolveAssistantDeliveryMode,
-  resolveFollowUpDispatchMode,
-  useAppSettings,
-} from "../appSettings";
-import { isTerminalFocused } from "../lib/terminalFocus";
-import { isEditableEventTarget } from "../lib/editableEventTarget";
-import {
-  type ComposerFileAttachment,
-  type ComposerImageAttachment,
-  type ComposerAssistantSelectionAttachment,
-  type BrowserAnnotationDraft,
-  type DraftThreadEnvMode,
-  type PersistedComposerImageAttachment,
-  type QueuedComposerChatTurn,
-  type QueuedComposerPlanFollowUp,
-  type QueuedComposerTurn,
-  type RestoredComposerSourceProposedPlan,
-  captureComposerPromptHistorySavedDraft,
-  useComposerDraftStore,
-  useComposerThreadDraft,
-  useEffectiveComposerModelState,
-} from "../composerDraftStore";
-import { useTemporaryThreadStore } from "../temporaryThreadStore";
-import { useComposerFocusRequestStore } from "../composerFocusRequestStore";
-import { useWorkflowRunUiStore, useWorkflowRunUiThreadState } from "../workflowRunUiStore";
+import { formatShortcutLabel, shortcutLabelForCommand } from "../keybindings";
+import { isHomeChatContainerProject } from "../lib/chatProjects";
 import { appendComposerPromptText } from "../lib/chatReferences";
+import { createPastedTextDraft } from "../lib/composerPastedText";
 import {
-  appendOriginalComposerPromptBlocks,
-  appendTerminalContextsToPrompt,
-  IMAGE_ONLY_BOOTSTRAP_PROMPT,
-  formatTerminalContextLabel,
-  insertInlineTerminalContextPlaceholder,
-  removeInlineTerminalContextPlaceholder,
-  syncTerminalContextsByIds,
-  terminalContextIdListsEqual,
-  type TerminalContextDraft,
-  type TerminalContextSelection,
-} from "../lib/terminalContext";
-import { registerTerminalContextComposerTarget } from "../lib/terminalContextComposerRegistry";
-import {
-  appendPastedTextsToPrompt,
-  createPastedTextDraft,
-  pastedTextTitle,
-  type PastedTextDraft,
-} from "../lib/composerPastedText";
-import {
-  appendPullRequestContextsToPrompt,
-  formatPullRequestContextTitleSeed,
-  type PullRequestContextDraft,
-} from "../lib/pullRequestContext";
-import {
-  appendAssistantSelectionsToPrompt,
-  formatAssistantSelectionQueuePreview,
-  formatAssistantSelectionTitleSeed,
-} from "../lib/assistantSelections";
-import {
-  appendBrowserAnnotationsToPrompt,
-  formatBrowserAnnotationLabel,
-} from "../lib/browserAnnotations";
-import {
-  appendFileCommentsToPrompt,
-  formatFileCommentLabel,
-  formatFileCommentTitleSeed,
-  type FileCommentDraft,
-} from "../lib/fileComments";
+  buildComposerFileAttachmentsFromFiles,
+  effectiveComposerAttachmentCount,
+} from "../lib/composerSend";
 import {
   deriveContextWindowSelectionStatus,
   deriveCumulativeCostUsd,
   deriveLatestContextWindowState,
   deriveSelectedContextWindowSnapshot,
 } from "../lib/contextWindow";
-import { useComposerVoiceController } from "./chat/useComposerVoiceController";
+import { reconcileDeletedThreadFromClient } from "../lib/deletedThreadClientReconciliation";
 import {
-  composerFooterPlanForTier,
-  resolveNextComposerFooterTier,
-  shouldUseCompactComposerFooter,
-} from "./composerFooterLayout";
-import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
+  normalizeRuntimeModeForProvider,
+  providerModelSupportsAutoRuntimeMode,
+} from "../lib/runtimeMode";
+import { addSelectionToSide, startSelectionChat } from "../lib/selectionChat";
+import { waitForSidechatCreator } from "../lib/sidechatCreatorRegistry";
+import { isStudioContainerProject } from "../lib/studioProjects";
+import { resolveSubagentPresentationForThread } from "../lib/subagentPresentation";
+import {
+  insertInlineTerminalContextPlaceholder,
+  type TerminalContextSelection,
+} from "../lib/terminalContext";
+import { registerTerminalContextComposerTarget } from "../lib/terminalContextComposerRegistry";
+import {
+  resolveDiffEnvironmentState,
+  resolveThreadEnvironmentMode,
+} from "../lib/threadEnvironment";
+import {
+  canCreateThreadHandoff,
+  resolveAvailableHandoffTargetProviders,
+  resolveThreadHandoffBadgeLabel,
+} from "../lib/threadHandoff";
+import { buildDraftThreadRenameCreateInput, dispatchThreadRename } from "../lib/threadRename";
+import { useProjectEnvironmentStore } from "../projectEnvironmentStore";
+import { proposedPlanTitle } from "../proposedPlan";
+import { buildModelSelection, buildNextProviderOptions } from "../providerModelOptions";
+import { selectRightDockState, useRightDockStore } from "../rightDockStore";
+import { AutomationDialog, automationsForThread } from "../routes/-automations.shared";
+import {
+  deriveActiveBackgroundTasksState,
+  deriveActiveTaskListState,
+  deriveActiveWorkStartedAt,
+  derivePhase,
+  deriveTimelineEntries,
+  findLatestProposedPlan,
+  findSidebarProposedPlan,
+  hasActionableProposedPlan,
+  hasLiveTurnTailWork,
+  isLatestTurnSettled,
+  type ActiveTaskListState,
+} from "../session-logic";
 import {
   resolveSplitViewFocusedThreadId,
   selectSplitView,
-  type SplitViewPanePanelState,
   useSplitViewStore,
+  type SplitViewPanePanelState,
 } from "../splitViewStore";
-import { ComposerPromptEditor, type ComposerPromptEditorHandle } from "./ComposerPromptEditor";
+import { useStore } from "../store";
+import {
+  createComposerThreadMentionSourcesSelector,
+  createProjectSelector,
+  createSidechatSummariesForSourceSelector,
+  createThreadSelector,
+} from "../storeSelectors";
+import { useTemporaryThreadStore } from "../temporaryThreadStore";
+import { useTerminalStateStore } from "../terminalStateStore";
+import { getThreadFromState } from "../threadDerivation";
+import { buildThreadSubscribeInput } from "../threadDetailResumeCursors";
+import {
+  DEFAULT_INTERACTION_MODE,
+  DEFAULT_RUNTIME_MODE,
+  type ChatMessage,
+  type Thread,
+} from "../types";
+import { useWorkflowRunUiStore } from "../workflowRunUiStore";
+import { useWorkspacePathsStore } from "../workspacePathsStore";
+import BranchToolbar, { RuntimeUsageControls } from "./BranchToolbar";
+import {
+  ACTIVE_TURN_LAYOUT_SETTLE_DELAY_MS,
+  DISMISSED_PROVIDER_HEALTH_BANNERS_KEY,
+  DismissedProviderHealthBannersSchema,
+  PullRequestDialogState,
+  appendVoiceTranscriptToPrompt,
+  buildLocalDraftThread,
+  buildThreadBreadcrumbs,
+  commitAfterRuntimeModePersistence,
+  derivePromptHistoryFromMessages,
+  hasFileUndoSettled,
+  resolveActiveThreadTitle,
+  resolveActiveTurnLiveDiffState,
+  resolveCommittedProviderModel,
+  resolveDefaultEnvironmentPanelOpen,
+  resolveDraftFallbackModelSelection,
+  resolveEnvironmentPanelOpen,
+  resolveEnvironmentPanelPreferenceUpdate,
+  resolveEnvironmentPanelVisible,
+  resolveGitRepoUiState,
+  resolveSettledThreadBranchMismatch,
+  resolveThreadArtifactWorkspaceRoot,
+  resolveThreadDetailHydration,
+  resolveWorkingLabel,
+  shouldEnableComposerPastedTextCollapse,
+  shouldRenderProviderHealthBanner,
+  shouldStartActiveTurnLayoutGrace,
+  type PendingFileUndo,
+} from "./ChatView.logic";
+import { createThreadLineageSelector, localSubagentThreadId } from "./ChatView.selectors";
+import { ComposerPromptEditor } from "./ComposerPromptEditor";
+import { FolderClosed } from "./FolderClosed";
+import PlanSidebar from "./PlanSidebar";
 import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
+import { RenameThreadDialog } from "./RenameThreadDialog";
+import { SidebarHeaderNavigationControls } from "./SidebarHeaderNavigationControls";
+import { SynaraLogo } from "./SynaraLogo";
+import TerminalWorkspaceTabs from "./TerminalWorkspaceTabs";
+import { ThreadWorktreeHandoffDialog } from "./ThreadWorktreeHandoffDialog";
+import { ChatComposerFooter } from "./chat/ChatComposerFooter";
 import { ChatHeader } from "./chat/ChatHeader";
 import { ChatSurfaceHeader } from "./chat/ChatSurfaceHeader";
-import { dispatchThreadNotes } from "~/pinnedMessages";
-import { dispatchThreadGoal } from "~/threadGoal";
+import { ChatTranscriptPane } from "./chat/ChatTranscriptPane";
+import { ComposerActiveTaskListCard } from "./chat/ComposerActiveTaskListCard";
+import { ComposerBranchMismatchBanner } from "./chat/ComposerBranchMismatchBanner";
+import { ComposerColumnFrame } from "./chat/ComposerColumnFrame";
+import { ComposerCommandItem, ComposerCommandMenu } from "./chat/ComposerCommandMenu";
+import { ComposerExpiredUserInputNotice } from "./chat/ComposerExpiredUserInputNotice";
+import { ComposerExtrasMenu } from "./chat/ComposerExtrasMenu";
+import { ComposerGoalHeader } from "./chat/ComposerGoalHeader";
+import { ComposerInputBanners } from "./chat/ComposerInputBanners";
+import { ComposerLiveChangesHeader } from "./chat/ComposerLiveChangesHeader";
 import {
-  mergeProjectInstructionsIntoThreadNotes,
-  useProjectInstructionsStore,
-} from "~/projectInstructionsStore";
+  ComposerLocalDirectoryMenu,
+  type ComposerLocalDirectoryMenuHandle,
+} from "./chat/ComposerLocalDirectoryMenu";
+import { ComposerModelEffortPicker } from "./chat/ComposerModelEffortPicker";
+import { ComposerPendingApprovalPanel } from "./chat/ComposerPendingApprovalPanel";
+import { ComposerPendingUserInputPanel } from "./chat/ComposerPendingUserInputPanel";
+import { ComposerQueuedHeader } from "./chat/ComposerQueuedHeader";
+import { ComposerReferenceAttachments } from "./chat/ComposerReferenceAttachments";
+import { ComposerSlashStatusDialog } from "./chat/ComposerSlashStatusDialog";
+import { ComposerSubagentStrip } from "./chat/ComposerSubagentStrip";
 import {
-  ENVIRONMENT_DOCKED_CONTENT_INSET_PX,
-  EnvironmentPanel,
-  type EnvironmentPanelProps,
-} from "./chat/environment/EnvironmentPanel";
-import { usePinnedMessageActions } from "./chat/environment/usePinnedMessageActions";
+  collectForegroundRunningSubagentStripItems,
+  collectRunningSubagentStripItems,
+  type ComposerSubagentStripItem,
+} from "./chat/ComposerSubagentStrip.logic";
+import { ContextWindowMeter } from "./chat/ContextWindowMeter";
+import { ExpandedImageOverlay } from "./chat/ExpandedImageOverlay";
+import { ExpandedImagePreview } from "./chat/ExpandedImagePreview";
+import { ExpiredSidechatNotice } from "./chat/ExpiredSidechatNotice";
+import type { MessagesTimelineController } from "./chat/MessagesTimeline";
+import { buildTurnDiffSummaryByAssistantMessageId } from "./chat/MessagesTimeline.logic";
+import { ProjectPicker } from "./chat/ProjectPicker";
+import { ProviderHealthBanner } from "./chat/ProviderHealthBanner";
+import { ProviderModelPicker, resolveProviderModelLabel } from "./chat/ProviderModelPicker";
+import {
+  RateLimitBanner,
+  deriveLatestRateLimitStatus,
+  type RateLimitStatus,
+} from "./chat/RateLimitBanner";
+import { ThreadDetailHydrationState } from "./chat/ThreadDetailHydrationState";
+import { ChatThreadFindHost } from "./chat/ThreadFindBar";
+import { TraitsPicker, resolveTraitsTriggerSummary } from "./chat/TraitsPicker";
+import { TranscriptSelectionActionLayer } from "./chat/TranscriptSelectionActionLayer";
+import { WorkflowRunCard } from "./chat/WorkflowRunCard";
+import { deriveAgentActivityTimelineState } from "./chat/agentActivity.logic";
 import {
   CHAT_SURFACE_HEADER_DIVIDER_CLASS_NAME,
   CHAT_SURFACE_HEADER_HEIGHT_CLASS,
   CHAT_SURFACE_HEADER_PADDING_X_CLASS,
   CHAT_SURFACE_HEADER_ROW_CLASS_NAME,
 } from "./chat/chatHeaderControls";
-import { SidebarHeaderNavigationControls } from "./SidebarHeaderNavigationControls";
-import { SidebarHeaderTrigger } from "./ui/sidebar";
-import {
-  useDesktopTopBarTrafficLightGutterClassName,
-  useDesktopTopBarWindowControlsGutterClassName,
-} from "~/hooks/useDesktopTopBarGutter";
-import { useNowMs } from "~/hooks/useNowMs";
-import { useThreadRecap } from "~/hooks/useThreadRecap";
-import { useRepoDiffTotals } from "~/hooks/useRepoDiffTotals";
-import { useIsMobile } from "~/hooks/useMediaQuery";
-import { useCopyThreadIdToClipboard } from "~/hooks/useCopyToClipboard";
-import {
-  acknowledgedRiskIdsForFormWarnings,
-  AutomationDialog,
-  automationQueryKey,
-  createInputFromForm,
-  formatCadence,
-  automationsForThread,
-  isFormSubmittable,
-  projectModelSelection as automationProjectModelSelection,
-  type AutomationFormState,
-} from "../routes/-automations.shared";
-import { ChatTranscriptPane } from "./chat/ChatTranscriptPane";
-import { ChatThreadFindHost } from "./chat/ThreadFindBar";
-import {
-  createThreadFindHighlightStore,
-  eventTargetsInAppBrowser,
-  shouldCaptureChatFindShortcut,
-  type ThreadFindMatch,
-} from "./chat/threadFind.logic";
-import { ThreadDetailHydrationState } from "./chat/ThreadDetailHydrationState";
-import type { MessagesTimelineController } from "./chat/MessagesTimeline";
-import { buildTurnDiffSummaryByAssistantMessageId } from "./chat/MessagesTimeline.logic";
-import { deriveAgentActivityTimelineState } from "./chat/agentActivity.logic";
-import { ExpandedImagePreview } from "./chat/ExpandedImagePreview";
-import {
-  AVAILABLE_PROVIDER_OPTIONS,
-  ProviderModelPicker,
-  resolveProviderModelLabel,
-} from "./chat/ProviderModelPicker";
-import { ComposerModelEffortPicker } from "./chat/ComposerModelEffortPicker";
-import { resolveTraitsTriggerSummary, TraitsPicker } from "./chat/TraitsPicker";
-import { ComposerCommandItem, ComposerCommandMenu } from "./chat/ComposerCommandMenu";
-import {
-  ComposerLocalDirectoryMenu,
-  type ComposerLocalDirectoryMenuHandle,
-} from "./chat/ComposerLocalDirectoryMenu";
-import { ComposerPendingApprovalPanel } from "./chat/ComposerPendingApprovalPanel";
-import { ComposerExtrasMenu } from "./chat/ComposerExtrasMenu";
-import { ContextWindowMeter } from "./chat/ContextWindowMeter";
-import { ComposerInputBanners } from "./chat/ComposerInputBanners";
-import { ComposerBranchMismatchBanner } from "./chat/ComposerBranchMismatchBanner";
-import { ComposerPendingUserInputPanel } from "./chat/ComposerPendingUserInputPanel";
-import { ComposerVoiceButton } from "./chat/ComposerVoiceButton";
-import { ComposerVoiceRecorderBar } from "./chat/ComposerVoiceRecorderBar";
-import { ComposerReferenceAttachments } from "./chat/ComposerReferenceAttachments";
-import { ComposerSlashStatusDialog } from "./chat/ComposerSlashStatusDialog";
-import { ExpandedImageOverlay } from "./chat/ExpandedImageOverlay";
-import { TranscriptSelectionActionLayer } from "./chat/TranscriptSelectionActionLayer";
-import { useChatTerminalController } from "./chat/useChatTerminalController";
-import { useChatAutomationSetup } from "./chat/useChatAutomationSetup";
-import { ComposerActiveTaskListCard } from "./chat/ComposerActiveTaskListCard";
-import { ComposerSubagentStrip } from "./chat/ComposerSubagentStrip";
-import {
-  collectForegroundRunningSubagentStripItems,
-  collectRunningSubagentStripItems,
-  deriveComposerSubagentStripItems,
-  type ComposerSubagentStripItem,
-} from "./chat/ComposerSubagentStrip.logic";
-import { WorkflowRunCard } from "./chat/WorkflowRunCard";
-import {
-  buildWorkflowResumePrompt,
-  deriveWorkflowRunState,
-  type WorkflowSubagentThreadRef,
-} from "./chat/WorkflowRunCard.logic";
-import { ComposerColumnFrame } from "./chat/ComposerColumnFrame";
-import { ExpiredSidechatNotice } from "./chat/ExpiredSidechatNotice";
-import { useTranscriptAssistantSelectionAction } from "./chat/useTranscriptAssistantSelectionAction";
-import {
-  scrollTranscriptToSettledEnd,
-  stopTranscriptScrollAtCurrentOffset,
-} from "./chat/transcriptScroll";
-import { addSelectionToSide, startSelectionChat } from "../lib/selectionChat";
-import { getComposerProviderState } from "./chat/composerProviderRegistry";
+import type { LateComposerSendHandlers } from "./chat/chatSendTypes";
 import { composerTranscriptBottomInsetPx, useComposerOverlayHeight } from "./chat/composerOverlay";
 import {
-  COMPOSER_COMMAND_MENU_FLOATING_WRAPPER_CLASS_NAME,
-  COMPOSER_INPUT_SHELL_CLASS_NAME,
-  COMPOSER_INPUT_SURFACE_CLASS_NAME,
-  COMPOSER_COLUMN_FRAME_CLASS_NAME,
-  COMPOSER_EDITOR_PADDING_CLASS_NAME,
-  COMPOSER_FOLDER_PICKER_CAPSULE_HOVER_CLASS_NAME,
-  COMPOSER_FOOTER_ROW_CLASS_NAME,
-  COMPOSER_TOOLBAR_CAPSULE_HOVER_CLASS_NAME,
-  COMPOSER_TOOLBAR_TRIGGER_TEXT_CLASS_NAME,
   CHAT_BACKGROUND_CLASS_NAME,
   CHAT_COLUMN_FRAME_CLASS_NAME,
   CHAT_COLUMN_GUTTER_CLASS_NAME,
+  COMPOSER_COLUMN_FRAME_CLASS_NAME,
+  COMPOSER_COMMAND_MENU_FLOATING_WRAPPER_CLASS_NAME,
+  COMPOSER_EDITOR_PADDING_CLASS_NAME,
+  COMPOSER_FOLDER_PICKER_CAPSULE_HOVER_CLASS_NAME,
+  COMPOSER_INPUT_SHELL_CLASS_NAME,
+  COMPOSER_INPUT_SURFACE_CLASS_NAME,
+  COMPOSER_TOOLBAR_CAPSULE_HOVER_CLASS_NAME,
+  COMPOSER_TOOLBAR_TRIGGER_TEXT_CLASS_NAME,
   ENVIRONMENT_CONTENT_INSET_MOTION_CLASS,
 } from "./chat/composerPickerStyles";
 import { getComposerTraitSelection } from "./chat/composerTraits";
+import {
+  ENVIRONMENT_DOCKED_CONTENT_INSET_PX,
+  EnvironmentPanel,
+  type EnvironmentPanelProps,
+} from "./chat/environment/EnvironmentPanel";
+import { usePinnedMessageActions } from "./chat/environment/usePinnedMessageActions";
 import { resolveRuntimeModelDescriptor } from "./chat/runtimeModelCapabilities";
-import { ProjectPicker } from "./chat/ProjectPicker";
-import { FolderClosed } from "./FolderClosed";
-import { ProviderHealthBanner } from "./chat/ProviderHealthBanner";
+import { createThreadFindHighlightStore, type ThreadFindMatch } from "./chat/threadFind.logic";
+import { useChatAutomationCreation } from "./chat/useChatAutomationCreation";
+import { useChatAutomationSetup } from "./chat/useChatAutomationSetup";
+import { useChatComposerCommands } from "./chat/useChatComposerCommands";
+import { useChatComposerDraft } from "./chat/useChatComposerDraft";
+import { useChatComposerEditing } from "./chat/useChatComposerEditing";
+import { useChatKeyboardShortcuts } from "./chat/useChatKeyboardShortcuts";
+import { useChatLocalDispatch } from "./chat/useChatLocalDispatch";
+import { useChatPendingInteractions } from "./chat/useChatPendingInteractions";
+import { useChatProjectScripts } from "./chat/useChatProjectScripts";
+import { useChatProviderModels } from "./chat/useChatProviderModels";
+import { useChatProviderStatus } from "./chat/useChatProviderStatus";
+import { useChatQueuedTurns } from "./chat/useChatQueuedTurns";
+import { useChatRuntimeModes } from "./chat/useChatRuntimeModes";
+import { useChatTerminalController } from "./chat/useChatTerminalController";
+import { useChatTimelineMessages } from "./chat/useChatTimelineMessages";
+import { useChatTranscriptScroll } from "./chat/useChatTranscriptScroll";
+import { useChatTurnFollowUps } from "./chat/useChatTurnFollowUps";
+import { useChatTurnSubmission } from "./chat/useChatTurnSubmission";
+import { useChatWorkLog } from "./chat/useChatWorkLog";
+import { useChatWorkspaceSelection } from "./chat/useChatWorkspaceSelection";
+import { useComposerDiscovery } from "./chat/useComposerDiscovery";
+import { useComposerReferences } from "./chat/useComposerReferences";
+import { useComposerVoiceController } from "./chat/useComposerVoiceController";
 import { useThreadErrorToast } from "./chat/useThreadErrorToast";
+import { useTranscriptAssistantSelectionAction } from "./chat/useTranscriptAssistantSelectionAction";
 import {
-  RateLimitBanner,
-  deriveLatestRateLimitStatus,
-  type RateLimitStatus,
-} from "./chat/RateLimitBanner";
-import {
-  ACTIVE_TURN_LAYOUT_SETTLE_DELAY_MS,
-  appendVoiceTranscriptToPrompt,
-  shouldStartActiveTurnLayoutGrace,
-  buildExpiredTerminalContextToastCopy,
-  buildLocalDraftThread,
-  resolveDraftFallbackModelSelection,
-  DISMISSED_PROVIDER_HEALTH_BANNERS_KEY,
-  DismissedProviderHealthBannersSchema,
-  collectUserMessageBlobPreviewUrls,
-  deriveComposerSendState,
-  failWorktreeSetupSnapshot,
-  filterSidechatTranscriptMessages,
-  hasLiveTurnTakenOver,
-  hasServerAcknowledgedLocalDispatch,
-  threadHasProviderLockingActivity,
-  LOCAL_DISPATCH_ACK_TIMEOUT_MS,
-  LOCAL_DISPATCH_TURN_TAKEOVER_TIMEOUT_MS,
-  resolveNextLocalDispatchSnapshot,
-  resolveWorkingLabel,
-  resolveThreadArtifactWorkspaceRoot,
-  WORKTREE_SETUP_ERROR_HOLD_MS,
-  worktreeSetupHasError,
-  WorktreeSetupCancelledError,
-  createWorktreeSetupResolution,
-  runWorktreeCreationFlow,
-  LAST_INVOKED_SCRIPT_BY_PROJECT_KEY,
-  LastInvokedScriptByProjectSchema,
-  type LocalDispatchSnapshot,
-  type WorktreeSetupDispatchOptions,
-  type WorktreeSetupResolution,
-  PullRequestDialogState,
-  type QueuedSteerGate,
-  resolveQueuedSteerGateTransition,
-  resolveQueuedComposerAutoDispatchHold,
-  shouldRenderProviderHealthBanner,
-  resolveRuntimeModeAfterApprovalDecision,
-  revokeBlobPreviewUrl,
-  revokeUserMessagePreviewUrls,
-} from "./ChatView.logic";
-import { clearPendingTurnDispatch, markPendingTurnDispatch } from "../pendingTurnDispatch";
-import { useLocalStorage } from "~/hooks/useLocalStorage";
-import { useComposerSlashCommands } from "../hooks/useComposerSlashCommands";
-import { useFeatureFlags } from "../featureFlags";
-import { useHandleNewThread } from "../hooks/useHandleNewThread";
-import {
-  canCreateThreadHandoff,
-  resolveAvailableHandoffTargetProviders,
-  resolveThreadHandoffBadgeLabel,
-} from "../lib/threadHandoff";
-import {
-  resolveDiffEnvironmentState,
-  resolveThreadEnvironmentMode,
-} from "../lib/threadEnvironment";
-import { buildModelSelection, buildNextProviderOptions } from "../providerModelOptions";
-import {
-  isDuplicateProjectCreateError,
-  waitForRecoverableProjectForDuplicateCreate,
-} from "../lib/projectCreateRecovery";
+  composerFooterPlanForTier,
+  resolveNextComposerFooterTier,
+  shouldUseCompactComposerFooter,
+} from "./composerFooterLayout";
+import { Button } from "./ui/button";
+import { SidebarHeaderTrigger } from "./ui/sidebar";
+import { Skeleton } from "./ui/skeleton";
+import { toastManager } from "./ui/toast";
 
 // The terminal drawer drags in xterm plus its addons (~223 KB gzip). Both mount points
 // are conditional, so loading it lazily keeps the terminal stack out of the initial
 // chat bundle and defers the cost to the first time a terminal is actually opened.
 const ThreadTerminalDrawer = lazy(() => import("./ThreadTerminalDrawer"));
 
-const ATTACHMENT_PREVIEW_HANDOFF_TTL_MS = 5000;
 const EMPTY_ACTIVITIES: OrchestrationThreadActivity[] = [];
 const EMPTY_MESSAGES: ChatMessage[] = [];
 const EMPTY_PINNED_MESSAGES: readonly PinnedMessage[] = [];
 const EMPTY_GOAL_ACHIEVEMENTS: readonly ThreadGoalAchievement[] = [];
 const EMPTY_PINNED_TEXT: ReadonlyMap<MessageId, string> = new Map();
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
-const EMPTY_PROJECT_ENTRIES: ProjectEntry[] = [];
-const EMPTY_PROVIDER_NATIVE_COMMANDS: ProviderNativeCommandDescriptor[] = [];
-const EMPTY_PROVIDER_SKILLS: ProviderSkillDescriptor[] = [];
-const LOCAL_PROJECT_DRAFT_CONTEXT = {
-  envMode: "local",
-  worktreePath: null,
-  branch: null,
-  lastKnownPr: null,
-} as const;
-const DRAFT_PROJECT_SYNC_MAX_ATTEMPTS = 6;
-const DRAFT_PROJECT_SYNC_DELAY_MS = 50;
-const SETUP_SCRIPT_TERMINAL_ACTIVITY_START_TIMEOUT_MS = 1_000;
-const SETUP_SCRIPT_TERMINAL_MAX_RUNTIME_MS = 10 * 60 * 1000;
 
-function terminalHasRunningSubprocess(threadId: ThreadId, terminalId: string): boolean {
-  const terminalState = selectThreadTerminalState(
-    useTerminalStateStore.getState().terminalStateByThreadId,
-    threadId,
-  );
-  return terminalState.runningTerminalIds.includes(terminalId);
-}
-
-function waitForSetupScriptTerminalActivity(input: {
-  threadId: ThreadId;
-  terminalId: string;
-  observeStartTimeoutMs?: number;
-  maxRuntimeMs?: number;
-  signal?: AbortSignal;
-}): Promise<void> {
-  if (typeof window === "undefined") {
-    return Promise.resolve();
-  }
-
-  const observeStartTimeoutMs =
-    input.observeStartTimeoutMs ?? SETUP_SCRIPT_TERMINAL_ACTIVITY_START_TIMEOUT_MS;
-  const maxRuntimeMs = input.maxRuntimeMs ?? SETUP_SCRIPT_TERMINAL_MAX_RUNTIME_MS;
-
-  return new Promise((resolve) => {
-    let resolved = false;
-    let observedRunning = terminalHasRunningSubprocess(input.threadId, input.terminalId);
-    let observeStartTimer: number | null = null;
-    let maxRuntimeTimer: number | null = null;
-
-    const unsubscribe = useTerminalStateStore.subscribe(() => {
-      checkRunningState();
-    });
-
-    const clearTimers = () => {
-      if (observeStartTimer !== null) {
-        window.clearTimeout(observeStartTimer);
-        observeStartTimer = null;
-      }
-      if (maxRuntimeTimer !== null) {
-        window.clearTimeout(maxRuntimeTimer);
-        maxRuntimeTimer = null;
-      }
-    };
-
-    const finish = () => {
-      if (resolved) return;
-      resolved = true;
-      clearTimers();
-      unsubscribe();
-      input.signal?.removeEventListener("abort", finish);
-      resolve();
-    };
-
-    const ensureMaxRuntimeTimer = () => {
-      if (maxRuntimeTimer !== null) return;
-      maxRuntimeTimer = window.setTimeout(finish, maxRuntimeMs);
-    };
-
-    function checkRunningState() {
-      const running = terminalHasRunningSubprocess(input.threadId, input.terminalId);
-      if (running) {
-        observedRunning = true;
-        if (observeStartTimer !== null) {
-          window.clearTimeout(observeStartTimer);
-          observeStartTimer = null;
-        }
-        ensureMaxRuntimeTimer();
-        return;
-      }
-      if (observedRunning) {
-        finish();
-      }
-    }
-
-    if (input.signal?.aborted) {
-      finish();
-      return;
-    }
-    input.signal?.addEventListener("abort", finish, { once: true });
-    checkRunningState();
-    if (!observedRunning) {
-      observeStartTimer = window.setTimeout(finish, observeStartTimeoutMs);
-    }
-  });
-}
-
-function waitForDraftProjectSyncDelay(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    window.setTimeout(resolve, ms);
-  });
-}
-
-// Waits for a project to appear in the shell snapshot before a local draft points at it.
-async function waitForShellProjectById(
-  api: NativeApi,
-  projectId: ProjectId,
-): Promise<{
-  project: OrchestrationShellSnapshot["projects"][number] | null;
-  snapshot: OrchestrationShellSnapshot | null;
-}> {
-  let latestSnapshot: OrchestrationShellSnapshot | null = null;
-  for (let attempt = 1; attempt <= DRAFT_PROJECT_SYNC_MAX_ATTEMPTS; attempt += 1) {
-    const snapshot = await api.orchestration.getShellSnapshot().catch(() => null);
-    if (snapshot) {
-      latestSnapshot = snapshot;
-      const project = snapshot.projects.find((candidate) => candidate.id === projectId) ?? null;
-      if (project) {
-        return { project, snapshot };
-      }
-    }
-    if (attempt < DRAFT_PROJECT_SYNC_MAX_ATTEMPTS) {
-      await waitForDraftProjectSyncDelay(DRAFT_PROJECT_SYNC_DELAY_MS * attempt);
-    }
-  }
-  return { project: null, snapshot: latestSnapshot };
-}
-
-function automationScheduleActivityPayload(schedule: AutomationSchedule) {
-  switch (schedule.type) {
-    case "manual":
-      return { type: "manual" } as const;
-    case "once":
-      return { type: "once", runAt: schedule.runAt } as const;
-    case "interval":
-      return { type: "interval", everySeconds: schedule.everySeconds } as const;
-    case "daily":
-      return schedule.timezone
-        ? { type: "daily", timeOfDay: schedule.timeOfDay, timezone: schedule.timezone }
-        : { type: "daily", timeOfDay: schedule.timeOfDay };
-    case "weekdays":
-      return schedule.timezone
-        ? { type: "weekdays", timeOfDay: schedule.timeOfDay, timezone: schedule.timezone }
-        : { type: "weekdays", timeOfDay: schedule.timeOfDay };
-    case "weekly":
-      return schedule.timezone
-        ? {
-            type: "weekly",
-            dayOfWeek: schedule.dayOfWeek,
-            timeOfDay: schedule.timeOfDay,
-            timezone: schedule.timezone,
-          }
-        : {
-            type: "weekly",
-            dayOfWeek: schedule.dayOfWeek,
-            timeOfDay: schedule.timeOfDay,
-          };
-    case "cron":
-      return {
-        type: "cron",
-        expression: schedule.expression,
-        timezone: schedule.timezone,
-      } as const;
-  }
-}
-
-function revokeBlobPreviewUrlsAfterPaint(previewUrls: readonly string[]): void {
-  if (previewUrls.length === 0 || typeof window === "undefined") {
-    return;
-  }
-  window.requestAnimationFrame(() => {
-    window.setTimeout(() => {
-      for (const previewUrl of previewUrls) {
-        revokeBlobPreviewUrl(previewUrl);
-      }
-    }, 0);
-  });
-}
-
-// Shared by the live-composer and prompt-history attachment sync effects:
-// AppSnap images persist their bytes as IndexedDB blobs (reusing an existing
-// blob key when valid), everything else inlines a data URL. Falls back to the
-// already-persisted attachments for images whose serialization fails.
-async function stagePersistedComposerImageAttachments(input: {
-  threadId: ThreadId;
-  images: ReadonlyArray<ComposerImageAttachment>;
-  getPersistedAttachments: () => PersistedComposerImageAttachment[];
-}): Promise<PersistedComposerImageAttachment[]> {
-  try {
-    const existingPersistedById = new Map(
-      input.getPersistedAttachments().map((attachment) => [attachment.id, attachment]),
-    );
-    const stagedAttachmentById = new Map<string, PersistedComposerImageAttachment>();
-    await Promise.all(
-      input.images.map(async (image) => {
-        try {
-          if (image.source?.kind === "appsnap") {
-            const existingPersisted = existingPersistedById.get(image.id);
-            const expectedBlobKey = composerImageBlobKey(input.threadId, image.id);
-            const blobKey =
-              existingPersisted?.blobKey === expectedBlobKey
-                ? expectedBlobKey
-                : await persistComposerImageBlob({
-                    threadId: input.threadId,
-                    imageId: image.id,
-                    file: image.file,
-                  });
-            stagedAttachmentById.set(image.id, {
-              id: image.id,
-              name: image.name,
-              mimeType: image.mimeType,
-              sizeBytes: image.sizeBytes,
-              blobKey,
-              source: image.source,
-            });
-            return;
-          }
-          const dataUrl = await readFileAsDataUrl(image.file);
-          stagedAttachmentById.set(image.id, {
-            id: image.id,
-            name: image.name,
-            mimeType: image.mimeType,
-            sizeBytes: image.sizeBytes,
-            dataUrl,
-          });
-        } catch {
-          const existingPersisted = existingPersistedById.get(image.id);
-          if (existingPersisted) {
-            stagedAttachmentById.set(image.id, existingPersisted);
-          }
-        }
-      }),
-    );
-    return Array.from(stagedAttachmentById.values());
-  } catch {
-    const currentImageIds = new Set(input.images.map((image) => image.id));
-    return input
-      .getPersistedAttachments()
-      .filter((attachment) => currentImageIds.has(attachment.id));
-  }
-}
-
-function eventTargetsComposer(
-  event: globalThis.KeyboardEvent,
-  composerForm: HTMLFormElement | null,
-): boolean {
-  if (!composerForm) return false;
-  const target = event.target;
-  return target instanceof Node ? composerForm.contains(target) : false;
-}
-
-function canHandleComposerPickerShortcut(
-  event: globalThis.KeyboardEvent,
-  composerForm: HTMLFormElement | null,
-): boolean {
-  if (!composerForm) return false;
-  if (eventTargetsComposer(event, composerForm)) return true;
-  const target = event.target;
-  return (
-    target === document.body ||
-    target === document.documentElement ||
-    document.activeElement === document.body ||
-    document.activeElement === document.documentElement
-  );
-}
 const EMPTY_AVAILABLE_EDITORS: EditorId[] = [];
-const EMPTY_PROVIDER_STATUSES: ServerProviderStatus[] = [];
-const EMPTY_PENDING_USER_INPUT_ANSWERS: Record<string, PendingUserInputDraftAnswer> = {};
+
 const EMPTY_TERMINAL_RUNTIME_ENV: Record<string, string> = {};
 const MAX_DISMISSED_PROVIDER_HEALTH_BANNERS = 50;
-const EMPTY_LAST_INVOKED_SCRIPT_BY_PROJECT: Record<string, string> = {};
+
 const EMPTY_DISMISSED_PROVIDER_HEALTH_BANNERS: ReadonlyArray<string> = [];
-
-function getThreadProviderCustomBinaryPathKey(threadId: Thread["id"], provider: ProviderKind) {
-  return `${threadId}:${provider}`;
-}
-
-function getConfirmedCustomBinarySessionKey(
-  thread: Thread | null | undefined,
-  provider: ProviderKind,
-): string | null {
-  const session = thread?.session;
-  if (!thread || session?.provider !== provider) {
-    return null;
-  }
-  if (session.status !== "ready" && session.status !== "running") {
-    return null;
-  }
-  return getThreadProviderCustomBinaryPathKey(thread.id, provider);
-}
-
-function getProviderStartOptionsCustomBinaryPath(
-  providerOptions: ProviderStartOptions | undefined,
-  provider: ProviderKind,
-): string | null {
-  switch (provider) {
-    case "codex":
-      return normalizeCustomBinaryPath(providerOptions?.codex?.binaryPath);
-    case "claudeAgent":
-      return normalizeCustomBinaryPath(providerOptions?.claudeAgent?.binaryPath);
-    case "antigravity":
-      return normalizeCustomBinaryPath(providerOptions?.antigravity?.binaryPath);
-    case "grok":
-      return normalizeCustomBinaryPath(providerOptions?.grok?.binaryPath);
-    case "droid":
-      return normalizeCustomBinaryPath(providerOptions?.droid?.binaryPath);
-    case "opencode":
-      return normalizeCustomBinaryPath(providerOptions?.opencode?.binaryPath);
-    case "cursor":
-      return normalizeCustomBinaryPath(providerOptions?.cursor?.binaryPath);
-    case "devin":
-      return normalizeCustomBinaryPath(providerOptions?.devin?.binaryPath);
-    case "pi":
-      return normalizeCustomBinaryPath(providerOptions?.pi?.binaryPath);
-  }
-}
 
 function getProviderHealthBannerDismissalKey(status: ServerProviderStatus | null): string | null {
   if (!status || status.status === "ready") {
@@ -1019,72 +392,6 @@ function getRateLimitBannerDismissalKey(
   ].join("\u001f");
 }
 
-type ComposerPluginSuggestion = {
-  plugin: ProviderPluginDescriptor;
-  mention: ProviderMentionReference;
-};
-
-const EMPTY_COMPOSER_PLUGIN_SUGGESTIONS: ComposerPluginSuggestion[] = [];
-
-function buildQueuedComposerPreviewText(input: {
-  trimmedPrompt: string;
-  images: ReadonlyArray<ComposerImageAttachment>;
-  files: ReadonlyArray<ComposerFileAttachment>;
-  assistantSelections: ReadonlyArray<{ id: string }>;
-  browserAnnotations: ReadonlyArray<BrowserAnnotationDraft>;
-  terminalContexts: ReadonlyArray<TerminalContextDraft>;
-  fileComments: ReadonlyArray<FileCommentDraft>;
-  pastedTexts: ReadonlyArray<PastedTextDraft>;
-  pullRequestContexts: ReadonlyArray<PullRequestContextDraft>;
-}): string {
-  if (input.trimmedPrompt.length > 0) {
-    return input.trimmedPrompt;
-  }
-  const firstImage = input.images[0];
-  if (firstImage) {
-    return `Image: ${firstImage.name}`;
-  }
-  const firstFile = input.files[0];
-  if (firstFile) {
-    return `File: ${firstFile.name}`;
-  }
-  if (input.assistantSelections.length > 0) {
-    return formatAssistantSelectionQueuePreview(input.assistantSelections.length);
-  }
-  const firstBrowserAnnotation = input.browserAnnotations[0];
-  if (firstBrowserAnnotation) {
-    return `#${firstBrowserAnnotation.ordinal} ${formatBrowserAnnotationLabel(firstBrowserAnnotation)}`;
-  }
-  const firstTerminalContext = input.terminalContexts[0];
-  if (firstTerminalContext) {
-    return formatTerminalContextLabel(firstTerminalContext);
-  }
-  const firstFileComment = input.fileComments[0];
-  if (firstFileComment) {
-    return formatFileCommentLabel(firstFileComment);
-  }
-  const pastedTitle = formatPastedTextTitleSeed(input.pastedTexts);
-  if (pastedTitle) {
-    return pastedTitle;
-  }
-  const pullRequestTitle = formatPullRequestContextTitleSeed(input.pullRequestContexts);
-  if (pullRequestTitle) {
-    return pullRequestTitle;
-  }
-  return "Queued follow-up";
-}
-
-function formatPastedTextTitleSeed(pastedTexts: ReadonlyArray<PastedTextDraft>): string | null {
-  const firstPastedText = pastedTexts[0];
-  if (!firstPastedText) {
-    return null;
-  }
-  return pastedTexts.length === 1
-    ? pastedTextTitle(firstPastedText.text)
-    : `${pastedTexts.length} pasted texts`;
-}
-
-const COMPOSER_PATH_QUERY_DEBOUNCE_MS = 120;
 const VOICE_RECORDER_ACTION_ARM_DELAY_MS = 250;
 
 function warnVoiceGuard(event: string, details?: Record<string, unknown>) {
@@ -1127,38 +434,6 @@ function ComposerModelLoadingControl(props: { widthClassName: string }) {
   );
 }
 
-interface PlanFollowUpSubmission {
-  text: string;
-  interactionMode: "default" | "plan";
-  dispatchMode: "queue" | "steer";
-  queuedTurn?: QueuedComposerPlanFollowUp;
-}
-
-/**
- * Send-path handlers that are declared *after* `onSend` in the component body (they depend on
- * state and callbacks that are set up later) yet have to be reachable from it — and, for
- * `send` itself, from the queued-turn dispatcher that is declared before it.
- *
- * Reading a later-declared binding from an earlier one makes React Compiler bail out on the
- * whole component ("Cannot access variable before it is declared") — silently, since
- * `panicThreshold` is unset — which would drop memoization for the single hottest component in
- * the app. Routing those calls through one latest-value ref keeps every reference well-ordered.
- * The ref is only ever read from user-driven send flows, never during render, and it is
- * refreshed in a layout effect so no passive-effect window can serve a stale handler.
- */
-interface LateComposerSendHandlers {
-  readonly send: (
-    event?: { preventDefault: () => void },
-    dispatchMode?: "queue" | "steer",
-    queuedTurn?: QueuedComposerChatTurn,
-  ) => Promise<boolean>;
-  readonly submitPlanFollowUp: (submission: PlanFollowUpSubmission) => Promise<boolean>;
-  readonly advanceActivePendingUserInput: (
-    answerOverrides?: Record<string, PendingUserInputDraftAnswer>,
-  ) => boolean;
-  readonly handleStandaloneSlashCommand: (trimmedPrompt: string) => Promise<boolean>;
-}
-
 interface ChatViewProps {
   threadId: ThreadId;
   hideHeader?: boolean;
@@ -1184,45 +459,9 @@ interface ChatViewProps {
   onCloseThreadPane?: () => void;
 }
 
-function normalizeRestoredQueuedPrompt(value: string): string {
-  return value.trim().replace(/\s+/g, " ");
-}
-
-function composerPromptStillMatchesRestoredQueuedDraft(
-  restoredPrompt: string,
-  nextPrompt: string,
-): boolean {
-  const restored = normalizeRestoredQueuedPrompt(restoredPrompt);
-  const next = normalizeRestoredQueuedPrompt(nextPrompt);
-  if (next.length === 0) {
-    return false;
-  }
-  if (restored.length === 0) {
-    return true;
-  }
-  if (next.includes(restored)) {
-    return true;
-  }
-  if (next.length >= Math.min(16, restored.length) && restored.includes(next)) {
-    return true;
-  }
-  const probe = restored.slice(0, Math.min(48, restored.length));
-  return probe.length >= 16 && next.includes(probe);
-}
-
 // Builds an ephemeral transcript bubble for the conversational automation-setup
 // exchange. These never reach a provider and are not persisted; they render the
 // back-and-forth (user request, Synara's clarifying questions) inline like Codex.
-function makeAutomationSetupBubble(role: "user" | "assistant", text: string): ChatMessage {
-  return {
-    id: newMessageId(),
-    role,
-    text,
-    createdAt: new Date().toISOString(),
-    streaming: false,
-    source: "native",
-  };
-}
 
 export default function ChatView({
   threadId,
@@ -1247,7 +486,7 @@ export default function ChatView({
   // Prop defaults are resolved here instead of in the destructuring pattern: an
   // AssignmentPattern in the parameter list makes React Compiler bail out (silently —
   // `panicThreshold` is unset) on this entire component, the hottest one in the app.
-  // See ChatView.compiler.test.ts.
+  // See chatHotPath.compiler.test.ts.
   const paneScopeId = paneScopeIdProp ?? SINGLE_CHAT_PANE_SCOPE_ID;
   const hideHeader = hideHeaderProp ?? false;
   const surfaceMode = surfaceModeProp ?? "single";
@@ -1291,132 +530,82 @@ export default function ChatView({
   );
   const isEditorRail = presentationMode === "editor";
   const isInactiveSplitPane = surfaceMode === "split" && !isFocusedPane;
-  const composerDraft = useComposerThreadDraft(threadId);
-  const prompt = composerDraft.prompt;
-  const composerPromptHistorySavedDraft = composerDraft.promptHistorySavedDraft;
-  const composerPromptHistorySavedDraftImages = composerPromptHistorySavedDraft?.images ?? null;
-  const composerImages = composerDraft.images;
-  const composerFiles = composerDraft.files;
-  const composerAssistantSelections = composerDraft.assistantSelections;
-  const composerBrowserAnnotations = composerDraft.browserAnnotations;
-  const composerFileComments = composerDraft.fileComments;
-  const composerTerminalContexts = composerDraft.terminalContexts;
-  const composerPastedTexts = composerDraft.pastedTexts;
-  const composerPullRequestContexts = composerDraft.pullRequestContexts;
-  const composerSkills = composerDraft.skills;
-  const composerMentions = composerDraft.mentions;
-  const queuedComposerTurns = composerDraft.queuedTurns;
-  const restoredSourceProposedPlan = composerDraft.restoredSourceProposedPlan;
-  const composerSendState = useMemo(
-    () =>
-      deriveComposerSendState({
-        prompt,
-        imageCount: composerImages.length,
-        fileCount: composerFiles.length,
-        assistantSelectionCount: composerAssistantSelections.length,
-        browserAnnotationCount: composerBrowserAnnotations.length,
-        fileCommentCount: composerFileComments.length,
-        terminalContexts: composerTerminalContexts,
-        pastedTexts: composerPastedTexts,
-        pullRequestContexts: composerPullRequestContexts,
-      }),
-    [
-      composerAssistantSelections.length,
-      composerBrowserAnnotations.length,
-      composerFileComments.length,
-      composerFiles.length,
-      composerImages.length,
-      composerTerminalContexts,
-      composerPastedTexts,
-      composerPullRequestContexts,
-      prompt,
-    ],
-  );
-  const nonPersistedComposerImageIds = composerDraft.nonPersistedImageIds;
-  const durablyPersistedComposerImageIds = composerDraft.persistedAttachments;
-  const setComposerDraftPrompt = useComposerDraftStore((store) => store.setPrompt);
-  const setComposerDraftPromptHistorySavedDraft = useComposerDraftStore(
-    (store) => store.setPromptHistorySavedDraft,
-  );
-  const restoreComposerDraftPromptHistorySavedDraft = useComposerDraftStore(
-    (store) => store.restorePromptHistorySavedDraft,
-  );
-  const setComposerDraftModelSelection = useComposerDraftStore((store) => store.setModelSelection);
-  const setComposerDraftProviderModelOptions = useComposerDraftStore(
-    (store) => store.setProviderModelOptions,
-  );
-  const setComposerDraftRuntimeMode = useComposerDraftStore((store) => store.setRuntimeMode);
-  const setComposerDraftInteractionMode = useComposerDraftStore(
-    (store) => store.setInteractionMode,
-  );
-  const enqueueQueuedComposerTurn = useComposerDraftStore((store) => store.enqueueQueuedTurn);
-  const insertQueuedComposerTurn = useComposerDraftStore((store) => store.insertQueuedTurn);
-  const removeQueuedComposerTurnFromDraft = useComposerDraftStore(
-    (store) => store.removeQueuedTurn,
-  );
-  const addComposerDraftImages = useComposerDraftStore((store) => store.addImages);
-  const removeComposerDraftImage = useComposerDraftStore((store) => store.removeImage);
-  const addComposerDraftFiles = useComposerDraftStore((store) => store.addFiles);
-  const removeComposerDraftFile = useComposerDraftStore((store) => store.removeFile);
-  const addComposerDraftAssistantSelection = useComposerDraftStore(
-    (store) => store.addAssistantSelection,
-  );
-  const addComposerDraftBrowserAnnotations = useComposerDraftStore(
-    (store) => store.addBrowserAnnotations,
-  );
-  const removeComposerDraftBrowserAnnotation = useComposerDraftStore(
-    (store) => store.removeBrowserAnnotation,
-  );
-  const clearComposerDraftAssistantSelections = useComposerDraftStore(
-    (store) => store.clearAssistantSelections,
-  );
-  const addComposerDraftFileComment = useComposerDraftStore((store) => store.addFileComment);
-  const clearComposerDraftFileComments = useComposerDraftStore((store) => store.clearFileComments);
-  const insertComposerDraftTerminalContext = useComposerDraftStore(
-    (store) => store.insertTerminalContext,
-  );
-  const addComposerDraftTerminalContexts = useComposerDraftStore(
-    (store) => store.addTerminalContexts,
-  );
-  const removeComposerDraftTerminalContext = useComposerDraftStore(
-    (store) => store.removeTerminalContext,
-  );
-  const addComposerDraftPastedTexts = useComposerDraftStore((store) => store.addPastedTexts);
-  const removeComposerDraftPastedText = useComposerDraftStore((store) => store.removePastedText);
-  const addComposerDraftPullRequestContext = useComposerDraftStore(
-    (store) => store.addPullRequestContext,
-  );
-  const removeComposerDraftPullRequestContext = useComposerDraftStore(
-    (store) => store.removePullRequestContext,
-  );
-  const setComposerDraftTerminalContexts = useComposerDraftStore(
-    (store) => store.setTerminalContexts,
-  );
-  const setComposerDraftSkills = useComposerDraftStore((store) => store.setSkills);
-  const setComposerDraftMentions = useComposerDraftStore((store) => store.setMentions);
-  const clearComposerDraftPersistedAttachments = useComposerDraftStore(
-    (store) => store.clearPersistedAttachments,
-  );
-  const syncComposerDraftPersistedAttachments = useComposerDraftStore(
-    (store) => store.syncPersistedAttachments,
-  );
-  const syncComposerDraftPromptHistorySavedDraftPersistedAttachments = useComposerDraftStore(
-    (store) => store.syncPromptHistorySavedDraftPersistedAttachments,
-  );
-  const setComposerDraftRestoredSourceProposedPlan = useComposerDraftStore(
-    (store) => store.setRestoredSourceProposedPlan,
-  );
-  const clearComposerDraftContent = useComposerDraftStore((store) => store.clearComposerContent);
-  const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
-  const moveDraftThreadToProject = useComposerDraftStore((store) => store.moveDraftThreadToProject);
-  const getDraftThreadByProjectId = useComposerDraftStore(
-    (store) => store.getDraftThreadByProjectId,
-  );
-  const getDraftThread = useComposerDraftStore((store) => store.getDraftThread);
-  const setProjectDraftThreadId = useComposerDraftStore((store) => store.setProjectDraftThreadId);
-  const clearProjectDraftThreadId = useComposerDraftStore(
-    (store) => store.clearProjectDraftThreadId,
-  );
+  const {
+    composerDraft,
+    prompt,
+    composerImages,
+    composerFiles,
+    composerAssistantSelections,
+    composerBrowserAnnotations,
+    composerFileComments,
+    composerTerminalContexts,
+    composerPastedTexts,
+    composerPullRequestContexts,
+    composerSkills,
+    composerMentions,
+    queuedComposerTurns,
+    composerSendState,
+    nonPersistedComposerImageIds,
+    durablyPersistedComposerImageIds,
+    setComposerDraftPrompt,
+    setComposerDraftPromptHistorySavedDraft,
+    restoreComposerDraftPromptHistorySavedDraft,
+    setComposerDraftModelSelection,
+    setComposerDraftProviderModelOptions,
+    setComposerDraftRuntimeMode,
+    setComposerDraftInteractionMode,
+    enqueueQueuedComposerTurn,
+    insertQueuedComposerTurn,
+    removeQueuedComposerTurnFromDraft,
+    removeComposerDraftFile,
+    addComposerDraftBrowserAnnotations,
+    insertComposerDraftTerminalContext,
+    addComposerDraftPastedTexts,
+    setComposerDraftTerminalContexts,
+    clearComposerDraftContent,
+    setDraftThreadContext,
+    getDraftThreadByProjectId,
+    getDraftThread,
+    setProjectDraftThreadId,
+    clearProjectDraftThreadId,
+    promptRef,
+    composerAssistantSelectionsRef,
+    composerBrowserAnnotationsRef,
+    composerTerminalContextsRef,
+    composerFileCommentsRef,
+    composerPastedTextsRef,
+    composerPullRequestContextsRef,
+    composerCursor,
+    setComposerCursor,
+    composerTrigger,
+    setComposerTrigger,
+    composerEditorRef,
+    promptHistoryNavigationRef,
+    applyingPromptHistoryNavigationRef,
+    expectedPromptHistoryPromptRef,
+    promptHistoryAppliedPromptRef,
+    composerImagesRef,
+    composerFilesRef,
+    restoredQueuedSourceProposedPlanRef,
+    setRestoredQueuedSourceProposedPlan,
+    setPrompt,
+    discardPromptHistoryNavigationForComposerMutation,
+    addComposerImagesToDraft,
+    addComposerFilesToDraft,
+    addComposerAssistantSelectionToDraft,
+    addComposerTerminalContextsToDraft,
+    addComposerPastedTextsToDraft,
+    addComposerFileCommentToDraft,
+    removeComposerImageFromDraft,
+    clearComposerAssistantSelectionsFromDraft,
+    clearComposerFileCommentsFromDraft,
+    removeComposerTerminalContextFromDraft,
+    removeComposerPastedTextFromDraft,
+    addComposerPullRequestContextsToDraft,
+    removeComposerPullRequestContextFromDraft,
+    removeComposerBrowserAnnotationFromDraft,
+    showComposerPastedTextInField,
+  } = useChatComposerDraft({ threadId });
   const draftThread = useComposerDraftStore(
     (store) => store.draftThreadsByThreadId[threadId] ?? null,
   );
@@ -1483,48 +672,17 @@ export default function ChatView({
       }),
     [fallbackDraftProject?.defaultModelSelection, settings.defaultProvider],
   );
-  const promptRef = useRef(prompt);
+
   const [isDragOverComposer, setIsDragOverComposer] = useState(false);
   const [expandedImage, setExpandedImage] = useState<ExpandedImagePreview | null>(null);
-  const [optimisticUserMessages, setOptimisticUserMessages] = useState<ChatMessage[]>([]);
-  const optimisticUserMessagesRef = useRef(optimisticUserMessages);
-  // Mirror during the commit, before events or async continuations can observe
-  // the new UI with the previous render's preview URLs.
-  useLayoutEffect(() => {
-    optimisticUserMessagesRef.current = optimisticUserMessages;
-  }, [optimisticUserMessages]);
-  const composerAssistantSelectionsRef = useRef<ComposerAssistantSelectionAttachment[]>(
-    composerAssistantSelections,
-  );
-  const composerBrowserAnnotationsRef = useRef<BrowserAnnotationDraft[]>(
-    composerBrowserAnnotations,
-  );
-  const composerTerminalContextsRef = useRef<TerminalContextDraft[]>(composerTerminalContexts);
-  const composerFileCommentsRef = useRef<FileCommentDraft[]>(composerFileComments);
-  const composerPastedTextsRef = useRef<PastedTextDraft[]>(composerPastedTexts);
-  const composerPullRequestContextsRef = useRef<PullRequestContextDraft[]>(
-    composerPullRequestContexts,
-  );
+
   const [localDraftErrorsByThreadId, setLocalDraftErrorsByThreadId] = useState<
     Record<ThreadId, string | null>
   >({});
-  const [localDispatch, setLocalDispatch] = useState<LocalDispatchSnapshot | null>(null);
-  const failedWorktreeSetupDispatchStartedAtRef = useRef<string | null>(null);
-  // Live handle to the in-flight send's worktree preparation, resolved by the
-  // setup card's Cancel / Work locally buttons. One send at a time can prepare
-  // a worktree (the composer is send-busy while it runs), so a single ref is safe.
-  const worktreeSetupResolutionRef = useRef<WorktreeSetupResolution | null>(null);
-  const [worktreeSetupPendingAction, setWorktreeSetupPendingAction] =
-    useState<WorktreeSetupResolutionAction | null>(null);
+
   const [isRevertingCheckpoint, setIsRevertingCheckpoint] = useState(false);
   const [pendingFileUndo, setPendingFileUndo] = useState<PendingFileUndo | null>(null);
-  const [showScrollToBottom, setShowScrollToBottom] = useState(false);
-  const [respondingRequestKeys, setRespondingRequestKeys] = useState<string[]>([]);
-  const [respondingUserInputRequestKeys, setRespondingUserInputRequestKeys] = useState<string[]>(
-    [],
-  );
-  const [pendingUserInputQuestionIndexByRequestId, setPendingUserInputQuestionIndexByRequestId] =
-    useState<Record<string, number>>({});
+
   const [planSidebarOpen, setPlanSidebarOpen] = useState(false);
   const [activeTaskListCompact, setActiveTaskListCompact] = useState(false);
   const [subagentStripCompact, setSubagentStripCompact] = useState(false);
@@ -1538,11 +696,7 @@ export default function ChatView({
   const composerFooterTierRef = useRef(0);
   const composerFooterDemotionWidthsRef = useRef<ReadonlyArray<number | undefined>>([]);
   const composerFooterLayoutSyncRef = useRef<(() => void) | null>(null);
-  const [confirmedCustomBinaryPathsByProvider, setConfirmedCustomBinaryPathsByProvider] = useState<
-    Partial<Record<ProviderKind, string>>
-  >(loadConfirmedCustomBinaryPaths);
-  const confirmedCustomBinarySessionKeysRef = useRef<Set<string>>(new Set());
-  const pendingCustomBinaryPathsByThreadProviderRef = useRef<Map<string, string>>(new Map());
+
   const [composerCommandPicker, setComposerCommandPicker] = useState<
     null | "fork-target" | "review-target"
   >(null);
@@ -1555,64 +709,7 @@ export default function ChatView({
   const [composerHighlightedItemId, setComposerHighlightedItemId] = useState<string | null>(null);
   const [pullRequestDialogState, setPullRequestDialogState] =
     useState<PullRequestDialogState | null>(null);
-  const [attachmentPreviewHandoffByMessageId, setAttachmentPreviewHandoffByMessageId] = useState<
-    Record<string, string[]>
-  >({});
-  const [composerCursor, setComposerCursor] = useState(() =>
-    collapseExpandedComposerCursor(prompt, prompt.length),
-  );
-  const [composerTrigger, setComposerTrigger] = useState<ComposerTrigger | null>(() =>
-    detectComposerTrigger(prompt, prompt.length),
-  );
-  const [selectedComposerSkills, setSelectedComposerSkills] = useState<ProviderSkillReference[]>(
-    () => composerSkills,
-  );
-  const [selectedComposerMentions, setSelectedComposerMentions] = useState<
-    ProviderMentionReference[]
-  >(() => composerMentions);
-  const selectedComposerSkillsRef = useRef<ProviderSkillReference[]>(selectedComposerSkills);
-  const selectedComposerMentionsRef = useRef<ProviderMentionReference[]>(selectedComposerMentions);
-  // The setters below stamp these refs synchronously; layout effects backstop
-  // external state changes before another browser event can read stale values.
-  useLayoutEffect(() => {
-    selectedComposerSkillsRef.current = selectedComposerSkills;
-  }, [selectedComposerSkills]);
-  useLayoutEffect(() => {
-    selectedComposerMentionsRef.current = selectedComposerMentions;
-  }, [selectedComposerMentions]);
-  const updateSelectedComposerSkills = useCallback(
-    (
-      next:
-        | ProviderSkillReference[]
-        | ((existing: ProviderSkillReference[]) => ProviderSkillReference[]),
-    ) => {
-      const existing = selectedComposerSkillsRef.current;
-      const resolved = typeof next === "function" ? next(existing) : next;
-      selectedComposerSkillsRef.current = resolved;
-      setSelectedComposerSkills(resolved);
-      setComposerDraftSkills(threadId, resolved);
-    },
-    [setComposerDraftSkills, threadId],
-  );
-  const updateSelectedComposerMentions = useCallback(
-    (
-      next:
-        | ProviderMentionReference[]
-        | ((existing: ProviderMentionReference[]) => ProviderMentionReference[]),
-    ) => {
-      const existing = selectedComposerMentionsRef.current;
-      const resolved = typeof next === "function" ? next(existing) : next;
-      selectedComposerMentionsRef.current = resolved;
-      setSelectedComposerMentions(resolved);
-      setComposerDraftMentions(threadId, resolved);
-    },
-    [setComposerDraftMentions, threadId],
-  );
-  const [lastInvokedScriptByProjectId, setLastInvokedScriptByProjectId] = useLocalStorage(
-    LAST_INVOKED_SCRIPT_BY_PROJECT_KEY,
-    EMPTY_LAST_INVOKED_SCRIPT_BY_PROJECT,
-    LastInvokedScriptByProjectSchema,
-  );
+
   const [dismissedProviderHealthBannerKeys, setDismissedProviderHealthBannerKeys] = useLocalStorage(
     DISMISSED_PROVIDER_HEALTH_BANNERS_KEY,
     EMPTY_DISMISSED_PROVIDER_HEALTH_BANNERS,
@@ -1638,16 +735,6 @@ export default function ChatView({
     threadFindHighlightStore.setActiveMatch(match);
     timelineControllerRef.current?.setActiveFindMatch(match);
   };
-  const isAtEndRef = useRef(true);
-  const autoFollowThreadIdRef = useRef<ThreadId | null>(null);
-  const pendingInteractionAnchorRef = useRef<{
-    element: HTMLElement;
-    top: number;
-  } | null>(null);
-  const pendingInteractionAnchorFrameRef = useRef<number | null>(null);
-  const showScrollDebouncer = useRef(
-    new Debouncer(() => setShowScrollToBottom(true), { wait: 150 }),
-  );
 
   useEffect(() => {
     // Async setState (post-paint) keeps this thread-change reset out of the
@@ -1660,282 +747,42 @@ export default function ChatView({
       threadFindHighlightStore.set(null);
     }, 0);
     return () => window.clearTimeout(settle);
-  }, [threadId, threadFindHighlightStore]);
-  useEffect(() => {
-    const scrollDebouncer = showScrollDebouncer.current;
-    return () => {
-      scrollDebouncer.cancel();
-      const pendingFrame = pendingInteractionAnchorFrameRef.current;
-      if (pendingFrame !== null) {
-        window.cancelAnimationFrame(pendingFrame);
-      }
-    };
-  }, []);
-  useEffect(() => {
-    // Thread-bound handoff dialog state is reset by the dedicated hook.
-  }, [threadId]);
-  const composerEditorRef = useRef<ComposerPromptEditorHandle>(null);
+  }, [
+    setComposerCommandPicker,
+    setIsModelPickerOpen,
+    setIsTraitsPickerOpen,
+    setThreadFindOpen,
+    threadId,
+    threadFindHighlightStore,
+  ]);
+
   const composerFormRef = useRef<HTMLFormElement>(null);
   // Set by whichever mounted GitActionsControl instance (header quick-action or the
   // Environment panel row) last registered — either performs the identical commit &
   // push mutation for this thread's repo, so it doesn't matter which one is "current".
   const commitAndPushTriggerRef = useRef<(() => void) | null>(null);
-  const onRegisterCommitAndPushTrigger = useCallback((trigger: (() => void) | null) => {
-    commitAndPushTriggerRef.current = trigger;
-  }, []);
+  const onRegisterCommitAndPushTrigger = useCallback(
+    (trigger: (() => void) | null) => {
+      commitAndPushTriggerRef.current = trigger;
+    },
+    [commitAndPushTriggerRef],
+  );
   const pendingComposerFocusRef = useRef(false);
-  const promptHistoryNavigationRef = useRef<PromptHistoryNavigationState | null>(null);
-  const applyingPromptHistoryNavigationRef = useRef(false);
-  const expectedPromptHistoryPromptRef = useRef<string | null>(null);
-  const promptHistoryAppliedPromptRef = useRef<string | null>(null);
+
   const composerFormHeightRef = useRef(0);
-  const composerImagesRef = useRef<ComposerImageAttachment[]>([]);
-  const composerFilesRef = useRef<ComposerFileAttachment[]>([]);
+
   const composerSelectLockRef = useRef(false);
   const composerMenuOpenRef = useRef(false);
   const composerMenuItemsRef = useRef<ComposerCommandItem[]>([]);
-  const queuedComposerTurnsRef = useRef<QueuedComposerTurn[]>([]);
-  const restoredQueuedSourceProposedPlanRef = useRef<RestoredComposerSourceProposedPlan | null>(
-    restoredSourceProposedPlan ?? null,
-  );
-  const autoDispatchingQueuedTurnRef = useRef(false);
-  // Holds queued-composer auto-dispatch through a non-natively-steerable
-  // provider steer's interrupt→re-dispatch gap; see
-  // resolveQueuedSteerGateTransition. Seed from the shared map so a remount
-  // during the interrupt gap still sees the gate the watcher has been holding.
-  const [queuedSteerGate, setQueuedSteerGate] = useState<QueuedSteerGate | null>(() =>
-    getQueuedComposerSteerGate(threadId),
-  );
-  // Bumped to re-evaluate auto-dispatch when only non-reactive guards (refs)
-  // blocked it; nothing else re-triggers the effect once they reset.
-  const [queuedAutoDispatchTick, setQueuedAutoDispatchTick] = useState(0);
+
   const activeComposerMenuItemRef = useRef<ComposerCommandItem | null>(null);
   const localDirectoryMenuRef = useRef<ComposerLocalDirectoryMenuHandle | null>(null);
-  const attachmentPreviewHandoffByMessageIdRef = useRef<Record<string, string[]>>({});
-  const attachmentPreviewHandoffTimeoutByMessageIdRef = useRef<Record<string, number>>({});
+
   const sendInFlightRef = useRef(false);
   const sendPreflightInFlightRef = useRef(false);
   const dragDepthRef = useRef(0);
   const terminalOpenByThreadRef = useRef<Record<string, boolean>>({});
   const activatedThreadIdRef = useRef<ThreadId | null>(null);
-  useEffect(() => {
-    promptHistoryNavigationRef.current = null;
-    applyingPromptHistoryNavigationRef.current = false;
-    expectedPromptHistoryPromptRef.current = null;
-    promptHistoryAppliedPromptRef.current = null;
-  }, [threadId]);
-  // While a history browse is active the persisted draft prompt holds a
-  // recalled entry and the user's real draft snapshot sits in promptHistorySavedDraft.
-  // A non-null saved draft with no live navigation state means the browse was
-  // interrupted (thread switch, reload, unmount) — put the real draft back.
-  useEffect(() => {
-    if (promptHistoryNavigationRef.current !== null || composerPromptHistorySavedDraft === null) {
-      return;
-    }
-    restoreComposerDraftPromptHistorySavedDraft(threadId);
-    setComposerCursor(
-      collapseExpandedComposerCursor(
-        composerPromptHistorySavedDraft.prompt,
-        composerPromptHistorySavedDraft.prompt.length,
-      ),
-    );
-  }, [composerPromptHistorySavedDraft, restoreComposerDraftPromptHistorySavedDraft, threadId]);
-  const setRestoredQueuedSourceProposedPlan = useCallback(
-    (targetThreadId: ThreadId, source: RestoredComposerSourceProposedPlan | null) => {
-      restoredQueuedSourceProposedPlanRef.current = source;
-      setComposerDraftRestoredSourceProposedPlan(targetThreadId, source);
-    },
-    [setComposerDraftRestoredSourceProposedPlan],
-  );
-  useEffect(() => {
-    restoredQueuedSourceProposedPlanRef.current = restoredSourceProposedPlan ?? null;
-  }, [restoredSourceProposedPlan]);
-
-  const setPrompt = useCallback(
-    (nextPrompt: string) => {
-      setComposerDraftPrompt(threadId, nextPrompt);
-    },
-    [setComposerDraftPrompt, threadId],
-  );
-  const discardPromptHistoryNavigationForComposerMutation = useCallback(() => {
-    if (promptHistoryNavigationRef.current === null) {
-      return;
-    }
-    // Attachment edits mean the recalled prompt is now the user's draft; do not restore the old one.
-    promptHistoryNavigationRef.current = null;
-    applyingPromptHistoryNavigationRef.current = false;
-    expectedPromptHistoryPromptRef.current = null;
-    promptHistoryAppliedPromptRef.current = null;
-    setComposerDraftPromptHistorySavedDraft(threadId, null);
-  }, [setComposerDraftPromptHistorySavedDraft, threadId]);
-  const addComposerImagesToDraft = useCallback(
-    (images: ComposerImageAttachment[]) => {
-      discardPromptHistoryNavigationForComposerMutation();
-      return addComposerDraftImages(threadId, images);
-    },
-    [addComposerDraftImages, discardPromptHistoryNavigationForComposerMutation, threadId],
-  );
-  const addComposerFilesToDraft = useCallback(
-    (files: ComposerFileAttachment[]) => {
-      discardPromptHistoryNavigationForComposerMutation();
-      return addComposerDraftFiles(threadId, files);
-    },
-    [addComposerDraftFiles, discardPromptHistoryNavigationForComposerMutation, threadId],
-  );
-  const addComposerAssistantSelectionToDraft = useCallback(
-    (selection: ComposerAssistantSelectionAttachment) => {
-      discardPromptHistoryNavigationForComposerMutation();
-      return addComposerDraftAssistantSelection(threadId, selection);
-    },
-    [
-      addComposerDraftAssistantSelection,
-      discardPromptHistoryNavigationForComposerMutation,
-      threadId,
-    ],
-  );
-  const addComposerTerminalContextsToDraft = useCallback(
-    (contexts: TerminalContextDraft[]) => {
-      discardPromptHistoryNavigationForComposerMutation();
-      addComposerDraftTerminalContexts(threadId, contexts);
-    },
-    [addComposerDraftTerminalContexts, discardPromptHistoryNavigationForComposerMutation, threadId],
-  );
-  const addComposerPastedTextsToDraft = useCallback(
-    (pastedTexts: PastedTextDraft[]) => {
-      discardPromptHistoryNavigationForComposerMutation();
-      addComposerDraftPastedTexts(threadId, pastedTexts);
-    },
-    [addComposerDraftPastedTexts, discardPromptHistoryNavigationForComposerMutation, threadId],
-  );
-  const addComposerFileCommentToDraft = useCallback(
-    (comment: FileCommentDraft) => {
-      discardPromptHistoryNavigationForComposerMutation();
-      addComposerDraftFileComment(threadId, comment);
-    },
-    [addComposerDraftFileComment, discardPromptHistoryNavigationForComposerMutation, threadId],
-  );
-  const removeComposerImageFromDraft = useCallback(
-    (imageId: string) => {
-      discardPromptHistoryNavigationForComposerMutation();
-      removeComposerDraftImage(threadId, imageId);
-    },
-    [discardPromptHistoryNavigationForComposerMutation, removeComposerDraftImage, threadId],
-  );
-  const clearComposerAssistantSelectionsFromDraft = useCallback(() => {
-    discardPromptHistoryNavigationForComposerMutation();
-    clearComposerDraftAssistantSelections(threadId);
-  }, [
-    clearComposerDraftAssistantSelections,
-    discardPromptHistoryNavigationForComposerMutation,
-    threadId,
-  ]);
-  const clearComposerFileCommentsFromDraft = useCallback(() => {
-    discardPromptHistoryNavigationForComposerMutation();
-    clearComposerDraftFileComments(threadId);
-  }, [clearComposerDraftFileComments, discardPromptHistoryNavigationForComposerMutation, threadId]);
-  const removeComposerTerminalContextFromDraft = useCallback(
-    (contextId: string) => {
-      discardPromptHistoryNavigationForComposerMutation();
-      const contextIndex = composerTerminalContexts.findIndex(
-        (context) => context.id === contextId,
-      );
-      if (contextIndex < 0) {
-        return;
-      }
-      const nextPrompt = removeInlineTerminalContextPlaceholder(promptRef.current, contextIndex);
-      promptRef.current = nextPrompt.prompt;
-      setPrompt(nextPrompt.prompt);
-      removeComposerDraftTerminalContext(threadId, contextId);
-      setComposerCursor(nextPrompt.cursor);
-      setComposerTrigger(
-        detectComposerTrigger(
-          nextPrompt.prompt,
-          expandCollapsedComposerCursor(nextPrompt.prompt, nextPrompt.cursor),
-        ),
-      );
-    },
-    [
-      composerTerminalContexts,
-      discardPromptHistoryNavigationForComposerMutation,
-      removeComposerDraftTerminalContext,
-      setPrompt,
-      threadId,
-    ],
-  );
-  const removeComposerPastedTextFromDraft = useCallback(
-    (pastedTextId: string) => {
-      discardPromptHistoryNavigationForComposerMutation();
-      removeComposerDraftPastedText(threadId, pastedTextId);
-    },
-    [discardPromptHistoryNavigationForComposerMutation, removeComposerDraftPastedText, threadId],
-  );
-  const addComposerPullRequestContextsToDraft = useCallback(
-    (contexts: ReadonlyArray<PullRequestContextDraft>) => {
-      if (contexts.length === 0) {
-        return;
-      }
-      discardPromptHistoryNavigationForComposerMutation();
-      for (const context of contexts) {
-        addComposerDraftPullRequestContext(threadId, context);
-      }
-    },
-    [
-      addComposerDraftPullRequestContext,
-      discardPromptHistoryNavigationForComposerMutation,
-      threadId,
-    ],
-  );
-  const removeComposerPullRequestContextFromDraft = useCallback(
-    (contextId: string) => {
-      discardPromptHistoryNavigationForComposerMutation();
-      removeComposerDraftPullRequestContext(threadId, contextId);
-    },
-    [
-      discardPromptHistoryNavigationForComposerMutation,
-      removeComposerDraftPullRequestContext,
-      threadId,
-    ],
-  );
-  const removeComposerBrowserAnnotationFromDraft = useCallback(
-    (annotationId: string) => {
-      discardPromptHistoryNavigationForComposerMutation();
-      removeComposerDraftBrowserAnnotation(threadId, annotationId);
-    },
-    [
-      discardPromptHistoryNavigationForComposerMutation,
-      removeComposerDraftBrowserAnnotation,
-      threadId,
-    ],
-  );
-  // "Show in text field": drop the full pasted text back into the editor (appended
-  // to the current prompt) and discard the card so it can be edited as normal text.
-  const showComposerPastedTextInField = useCallback(
-    (pastedTextId: string) => {
-      const pasted = composerPastedTexts.find((entry) => entry.id === pastedTextId);
-      if (!pasted) {
-        return;
-      }
-      discardPromptHistoryNavigationForComposerMutation();
-      const current = promptRef.current;
-      const separator = current.length > 0 && !current.endsWith("\n") ? "\n" : "";
-      const nextPrompt = `${current}${separator}${pasted.text}`;
-      promptRef.current = nextPrompt;
-      setPrompt(nextPrompt);
-      removeComposerDraftPastedText(threadId, pastedTextId);
-      setComposerCursor(collapseExpandedComposerCursor(nextPrompt, nextPrompt.length));
-      setComposerTrigger(detectComposerTrigger(nextPrompt, nextPrompt.length));
-      window.requestAnimationFrame(() => {
-        composerEditorRef.current?.focusAtEnd();
-      });
-    },
-    [
-      composerPastedTexts,
-      discardPromptHistoryNavigationForComposerMutation,
-      removeComposerDraftPastedText,
-      setPrompt,
-      threadId,
-    ],
-  );
 
   const localDraftError = serverThread ? null : (localDraftErrorsByThreadId[threadId] ?? null);
   const localDraftThread = useMemo(
@@ -1968,7 +815,12 @@ export default function ChatView({
       isSettled: activeThread.settledAt != null,
     });
     setSettledThreadBranchWarningDismissedThreadId(null);
-  }, [activeThread, activeThreadBranchAtActivation?.threadId]);
+  }, [
+    setActiveThreadBranchAtActivation,
+    setSettledThreadBranchWarningDismissedThreadId,
+    activeThread,
+    activeThreadBranchAtActivation?.threadId,
+  ]);
   const settledThreadBranchAtActivation =
     activeThreadBranchAtActivation !== null &&
     activeThreadBranchAtActivation.threadId === activeThread?.id &&
@@ -1989,23 +841,10 @@ export default function ChatView({
       setIsRevertingCheckpoint(false);
     }, 0);
     return () => window.clearTimeout(settle);
-  }, [activeThread, pendingFileUndo]);
+  }, [setIsRevertingCheckpoint, setPendingFileUndo, activeThread, pendingFileUndo]);
   const runtimeMode =
     composerDraft.runtimeMode ?? activeThread?.runtimeMode ?? DEFAULT_RUNTIME_MODE;
-  const runtimeModePersistenceQueuesRef = useRef(
-    new Map<ThreadId, ReturnType<typeof createRuntimeModePersistenceQueue>>(),
-  );
-  useEffect(() => {
-    const existing = runtimeModePersistenceQueuesRef.current.get(threadId);
-    if (existing) {
-      existing.syncAcknowledgedMode(runtimeMode);
-      return;
-    }
-    runtimeModePersistenceQueuesRef.current.set(
-      threadId,
-      createRuntimeModePersistenceQueue(runtimeMode),
-    );
-  }, [runtimeMode, threadId]);
+
   const interactionMode =
     composerDraft.interactionMode ?? activeThread?.interactionMode ?? DEFAULT_INTERACTION_MODE;
   const isServerThread = serverThread !== undefined;
@@ -2020,9 +859,7 @@ export default function ChatView({
   // `foo?.bar` read inside a memo makes React Compiler infer `foo` as the dependency, which
   // no longer matches the hand-written `foo?.bar` dep and bails the whole component out.
   const activeLatestTurnId = activeLatestTurn?.turnId ?? null;
-  const activeLatestTurnStartedAt = activeLatestTurn?.startedAt ?? null;
   const activeLatestTurnState = activeLatestTurn?.state ?? null;
-  const activeLatestTurnCompletedAt = activeLatestTurn?.completedAt ?? null;
   const threadActivities = activeThread?.activities ?? EMPTY_ACTIVITIES;
   const hasLiveTurnTail = hasLiveTurnTailWork({
     latestTurn: activeLatestTurn,
@@ -2131,8 +968,6 @@ export default function ChatView({
     setTerminalActivityInStore: storeSetTerminalActivity,
     openChatThreadPageInStore: storeOpenChatThreadPage,
     openTerminalThreadPageInStore: storeOpenTerminalThreadPage,
-    newTerminalInStore: storeNewTerminal,
-    setActiveTerminalInStore: storeSetActiveTerminal,
     closeTerminalGroupInStore: storeCloseTerminalGroup,
     resizeTerminalSplitInStore: storeResizeTerminalSplit,
     toggleTerminalVisibility,
@@ -2247,12 +1082,12 @@ export default function ChatView({
       });
       setComposerHighlightedItemId(null);
     },
-    [canCheckoutPullRequestIntoThread],
+    [setComposerHighlightedItemId, setPullRequestDialogState, canCheckoutPullRequestIntoThread],
   );
 
   const closePullRequestDialog = useCallback(() => {
     setPullRequestDialogState(null);
-  }, []);
+  }, [setPullRequestDialogState]);
 
   const openOrReuseProjectDraftThread = useCallback(
     async (input: {
@@ -2354,442 +1189,66 @@ export default function ChatView({
     markThreadVisited,
   ]);
 
-  const sessionProvider = activeThread?.session?.provider ?? null;
-  const selectedProviderByThreadId = composerDraft.activeProvider ?? null;
-  const threadProvider =
-    activeThread?.modelSelection.provider ?? activeProject?.defaultModelSelection?.provider ?? null;
-  const hasThreadStarted = Boolean(
-    activeThread &&
-    (activeThread.latestTurn !== null ||
-      activeThread.messages.length > 0 ||
-      activeThread.session !== null),
-  );
-  // Side chats import source history as fork-import rows. Those imports must not lock the
-  // provider picker before the Side produces its first native turn (#810).
-  const hasProviderLockingActivity = Boolean(
-    activeThread && threadHasProviderLockingActivity(activeThread),
-  );
-  const lockedProvider: ProviderKind | null = hasProviderLockingActivity
-    ? (sessionProvider ?? threadProvider ?? selectedProviderByThreadId ?? null)
-    : null;
-  const serverConfigQuery = useQuery(serverConfigQueryOptions());
-  const localProviderStatuses = useProviderStatusesForLocalConfig();
-  const preferredDraftProvider =
-    selectedProviderByThreadId ?? threadProvider ?? settings.defaultProvider;
-  const providerStatusesReconciled = hasReconciledServerProviderStatuses(queryClient);
-  const selectedProvider = useMemo<ProviderKind>(
-    () =>
-      lockedProvider ??
-      // Keep an unstarted draft pinned to its explicit provider; availability is validated at send time.
-      selectedProviderByThreadId ??
-      resolveAvailableProviderPreference({
-        preferredProvider: preferredDraftProvider,
-        statuses: providerStatusesReconciled ? localProviderStatuses : EMPTY_PROVIDER_STATUSES,
-        providerOrder: settings.providerOrder,
-        hiddenProviders: settings.hiddenProviders,
-      }),
-    [
-      localProviderStatuses,
-      lockedProvider,
-      preferredDraftProvider,
-      providerStatusesReconciled,
-      selectedProviderByThreadId,
-      settings.hiddenProviders,
-      settings.providerOrder,
-    ],
-  );
-  const previousSelectedProviderRef = useRef<{
-    threadId: ThreadId;
-    provider: ProviderKind;
-  } | null>(null);
-  const featureFlags = useFeatureFlags();
-  const showDebugTaskBanner = import.meta.env.DEV && featureFlags["show-debug-task-banner"];
-  const serverSettingsQuery = useQuery(serverSettingsQueryOptions());
-  const composerModelHintByProvider = useMemo<Record<ProviderKind, string | null>>(() => {
-    const threadModelSelection = activeThread?.modelSelection ?? null;
-    const projectModelSelection = activeProject?.defaultModelSelection ?? null;
-    const draftSelections = composerDraft.modelSelectionByProvider;
-
-    const resolveHint = (provider: ProviderKind): string | null =>
-      draftSelections[provider]?.model ??
-      (threadModelSelection?.provider === provider ? threadModelSelection.model : null) ??
-      (projectModelSelection?.provider === provider ? projectModelSelection.model : null);
-
-    return {
-      codex: resolveHint("codex"),
-      claudeAgent: resolveHint("claudeAgent"),
-      cursor: resolveHint("cursor"),
-      antigravity: resolveHint("antigravity"),
-      grok: resolveHint("grok"),
-      droid: resolveHint("droid"),
-      opencode: resolveHint("opencode"),
-      pi: resolveHint("pi"),
-      devin: resolveHint("devin"),
-    };
-  }, [
-    activeProject?.defaultModelSelection,
-    activeThread?.modelSelection,
-    composerDraft.modelSelectionByProvider,
-  ]);
-  const providerModelDiscoveryCwd = resolveProviderDiscoveryCwd({
-    activeThreadWorktreePath: resolvedThreadWorktreePath,
-    activeProjectCwd: activeProject?.cwd ?? null,
-    serverCwd: serverConfigQuery.data?.cwd ?? null,
-  });
   const {
+    hasThreadStarted,
+    lockedProvider,
+    serverConfigQuery,
+    selectedProvider,
+    providerModelDiscoveryCwd,
     customModelsByProvider,
     modelOptionsByProvider,
     loadingModelProviders,
     discoveryErrorsByProvider,
     runtimeModelsByProvider,
-    selectedRuntimeAgents: dynamicAgents,
-    selectedProviderModelsLoading,
+    dynamicAgents,
     selectedProviderRuntimeModelDiscoveryPending,
-  } = useProviderModelCatalog({
-    selectedProvider,
-    discoveryEnabled: isModelPickerOpen,
-    cwd: providerModelDiscoveryCwd,
-    modelHintByProvider: composerModelHintByProvider,
-    agentDiscoveryPolicy: "eager-core",
+    composerModelOptions,
+    selectedModel,
+    selectedRuntimeModel,
+    composerProviderState,
+    selectedPromptEffort,
+    selectedModelSelection,
+    providerOptionsForDispatch,
+    selectedModelForPickerWithCustomFallback,
+    showComposerModelBootstrapSkeleton,
+    searchableModelOptions,
+  } = useChatProviderModels({
+    threadId,
+    activeThread,
+    activeProject,
+    composerDraft,
+    settings,
+    isModelPickerOpen,
+    resolvedThreadWorktreePath,
   });
-  const { modelOptions: composerModelOptions, selectedModel } = useEffectiveComposerModelState({
+  const {
+    selectedComposerSkills,
+    selectedComposerMentions,
+    selectedComposerSkillsRef,
+    selectedComposerMentionsRef,
+    updateSelectedComposerSkills,
+    updateSelectedComposerMentions,
+  } = useComposerReferences({
     threadId,
     selectedProvider,
-    threadModelSelection: activeThread?.modelSelection,
-    projectModelSelection: activeProject?.defaultModelSelection,
-    customModelsByProvider,
-    availableModelOptionsByProvider: modelOptionsByProvider,
+    prompt,
+    composerSkills,
+    composerMentions,
   });
-  const draftModelSelectionForSelectedProvider =
-    composerDraft.modelSelectionByProvider[selectedProvider] ?? null;
-  const persistedClaudeSupportsAutoMode =
-    selectedProvider === "claudeAgent"
-      ? draftModelSelectionForSelectedProvider?.provider === "claudeAgent" &&
-        draftModelSelectionForSelectedProvider.model === selectedModel
-        ? draftModelSelectionForSelectedProvider.supportsAutoMode
-        : activeThread?.modelSelection.provider === "claudeAgent" &&
-            activeThread.modelSelection.model === selectedModel
-          ? activeThread.modelSelection.supportsAutoMode
-          : undefined
-      : undefined;
-  const selectedRuntimeModel = useMemo(() => {
-    const discovered = resolveRuntimeModelDescriptor({
-      provider: selectedProvider,
-      model: selectedModel,
-      runtimeModels: runtimeModelsByProvider[selectedProvider],
-    });
-    if (discovered) {
-      return discovered;
-    }
-    return selectedProvider === "claudeAgent" &&
-      typeof persistedClaudeSupportsAutoMode === "boolean"
-      ? {
-          slug: selectedModel,
-          name: selectedModel,
-          supportsAutoMode: persistedClaudeSupportsAutoMode,
-        }
-      : undefined;
-  }, [persistedClaudeSupportsAutoMode, runtimeModelsByProvider, selectedModel, selectedProvider]);
-  const composerProviderState = useMemo(
-    () =>
-      getComposerProviderState({
-        provider: selectedProvider,
-        model: selectedModel,
-        runtimeModel: selectedRuntimeModel,
-        prompt,
-        modelOptions: composerModelOptions,
-      }),
-    [composerModelOptions, prompt, selectedModel, selectedProvider, selectedRuntimeModel],
-  );
-  const selectedPromptEffort = composerProviderState.promptEffort;
-  const selectedModelOptionsForDispatch = composerProviderState.modelOptionsForDispatch;
-  const selectedModelSelection = useMemo<ModelSelection>(() => {
-    if (selectedProvider === "pi" && draftModelSelectionForSelectedProvider?.provider === "pi") {
-      return buildModelSelection(
-        selectedProvider,
-        draftModelSelectionForSelectedProvider.model,
-        selectedModelOptionsForDispatch ?? draftModelSelectionForSelectedProvider.options,
-      );
-    }
-    return buildModelSelection(
-      selectedProvider,
-      selectedModel,
-      selectedModelOptionsForDispatch,
-      selectedProvider === "claudeAgent" ? selectedRuntimeModel?.supportsAutoMode : undefined,
-    );
-  }, [
-    draftModelSelectionForSelectedProvider,
-    selectedModel,
-    selectedModelOptionsForDispatch,
-    selectedProvider,
-    selectedRuntimeModel,
-  ]);
-  const providerOptionsForDispatch = useMemo(() => getProviderStartOptions(settings), [settings]);
-  const selectedModelForPicker =
-    selectedModelSelection.provider === selectedProvider
-      ? selectedModelSelection.model
-      : selectedModel;
-  const selectedModelForPickerWithCustomFallback = useMemo(() => {
-    const currentOptions = modelOptionsByProvider[selectedProvider];
-    return currentOptions.some((option) => option.slug === selectedModelForPicker)
-      ? selectedModelForPicker
-      : (normalizeModelSlug(selectedModelForPicker, selectedProvider) ?? selectedModelForPicker);
-  }, [modelOptionsByProvider, selectedModelForPicker, selectedProvider]);
-  const persistedComposerModelSelection =
-    sessionProvider && activeThread?.modelSelection.provider !== sessionProvider
-      ? activeProject?.defaultModelSelection?.provider === selectedProvider
-        ? activeProject.defaultModelSelection
-        : null
-      : (activeThread?.modelSelection ?? activeProject?.defaultModelSelection ?? null);
-  const providerModelsLoading = selectedProviderModelsLoading;
-  const selectedProviderRequiresRuntimeModels =
-    selectedProvider === "cursor" ||
-    selectedProvider === "antigravity" ||
-    selectedProvider === "droid" ||
-    selectedProvider === "opencode" ||
-    selectedProvider === "pi" ||
-    selectedProvider === "devin";
-  const showComposerModelBootstrapSkeleton = shouldShowComposerModelBootstrapSkeleton({
-    selectedProvider,
-    selectedModel,
-    persistedModelSelection: persistedComposerModelSelection,
-    draftModelSelection: draftModelSelectionForSelectedProvider,
-    providerModelsLoading,
-    requiresDiscoveredModels: selectedProviderRequiresRuntimeModels,
-  });
-  const searchableModelOptions = useMemo(
-    () =>
-      buildSearchableModelOptions({
-        providerOptions: AVAILABLE_PROVIDER_OPTIONS,
-        modelOptionsByProvider,
-        providerOrder: settings.providerOrder,
-        hiddenProviders: settings.hiddenProviders,
-        protectedProviders: [selectedProvider],
-        lockedProvider,
-      }),
-    [
-      lockedProvider,
-      modelOptionsByProvider,
-      selectedProvider,
-      settings.hiddenProviders,
-      settings.providerOrder,
-    ],
-  );
+  const featureFlags = useFeatureFlags();
+  const showDebugTaskBanner = import.meta.env.DEV && featureFlags["show-debug-task-banner"];
+  const serverSettingsQuery = useQuery(serverSettingsQueryOptions());
+
   const phase = derivePhase(activeThread?.session ?? null);
   const isConnecting = phase === "connecting";
   const providerDisplayName =
     PROVIDER_DISPLAY_NAMES[activeThread?.session?.provider ?? selectedProvider];
-  // User messages intentionally have no turn id; assistant messages are the stable
-  // bridge for deciding which historical work can fold into visible replies.
-  // Memoized on purpose: an inline Set would change identity every render and cascade
-  // through the memoized work-log/timeline chain into the virtualized list, which resets
-  // in a loop on unstable data.
-  const workLogVisibleTurnIds = useMemo(() => {
-    const turnIds = new Set<TurnId>();
-    for (const message of activeThread?.messages ?? []) {
-      if (message.turnId) {
-        turnIds.add(message.turnId);
-      }
-    }
-    if (activeLatestTurnId) {
-      turnIds.add(activeLatestTurnId);
-    }
-    return turnIds;
-  }, [activeLatestTurnId, activeThread?.messages]);
-  const rawWorkLogEntries = useMemo(
-    () =>
-      deriveWorkLogEntries(threadActivities, activeLatestTurnId ?? undefined, {
-        visibleTurnIds: workLogVisibleTurnIds,
-        activeTurnId: latestTurnLive ? activeLatestTurnId : null,
-        activeTurnStartedAt: activeLatestTurnStartedAt,
-        latestTurnState: activeLatestTurnState,
-        latestTurnCompletedAt: activeLatestTurnCompletedAt,
-      }),
-    [
-      activeLatestTurnCompletedAt,
-      activeLatestTurnId,
-      activeLatestTurnStartedAt,
-      activeLatestTurnState,
+  const { workLogEntries, composerSubagentStripItems, stripSourceThreadId, workflowRunState } =
+    useChatWorkLog({
+      activeThread,
+      latestTurnSettled,
       latestTurnLive,
-      threadActivities,
-      workLogVisibleTurnIds,
-    ],
-  );
-  const hasWorkLogSubagents = useMemo(
-    () => rawWorkLogEntries.some((entry) => (entry.subagents?.length ?? 0) > 0),
-    [rawWorkLogEntries],
-  );
-  const relevantWorkLogThreads = useStore(
-    useMemo(
-      () =>
-        createRelevantWorkLogThreadsSelector({
-          workEntries: rawWorkLogEntries,
-          parentThreadId: activeThread?.id ?? null,
-          enabled: hasWorkLogSubagents,
-        }),
-      [activeThread?.id, hasWorkLogSubagents, rawWorkLogEntries],
-    ),
-  );
-  const enrichedWorkLogEntries = useMemo(
-    () =>
-      hasWorkLogSubagents
-        ? enrichSubagentWorkEntries(
-            rawWorkLogEntries,
-            relevantWorkLogThreads,
-            activeThread?.id ?? null,
-          )
-        : rawWorkLogEntries,
-    [activeThread?.id, hasWorkLogSubagents, rawWorkLogEntries, relevantWorkLogThreads],
-  );
-  // Subagents are presented by the composer strip (and their own threads); the
-  // transcript drops the routed fan-out rows entirely. The enriched list above is
-  // still what feeds the strip-adjacent derivations that need receiver metadata.
-  const workLogEntries = useMemo(
-    () => omitRoutedSubagentWorkEntries(enrichedWorkLogEntries),
-    [enrichedWorkLogEntries],
-  );
-  // The strip's liveness (running/settled) reads the child thread's own session and
-  // tail activities, so retain a detail subscription while a subagent runs; settled
-  // subagents stay on whatever the store already holds.
-  const liveSubagentThreadIdsKey = useMemo(() => {
-    if (!hasWorkLogSubagents) {
-      return "";
-    }
-    const threadIds = new Set<string>();
-    for (const entry of enrichedWorkLogEntries) {
-      for (const subagent of entry.subagents ?? []) {
-        if (subagent.isActive && subagent.resolvedThreadId) {
-          threadIds.add(subagent.resolvedThreadId);
-        }
-      }
-    }
-    return [...threadIds].toSorted().join("\n");
-  }, [enrichedWorkLogEntries, hasWorkLogSubagents]);
-  useEffect(() => {
-    if (!liveSubagentThreadIdsKey) {
-      return;
-    }
-    const releases = liveSubagentThreadIdsKey
-      .split("\n")
-      .map((threadId) => retainThreadDetailSubscription(ThreadId.makeUnsafe(threadId)));
-    return () => {
-      for (const release of releases) {
-        release();
-      }
-    };
-  }, [liveSubagentThreadIdsKey]);
-  // Native-CLI parity: while a subagent thread is open, the strip derives from the
-  // PARENT thread's activities so all sibling subagents (plus a way back to the
-  // main thread) stay visible, with the open subagent marked as viewed.
-  const stripParentThreadId = activeThread?.parentThreadId ?? null;
-  const stripParentThread = useStore(
-    useMemo(() => createThreadSelector(stripParentThreadId), [stripParentThreadId]),
-  );
-  // Deep links can land on a subagent thread before the parent has a detail
-  // subscription; retain one so the parent's activities hydrate for the strip.
-  useEffect(() => {
-    if (!stripParentThreadId) {
-      return;
-    }
-    return retainThreadDetailSubscription(stripParentThreadId);
-  }, [stripParentThreadId]);
-  const stripSourceThreadId = stripParentThread?.id ?? activeThread?.id ?? null;
-  const stripSourceActivities = stripParentThread?.activities ?? threadActivities;
-  const stripSourceLatestTurnId = stripParentThread
-    ? (stripParentThread.latestTurn?.turnId ?? null)
-    : (activeLatestTurn?.turnId ?? null);
-  const stripSourceLatestTurnState = stripParentThread
-    ? (stripParentThread.latestTurn?.state ?? null)
-    : activeLatestTurnState;
-  const stripSourceLatestTurnStartedAt = stripParentThread
-    ? (stripParentThread.latestTurn?.startedAt ?? null)
-    : activeLatestTurnStartedAt;
-  const stripSourceLatestTurnCompletedAt = stripParentThread
-    ? (stripParentThread.latestTurn?.completedAt ?? null)
-    : activeLatestTurnCompletedAt;
-  const stripVisibleTurnIds = useMemo(() => {
-    if (!stripParentThread) {
-      return workLogVisibleTurnIds;
-    }
-    const turnIds = new Set<TurnId>();
-    for (const message of stripParentThread.messages) {
-      if (message.turnId) {
-        turnIds.add(message.turnId);
-      }
-    }
-    if (stripParentThread.latestTurn?.turnId) {
-      turnIds.add(stripParentThread.latestTurn.turnId);
-    }
-    return turnIds;
-  }, [stripParentThread, workLogVisibleTurnIds]);
-  const stripLiveTurnId = stripParentThread
-    ? isLatestTurnSettled(stripParentThread.latestTurn, stripParentThread.session ?? null)
-      ? null
-      : (stripParentThread.latestTurn?.turnId ?? null)
-    : latestTurnSettled
-      ? null
-      : (activeLatestTurn?.turnId ?? null);
-  // Composer-strip source: the strip needs the routed subagent entries the
-  // transcript drops. A top-level thread has already derived that exact source
-  // above; reuse it so every live activity does not scan and normalize the full
-  // history twice. Subagent views still derive from their distinct parent source.
-  const stripRawWorkLogEntries = useMemo(
-    () =>
-      resolveComposerStripWorkLogEntries({
-        hasDistinctParentSource: stripParentThread !== undefined,
-        activeWorkLogEntries: rawWorkLogEntries,
-        deriveParentWorkLogEntries: () =>
-          deriveWorkLogEntries(stripSourceActivities, stripSourceLatestTurnId ?? undefined, {
-            visibleTurnIds: stripVisibleTurnIds,
-            activeTurnId: stripLiveTurnId,
-            activeTurnStartedAt: stripSourceLatestTurnStartedAt,
-            latestTurnState: stripSourceLatestTurnState,
-            latestTurnCompletedAt: stripSourceLatestTurnCompletedAt,
-          }),
-      }),
-    [
-      rawWorkLogEntries,
-      stripLiveTurnId,
-      stripParentThread,
-      stripSourceActivities,
-      stripSourceLatestTurnCompletedAt,
-      stripSourceLatestTurnId,
-      stripSourceLatestTurnStartedAt,
-      stripSourceLatestTurnState,
-      stripVisibleTurnIds,
-    ],
-  );
-  const hasStripWorkLogSubagents = useMemo(
-    () => stripRawWorkLogEntries.some((entry) => (entry.subagents?.length ?? 0) > 0),
-    [stripRawWorkLogEntries],
-  );
-  const stripRelevantWorkLogThreads = useStore(
-    useMemo(
-      () =>
-        createRelevantWorkLogThreadsSelector({
-          workEntries: stripRawWorkLogEntries,
-          parentThreadId: stripSourceThreadId,
-          enabled: hasStripWorkLogSubagents,
-        }),
-      [stripSourceThreadId, hasStripWorkLogSubagents, stripRawWorkLogEntries],
-    ),
-  );
-  const stripWorkLogEntries = useMemo(
-    () =>
-      hasStripWorkLogSubagents
-        ? enrichSubagentWorkEntries(
-            stripRawWorkLogEntries,
-            stripRelevantWorkLogThreads,
-            stripSourceThreadId,
-          )
-        : stripRawWorkLogEntries,
-    [
-      stripSourceThreadId,
-      hasStripWorkLogSubagents,
-      stripRawWorkLogEntries,
-      stripRelevantWorkLogThreads,
-    ],
-  );
+    });
   const [openAgentActivityId, setOpenAgentActivityId] = useState<string | null>(null);
   const agentActivityTimelineState = useMemo(
     () => deriveAgentActivityTimelineState(workLogEntries),
@@ -2805,7 +1264,7 @@ export default function ChatView({
       setOpenAgentActivityId(null);
     }, 0);
     return () => window.clearTimeout(settle);
-  }, [activeThread?.id]);
+  }, [setOpenAgentActivityId, activeThread?.id]);
   useEffect(() => {
     if (!openAgentActivityId || agentActivityTimelineState.detailById.has(openAgentActivityId)) {
       return;
@@ -2816,117 +1275,40 @@ export default function ChatView({
       setOpenAgentActivityId(null);
     }, 0);
     return () => window.clearTimeout(settle);
-  }, [agentActivityTimelineState.detailById, openAgentActivityId]);
-  const pendingApprovals = useMemo(
-    () =>
-      derivePendingApprovals(threadActivities, activeThread?.pendingInteractions, {
-        authoritativeHasPending: activeThread?.hasPendingApprovals,
-        latestTurnId: activeThread?.latestTurn?.turnId,
-      }),
-    [
-      activeThread?.hasPendingApprovals,
-      activeThread?.latestTurn?.turnId,
-      activeThread?.pendingInteractions,
-      threadActivities,
-    ],
-  );
-  const nextUserInputResponseReclaimAt = useMemo(() => {
-    let earliest: string | null = null;
-    for (const interaction of activeThread?.pendingInteractions ?? []) {
-      if (interaction.interactionKind !== "userInput" || interaction.status !== "responding") {
-        continue;
-      }
-      if (interaction.responseRequestedAt === null) {
-        return new Date(0).toISOString();
-      }
-      const reclaimAt = respondingInteractionReclaimAt(interaction.responseRequestedAt);
-      if (earliest === null || reclaimAt < earliest) {
-        earliest = reclaimAt;
-      }
-    }
-    return earliest;
-  }, [activeThread?.pendingInteractions]);
-  const [userInputResponseClaimReferenceAt, setUserInputResponseClaimReferenceAt] = useState(() =>
-    new Date().toISOString(),
-  );
-  useEffect(() => {
-    if (nextUserInputResponseReclaimAt === null) {
-      return;
-    }
-    const delayMs = Math.max(0, Date.parse(nextUserInputResponseReclaimAt) - Date.now());
-    const timeoutId = window.setTimeout(() => {
-      setUserInputResponseClaimReferenceAt(new Date().toISOString());
-    }, delayMs);
-    return () => window.clearTimeout(timeoutId);
-  }, [nextUserInputResponseReclaimAt]);
-  const pendingUserInputs = useMemo(
-    () =>
-      derivePendingUserInputs(threadActivities, activeThread?.pendingInteractions, {
-        authoritativeHasPending: activeThread?.hasPendingUserInput,
-        latestTurnId: activeThread?.latestTurn?.turnId,
-        responseClaimReferenceAt: userInputResponseClaimReferenceAt,
-      }),
-    [
-      activeThread?.hasPendingUserInput,
-      activeThread?.latestTurn?.turnId,
-      activeThread?.pendingInteractions,
-      threadActivities,
-      userInputResponseClaimReferenceAt,
-    ],
-  );
+  }, [setOpenAgentActivityId, agentActivityTimelineState.detailById, openAgentActivityId]);
   const {
-    answers: pendingUserInputAnswersByRequestId,
-    answersRef: pendingUserInputAnswersByRequestIdRef,
-    setAnswers: setPendingUserInputAnswersByRequestId,
-    drafts: pendingUserInputDrafts,
-  } = usePendingUserInputDrafts(threadId, pendingUserInputs, activeThread?.pendingInteractions);
-  const expiredQuestionDrafts = useMemo(
-    () => expiredUserInputDrafts(pendingUserInputDrafts, threadActivities),
-    [pendingUserInputDrafts, threadActivities],
-  );
-  const activePendingUserInput = pendingUserInputs[0] ?? null;
-  const activePendingUserInputKey = activePendingUserInput
-    ? pendingRequestInstanceKey(
-        activePendingUserInput.requestId,
-        activePendingUserInput.lifecycleGeneration,
-      )
-    : null;
-  const activePendingDraftAnswers = useMemo(
-    () =>
-      activePendingUserInputKey
-        ? (pendingUserInputAnswersByRequestId[activePendingUserInputKey] ??
-          EMPTY_PENDING_USER_INPUT_ANSWERS)
-        : EMPTY_PENDING_USER_INPUT_ANSWERS,
-    [activePendingUserInputKey, pendingUserInputAnswersByRequestId],
-  );
-  const activePendingQuestionIndex = activePendingUserInputKey
-    ? (pendingUserInputQuestionIndexByRequestId[activePendingUserInputKey] ?? 0)
-    : 0;
-  const activePendingProgress = useMemo(
-    () =>
-      activePendingUserInput
-        ? derivePendingUserInputProgress(
-            activePendingUserInput.questions,
-            activePendingDraftAnswers,
-            activePendingQuestionIndex,
-          )
-        : null,
-    [activePendingDraftAnswers, activePendingQuestionIndex, activePendingUserInput],
-  );
-  // Read once here for the same reason as `activeLatestTurnId`: an `activePendingProgress?.x`
-  // read inside a memo body makes React Compiler infer `activePendingProgress` as the
-  // dependency, which no longer matches the hand-written property-path dep.
-  const activePendingQuestion = activePendingProgress?.activeQuestion ?? null;
-  const activePendingResolvedAnswers = useMemo(
-    () =>
-      activePendingUserInput
-        ? buildPendingUserInputAnswers(activePendingUserInput.questions, activePendingDraftAnswers)
-        : null,
-    [activePendingDraftAnswers, activePendingUserInput],
-  );
-  const activePendingIsResponding = activePendingUserInputKey
-    ? respondingUserInputRequestKeys.includes(activePendingUserInputKey)
-    : false;
+    respondingRequestKeys,
+    pendingApprovals,
+    pendingUserInputs,
+    pendingUserInputAnswersByRequestIdRef,
+    setPendingUserInputAnswersByRequestId,
+    expiredQuestionDrafts,
+    activePendingUserInput,
+    activePendingUserInputKey,
+    activePendingDraftAnswers,
+    activePendingQuestionIndex,
+    activePendingProgress,
+    activePendingQuestion,
+    activePendingResolvedAnswers,
+    activePendingIsResponding,
+    activePendingApproval,
+    onRespondToApproval,
+    userInputSubmissionVersion,
+    onCancelActivePendingUserInput,
+    onToggleActivePendingUserInputOption,
+    onChangeActivePendingUserInputCustomAnswer,
+    onAdvanceActivePendingUserInput,
+    onPreviousActivePendingUserInputQuestion,
+  } = useChatPendingInteractions({
+    threadId,
+    activeThread,
+    runtimeMode,
+    promptRef,
+    setPrompt,
+    setComposerCursor,
+    setComposerTrigger,
+    setComposerHighlightedItemId,
+  });
   const activeProposedPlan = useMemo(() => {
     if (!latestTurnSettled) {
       return null;
@@ -3021,151 +1403,38 @@ export default function ChatView({
         : deriveActiveBackgroundTasksState(threadActivities, activeLatestTurn?.turnId ?? undefined),
     [activeLatestTurn?.turnId, latestTurnSettled, threadActivities],
   );
-  // Task tool_use_ids the provider confirmed as backgrounded via task_updated
-  // patches (last patch wins, so re-foregrounded tasks drop back out).
-  const backgroundedSubagentToolUseIds = useMemo(() => {
-    const toolUseIds = new Set<string>();
-    for (const activity of stripSourceActivities) {
-      if (activity.kind !== "task.updated") {
-        continue;
-      }
-      const payload =
-        activity.payload && typeof activity.payload === "object"
-          ? (activity.payload as Record<string, unknown>)
-          : null;
-      const toolUseId = typeof payload?.toolUseId === "string" ? payload.toolUseId : null;
-      if (!toolUseId || typeof payload?.isBackgrounded !== "boolean") {
-        continue;
-      }
-      if (payload.isBackgrounded) {
-        toolUseIds.add(toolUseId);
-      } else {
-        toolUseIds.delete(toolUseId);
-      }
-    }
-    return toolUseIds;
-  }, [stripSourceActivities]);
-  const composerSubagentStripItems = useMemo(
-    () =>
-      deriveComposerSubagentStripItems({
-        workEntries: stripWorkLogEntries,
-        liveTurnId: stripLiveTurnId,
-        backgroundedProviderThreadIds: backgroundedSubagentToolUseIds,
-        viewedThreadId: stripParentThread ? (activeThread?.id ?? null) : null,
-        parentRow: stripParentThread
-          ? { threadId: stripParentThread.id, label: stripParentThread.title ?? null }
-          : null,
-      }),
-    [
-      activeThread?.id,
-      backgroundedSubagentToolUseIds,
-      stripLiveTurnId,
-      stripParentThread,
-      stripWorkLogEntries,
-    ],
-  );
-  // Links workflow agent rows to their subagent child threads (and models) when the
-  // Task tool_use_id produced one; agents spawned without a tool call stay unlinked.
-  const workflowSubagentThreadsByToolUseId = useMemo(() => {
-    const refs = new Map<string, WorkflowSubagentThreadRef>();
-    for (const entry of enrichedWorkLogEntries) {
-      for (const subagent of entry.subagents ?? []) {
-        if (!subagent.providerThreadId) {
-          continue;
-        }
-        refs.set(subagent.providerThreadId, {
-          threadId: subagent.resolvedThreadId ?? subagent.threadId,
-          model: subagent.model,
-          effort: subagent.effort,
-        });
-      }
-    }
-    return refs;
-  }, [enrichedWorkLogEntries]);
-  // Persisted (per-thread) workflow run flags: pausedByUser tells the settled
-  // card apart from a plain stop; dismissed retires a settled card the run's
-  // activities would otherwise keep visible. Survive reloads via
-  // workflowRunUiStore instead of living in component state.
-  const workflowRunUiThreadState = useWorkflowRunUiThreadState(activeThreadId);
-  const pausedWorkflowTaskIds = useMemo(
-    () => new Set(workflowRunUiThreadState.pausedByUser),
-    [workflowRunUiThreadState.pausedByUser],
-  );
-  const dismissedWorkflowTaskIds = useMemo(
-    () => new Set(workflowRunUiThreadState.dismissed),
-    [workflowRunUiThreadState.dismissed],
-  );
-  const workflowRunState = useMemo(
-    () =>
-      deriveWorkflowRunState({
-        activities: threadActivities,
-        subagentThreadsByToolUseId: workflowSubagentThreadsByToolUseId,
-        pausedByUserTaskIds: pausedWorkflowTaskIds,
-        dismissedTaskIds: dismissedWorkflowTaskIds,
-      }),
-    [
-      threadActivities,
-      workflowSubagentThreadsByToolUseId,
-      pausedWorkflowTaskIds,
-      dismissedWorkflowTaskIds,
-    ],
-  );
-  const workflowNowMs = useNowMs(workflowRunState !== null && !workflowRunState.settled);
+
   const showPlanFollowUpPrompt =
     pendingUserInputs.length === 0 &&
     interactionMode === "plan" &&
     latestTurnSettled &&
     hasActionableProposedPlan(activeProposedPlan);
-  const activePendingApproval = pendingApprovals[0] ?? null;
-  const serverAcknowledgedLocalDispatch = useMemo(
-    () =>
-      hasServerAcknowledgedLocalDispatch({
-        localDispatch,
-        phase,
-        latestTurn: activeLatestTurn,
-        session: activeThread?.session ?? null,
-        messages: activeThread?.messages ?? EMPTY_MESSAGES,
-        hasPendingApproval: activePendingApproval !== null,
-        hasPendingUserInput: activePendingUserInput !== null,
-        threadError: activeThread?.error,
-      }),
-    [
-      activeLatestTurn,
-      activePendingApproval,
-      activePendingUserInput,
-      activeThread?.error,
-      activeThread?.messages,
-      activeThread?.session,
-      localDispatch,
-      phase,
-    ],
-  );
-  const turnTakenOver = useMemo(
-    () =>
-      hasLiveTurnTakenOver({
-        localDispatch,
-        phase,
-        latestTurn: activeLatestTurn,
-        session: activeThread?.session ?? null,
-        hasPendingApproval: activePendingApproval !== null,
-        hasPendingUserInput: activePendingUserInput !== null,
-        threadError: activeThread?.error,
-        now: Date.now(),
-      }),
-    [
-      activeLatestTurn,
-      activePendingApproval,
-      activePendingUserInput,
-      activeThread?.error,
-      activeThread?.session,
-      localDispatch,
-      phase,
-    ],
-  );
-  const isSendBusy = localDispatch !== null && !serverAcknowledgedLocalDispatch;
-  const isAwaitingTurnStart = localDispatch !== null && !turnTakenOver;
-  const activeWorktreeSetup = localDispatch?.worktreeSetup ?? null;
-  const isPreparingWorktree = activeWorktreeSetup !== null;
+
+  const {
+    localDispatch,
+    setLocalDispatch,
+    worktreeSetupResolutionRef,
+    worktreeSetupPendingAction,
+    setWorktreeSetupPendingAction,
+    turnTakenOver,
+    isSendBusy,
+    isAwaitingTurnStart,
+    activeWorktreeSetup,
+    isPreparingWorktree,
+    beginLocalDispatch,
+    failLocalDispatchWorktreeSetup,
+    resetLocalDispatch,
+    clearLocalDispatchWorktreeSetup,
+    onResolveWorktreeSetup,
+    armLocalDispatchAckFallback,
+    scheduleFailedWorktreeSetupDispatchReset,
+  } = useChatLocalDispatch({
+    phase,
+    activeLatestTurn,
+    activeThread,
+    activePendingApproval,
+    activePendingUserInput,
+  });
   const hasLiveTurn = phase === "running";
   // Providers that clear `activeTurnId` on every terminal event (Claude) would
   // otherwise leave the transcript with no active turn while work is still in
@@ -3267,10 +1536,7 @@ export default function ChatView({
       hasPendingUserInput: pendingUserInputs.length > 0,
     })
   );
-  const lastSyncedPendingInputRef = useRef<{
-    requestId: string | null;
-    questionId: string | null;
-  } | null>(null);
+
   useLayoutEffect(() => {
     if (previousActiveTurnLayoutKeyRef.current !== activeTurnLayoutKey) {
       previousActiveTurnLayoutKeyRef.current = activeTurnLayoutKey;
@@ -3302,182 +1568,21 @@ export default function ChatView({
     return () => {
       window.clearTimeout(timeoutId);
     };
-  }, [activeLatestTurn?.startedAt, activeTurnLayoutKey, activeTurnLayoutLive]);
-
-  useEffect(() => {
-    const nextCustomAnswer = activePendingProgress?.customAnswer;
-    if (typeof nextCustomAnswer !== "string") {
-      lastSyncedPendingInputRef.current = null;
-      return;
-    }
-    const nextRequestId = activePendingUserInput?.requestId ?? null;
-    const nextQuestionId = activePendingProgress?.activeQuestion?.id ?? null;
-    const questionChanged =
-      lastSyncedPendingInputRef.current?.requestId !== nextRequestId ||
-      lastSyncedPendingInputRef.current?.questionId !== nextQuestionId;
-    const textChangedExternally = promptRef.current !== nextCustomAnswer;
-
-    lastSyncedPendingInputRef.current = {
-      requestId: nextRequestId,
-      questionId: nextQuestionId,
-    };
-
-    if (!questionChanged && !textChangedExternally) {
-      return;
-    }
-
-    promptRef.current = nextCustomAnswer;
-    const nextCursor = collapseExpandedComposerCursor(nextCustomAnswer, nextCustomAnswer.length);
-    setComposerCursor(nextCursor);
-    setComposerTrigger(
-      detectComposerTrigger(
-        nextCustomAnswer,
-        expandCollapsedComposerCursor(nextCustomAnswer, nextCursor),
-      ),
-    );
-    setComposerHighlightedItemId(null);
   }, [
-    activePendingProgress?.customAnswer,
-    activePendingUserInput?.requestId,
-    activePendingProgress?.activeQuestion?.id,
+    setKeepSettledActiveTurnLayout,
+    previousActiveTurnLayoutLiveRef,
+    previousActiveTurnLayoutKeyRef,
+    activeLatestTurn?.startedAt,
+    activeTurnLayoutKey,
+    activeTurnLayoutLive,
   ]);
-  useLayoutEffect(() => {
-    attachmentPreviewHandoffByMessageIdRef.current = attachmentPreviewHandoffByMessageId;
-  }, [attachmentPreviewHandoffByMessageId]);
-  const clearAttachmentPreviewHandoffs = useCallback(() => {
-    for (const timeoutId of Object.values(attachmentPreviewHandoffTimeoutByMessageIdRef.current)) {
-      window.clearTimeout(timeoutId);
-    }
-    attachmentPreviewHandoffTimeoutByMessageIdRef.current = {};
-    for (const previewUrls of Object.values(attachmentPreviewHandoffByMessageIdRef.current)) {
-      for (const previewUrl of previewUrls) {
-        revokeBlobPreviewUrl(previewUrl);
-      }
-    }
-    attachmentPreviewHandoffByMessageIdRef.current = {};
-    setAttachmentPreviewHandoffByMessageId({});
-  }, []);
-  useEffect(() => {
-    return () => {
-      clearAttachmentPreviewHandoffs();
-      for (const message of optimisticUserMessagesRef.current) {
-        revokeUserMessagePreviewUrls(message);
-      }
-    };
-  }, [clearAttachmentPreviewHandoffs]);
-  const handoffAttachmentPreviews = useCallback((messageId: MessageId, previewUrls: string[]) => {
-    if (previewUrls.length === 0) return;
 
-    const previousPreviewUrls = attachmentPreviewHandoffByMessageIdRef.current[messageId] ?? [];
-    const replacedPreviewUrls = previousPreviewUrls.filter(
-      (previewUrl) => !previewUrls.includes(previewUrl),
-    );
-    revokeBlobPreviewUrlsAfterPaint(replacedPreviewUrls);
-    setAttachmentPreviewHandoffByMessageId((existing) => {
-      const next = {
-        ...existing,
-        [messageId]: previewUrls,
-      };
-      attachmentPreviewHandoffByMessageIdRef.current = next;
-      return next;
+  const { timelineMessages, optimisticUserMessages, setOptimisticUserMessages } =
+    useChatTimelineMessages({
+      threadId,
+      activeThread,
+      pendingAutomationConversation,
     });
-
-    const existingTimeout = attachmentPreviewHandoffTimeoutByMessageIdRef.current[messageId];
-    if (typeof existingTimeout === "number") {
-      window.clearTimeout(existingTimeout);
-    }
-    attachmentPreviewHandoffTimeoutByMessageIdRef.current[messageId] = window.setTimeout(() => {
-      const currentPreviewUrls = attachmentPreviewHandoffByMessageIdRef.current[messageId];
-      setAttachmentPreviewHandoffByMessageId((existing) => {
-        if (!(messageId in existing)) return existing;
-        const next = { ...existing };
-        delete next[messageId];
-        attachmentPreviewHandoffByMessageIdRef.current = next;
-        return next;
-      });
-      delete attachmentPreviewHandoffTimeoutByMessageIdRef.current[messageId];
-      // Let React swap the transcript back to persisted /attachments URLs before
-      // invalidating blob previews that may still be mounted in the old row.
-      if (currentPreviewUrls) {
-        revokeBlobPreviewUrlsAfterPaint(currentPreviewUrls);
-      }
-    }, ATTACHMENT_PREVIEW_HANDOFF_TTL_MS);
-  }, []);
-  const serverMessages = activeThread?.messages;
-  const timelineMessages = useMemo(() => {
-    const messages = filterSidechatTranscriptMessages(
-      serverMessages ?? [],
-      Boolean(activeThread?.sidechatSourceThreadId),
-    );
-    const serverMessagesWithPreviewHandoff =
-      Object.keys(attachmentPreviewHandoffByMessageId).length === 0
-        ? messages
-        : // Spread only fires for the few messages that actually changed;
-          // unchanged ones early-return their original reference.
-          // In-place mutation would break React's immutable state contract.
-          // oxlint-disable-next-line no-map-spread
-          messages.map((message) => {
-            if (
-              message.role !== "user" ||
-              !message.attachments ||
-              message.attachments.length === 0
-            ) {
-              return message;
-            }
-            const handoffPreviewUrls = attachmentPreviewHandoffByMessageId[message.id];
-            if (!handoffPreviewUrls || handoffPreviewUrls.length === 0) {
-              return message;
-            }
-
-            let changed = false;
-            let imageIndex = 0;
-            const attachments = message.attachments.map((attachment) => {
-              if (attachment.type !== "image") {
-                return attachment;
-              }
-              const handoffPreviewUrl = handoffPreviewUrls[imageIndex];
-              imageIndex += 1;
-              if (!handoffPreviewUrl || attachment.previewUrl === handoffPreviewUrl) {
-                return attachment;
-              }
-              changed = true;
-              return {
-                ...attachment,
-                previewUrl: handoffPreviewUrl,
-              };
-            });
-
-            return changed ? { ...message, attachments } : message;
-          });
-
-    // Ephemeral automation-setup bubbles render after everything else, at the tail.
-    // Gated on the originating thread so a same-pane switch never leaks the previous
-    // thread's setup into the newly rendered conversation (the reset effect runs after
-    // the first render, so the guard must be here too).
-    const setupBubbles =
-      pendingAutomationConversation && pendingAutomationConversation.threadId === threadId
-        ? pendingAutomationConversation.bubbles
-        : [];
-    // Optimistic messages exist only briefly after a send; skip the full-transcript
-    // id Set on the common (streaming-flush) path where there is nothing to reconcile.
-    let pendingMessages = optimisticUserMessages;
-    if (optimisticUserMessages.length > 0) {
-      const serverIds = new Set(serverMessagesWithPreviewHandoff.map((message) => message.id));
-      pendingMessages = optimisticUserMessages.filter((message) => !serverIds.has(message.id));
-    }
-    const withPending =
-      pendingMessages.length === 0
-        ? serverMessagesWithPreviewHandoff
-        : [...serverMessagesWithPreviewHandoff, ...pendingMessages];
-    return setupBubbles.length === 0 ? withPending : [...withPending, ...setupBubbles];
-  }, [
-    activeThread?.sidechatSourceThreadId,
-    serverMessages,
-    attachmentPreviewHandoffByMessageId,
-    optimisticUserMessages,
-    pendingAutomationConversation,
-    threadId,
-  ]);
   const promptHistory = useMemo(() => {
     const activeMessages = activeThread?.messages ?? EMPTY_MESSAGES;
     // Optimistic messages exist only briefly after a send; skip the full-transcript
@@ -3516,7 +1621,7 @@ export default function ChatView({
   // True from send until the tail-anchor hook finishes sliding the sent message
   // to the viewport top. The auto-follow effect stays quiet while set so the
   // anchored slide has exactly one scroll owner (see useTailAnchorScroll).
-  const tailAnchorScrollInFlightRef = useRef(false);
+
   // --- Pinned messages & notes (per-thread, server-synced through sidepanel commands) ---
   const pinnedMessages = activeThread?.pinnedMessages ?? EMPTY_PINNED_MESSAGES;
   const goalAchievements = activeThread?.goalAchievements ?? EMPTY_GOAL_ACHIEVEMENTS;
@@ -3578,9 +1683,12 @@ export default function ChatView({
         // `handleNotesChange` already surfaces the save failure through the shared notes toast.
       });
   }, [activeThreadId, handleNotesChange, projectInstructions, threadNotes]);
-  const handleJumpToPinnedMessage = useCallback((messageId: MessageId) => {
-    timelineControllerRef.current?.scrollToMessage(messageId);
-  }, []);
+  const handleJumpToPinnedMessage = useCallback(
+    (messageId: MessageId) => {
+      timelineControllerRef.current?.scrollToMessage(messageId);
+    },
+    [timelineControllerRef],
+  );
 
   // Before treating an empty timeline as a genuinely new thread, wait for the
   // detail snapshot: a server thread whose history has not synced yet must show
@@ -3708,89 +1816,35 @@ export default function ChatView({
           worktreePath: resolvedThreadWorktreePath,
         })
       : null;
-  const composerTriggerKind = composerTrigger?.kind ?? null;
-  const mentionTriggerQuery = composerTrigger?.kind === "mention" ? composerTrigger.query : "";
-  const isMentionTrigger = composerTriggerKind === "mention";
+
   const branchesQuery = useQuery(gitBranchesQueryOptions(gitBranchSourceCwd));
   const gitStatusQuery = useQuery(gitStatusQueryOptions(gitBranchSourceCwd));
   const localFolderBrowseRootPath = getLocalFolderBrowseRootPath(
     serverConfigQuery.data?.homeDir ?? null,
     isMacNavigatorPlatform(),
   );
-  const isLocalFolderBrowserOpen =
-    composerCommandPicker === null &&
-    isMentionTrigger &&
-    isLocalFolderMentionQuery(mentionTriggerQuery);
-  const isSkillTrigger = composerTriggerKind === "skill";
-  const [debouncedPathQuery, composerPathQueryDebouncer] = useDebouncedValue(
+  const {
     mentionTriggerQuery,
-    { wait: COMPOSER_PATH_QUERY_DEBOUNCE_MS },
-    (debouncerState) => ({ isPending: debouncerState.isPending }),
-  );
-  const effectiveMentionQuery = mentionTriggerQuery.length > 0 ? debouncedPathQuery : "";
-  const composerSkillCwd = providerModelDiscoveryCwd;
-  const providerComposerCapabilitiesQuery = useQuery(
-    providerComposerCapabilitiesQueryOptions(selectedProvider),
-  );
-  const providerCommandsQuery = useQuery(
-    providerCommandsQueryOptions({
-      provider: selectedProvider,
-      cwd: composerSkillCwd,
-      threadId,
-      binaryPath:
-        (selectedProvider === "opencode"
-          ? providerOptionsForDispatch?.opencode?.binaryPath
-          : selectedProvider === "devin"
-            ? providerOptionsForDispatch?.devin?.binaryPath
-            : null) ?? null,
-      serverUrl:
-        (selectedProvider === "opencode"
-          ? providerOptionsForDispatch?.opencode?.serverUrl
-          : null) ?? null,
-      experimentalWebSockets:
-        selectedProvider === "opencode"
-          ? providerOptionsForDispatch?.opencode?.experimentalWebSockets
-          : undefined,
-      agentDir: selectedProvider === "pi" ? settings.piAgentDir || null : null,
-      enabled:
-        (composerTriggerKind === "slash-command" || composerTriggerKind === "slash-model") &&
-        supportsNativeSlashCommandDiscovery(providerComposerCapabilitiesQuery.data) &&
-        composerSkillCwd !== null,
-    }),
-  );
-  const canDiscoverProviderSkills =
-    selectedProvider === "pi" || supportsSkillDiscovery(providerComposerCapabilitiesQuery.data);
-  const providerSkillsQuery = useQuery(
-    providerSkillsQueryOptions({
-      provider: selectedProvider,
-      cwd: composerSkillCwd,
-      threadId,
-      agentDir: selectedProvider === "pi" ? settings.piAgentDir || null : null,
-      enabled:
-        (isSkillTrigger || composerTriggerKind === "slash-command" || selectedProvider === "pi") &&
-        canDiscoverProviderSkills &&
-        composerSkillCwd !== null,
-    }),
-  );
-  const providerPluginsQuery = useQuery(
-    providerPluginsQueryOptions({
-      provider: selectedProvider,
-      cwd: composerSkillCwd,
-      threadId,
-      enabled:
-        supportsPluginDiscovery(providerComposerCapabilitiesQuery.data) &&
-        composerSkillCwd !== null,
-    }),
-  );
-  const workspaceEntriesQuery = useQuery(
-    projectSearchEntriesQueryOptions({
-      cwd: gitCwd,
-      query: effectiveMentionQuery,
-      enabled: isMentionTrigger && !isLocalFolderBrowserOpen,
-      limit: 80,
-    }),
-  );
-  const workspaceEntries = workspaceEntriesQuery.data?.entries ?? EMPTY_PROJECT_ENTRIES;
+    isLocalFolderBrowserOpen,
+    providerPlugins,
+    providerNativeCommands,
+    providerSkills,
+    workspaceEntries,
+    effectiveComposerTrigger,
+    effectiveComposerTriggerKind,
+    supportsTextNativeReviewCommand,
+    isComposerMenuLoading,
+    canCompactThread,
+  } = useComposerDiscovery({
+    threadId,
+    selectedProvider,
+    composerTrigger,
+    composerCommandPicker,
+    providerModelDiscoveryCwd,
+    providerOptionsForDispatch,
+    gitCwd,
+    piAgentDir: settings.piAgentDir,
+  });
   const activeRootBranch = useMemo(
     () =>
       resolveComposerSlashRootBranch({
@@ -3823,45 +1877,7 @@ export default function ChatView({
     threadBranch: settledThreadBranchAtActivation,
     currentBranch: currentActiveGitBranch,
   });
-  // Keep plugin suggestions referentially stable so prompt-sync effects do not loop on rerender.
-  const providerPlugins = useMemo(
-    () =>
-      providerPluginsQuery.data?.marketplaces.flatMap((marketplace) =>
-        marketplace.plugins.map((plugin) => ({
-          plugin,
-          mention: {
-            name: plugin.name,
-            path: `plugin://${plugin.name}@${marketplace.name}`,
-          } satisfies ProviderMentionReference,
-        })),
-      ) ?? EMPTY_COMPOSER_PLUGIN_SUGGESTIONS,
-    [providerPluginsQuery.data],
-  );
-  const providerNativeCommands =
-    providerCommandsQuery.data?.commands ?? EMPTY_PROVIDER_NATIVE_COMMANDS;
-  const providerNativeCommandNames = useMemo(
-    () => providerNativeCommands.map((command) => command.name),
-    [providerNativeCommands],
-  );
-  const effectiveComposerTrigger = useMemo(() => {
-    if (
-      composerTrigger?.kind === "slash-model" &&
-      hasProviderNativeSlashCommand(selectedProvider, providerNativeCommandNames, "model")
-    ) {
-      return {
-        ...composerTrigger,
-        kind: "slash-command" as const,
-        query: "model",
-      };
-    }
-    return composerTrigger;
-  }, [composerTrigger, providerNativeCommandNames, selectedProvider]);
-  const effectiveComposerTriggerKind = effectiveComposerTrigger?.kind ?? null;
-  const supportsTextNativeReviewCommand = useMemo(
-    () => providerSupportsTextNativeReviewCommand(selectedProvider, providerNativeCommands),
-    [providerNativeCommands, selectedProvider],
-  );
-  const providerSkills = providerSkillsQuery.data?.skills ?? EMPTY_PROVIDER_SKILLS;
+
   const selectedModelCaps = useMemo(
     () => getModelCapabilities(selectedProvider, selectedModel),
     [selectedModel, selectedProvider],
@@ -3931,7 +1947,7 @@ export default function ChatView({
     searchableModelOptions,
     supportsFastSlashCommand,
     canOfferCompactCommand:
-      supportsThreadCompaction(providerComposerCapabilitiesQuery.data) &&
+      canCompactThread &&
       isServerThread &&
       activeThread?.session !== null &&
       activeThread?.session?.status !== "closed",
@@ -4007,7 +2023,14 @@ export default function ChatView({
     composerMenuOpenRef.current = composerMenuOpen;
     composerMenuItemsRef.current = composerMenuItems;
     activeComposerMenuItemRef.current = activeComposerMenuItem;
-  }, [composerMenuOpen, composerMenuItems, activeComposerMenuItem]);
+  }, [
+    composerMenuOpenRef,
+    composerMenuItemsRef,
+    activeComposerMenuItemRef,
+    composerMenuOpen,
+    composerMenuItems,
+    activeComposerMenuItem,
+  ]);
   const nonPersistedComposerImageIdSet = useMemo(() => {
     const durableBlobIds = new Set(
       durablyPersistedComposerImageIds
@@ -4018,90 +2041,11 @@ export default function ChatView({
   }, [durablyPersistedComposerImageIds, nonPersistedComposerImageIds]);
   const keybindings = serverConfigQuery.data?.keybindings ?? EMPTY_KEYBINDINGS;
   const availableEditors = serverConfigQuery.data?.availableEditors ?? EMPTY_AVAILABLE_EDITORS;
-  const rememberCustomBinaryPathForDispatch = useCallback(
-    (input: {
-      threadId: Thread["id"];
-      provider: ProviderKind;
-      providerOptions: ProviderStartOptions | undefined;
-    }) => {
-      const pendingKey = getThreadProviderCustomBinaryPathKey(input.threadId, input.provider);
-      const customBinaryPath = getProviderStartOptionsCustomBinaryPath(
-        input.providerOptions,
-        input.provider,
-      );
-      if (!customBinaryPath) {
-        pendingCustomBinaryPathsByThreadProviderRef.current.delete(pendingKey);
-        return;
-      }
-      pendingCustomBinaryPathsByThreadProviderRef.current.set(pendingKey, customBinaryPath);
-    },
-    [],
-  );
-  useEffect(() => {
-    const provider = activeThread?.session?.provider;
-    if (!activeThread || !provider) {
-      return;
-    }
-
-    const sessionKey = getConfirmedCustomBinarySessionKey(activeThread, provider);
-    if (!sessionKey) {
-      confirmedCustomBinarySessionKeysRef.current.delete(
-        getThreadProviderCustomBinaryPathKey(activeThread.id, provider),
-      );
-      return;
-    }
-    const customBinaryPath =
-      pendingCustomBinaryPathsByThreadProviderRef.current.get(sessionKey) ?? null;
-    if (
-      !shouldConsumePendingCustomBinaryConfirmation({
-        sessionAlreadyChecked: confirmedCustomBinarySessionKeysRef.current.has(sessionKey),
-        pendingCustomBinaryPath: customBinaryPath,
-      })
-    ) {
-      return;
-    }
-    confirmedCustomBinarySessionKeysRef.current.add(sessionKey);
-
-    pendingCustomBinaryPathsByThreadProviderRef.current.delete(sessionKey);
-    if (!customBinaryPath) {
-      return;
-    }
-
-    setConfirmedCustomBinaryPathsByProvider((existing) =>
-      existing[provider] === customBinaryPath
-        ? existing
-        : {
-            ...existing,
-            [provider]: customBinaryPath,
-          },
-    );
-  }, [
+  const { rememberCustomBinaryPathForDispatch, providerStatuses } = useChatProviderStatus({
     activeThread,
-    activeThread?.id,
-    activeThread?.session?.provider,
-    activeThread?.session?.status,
-  ]);
-  // Persist confirmations so a custom binary path that already started a session
-  // stays trusted across restarts, instead of re-showing the availability warning.
-  useEffect(() => {
-    saveConfirmedCustomBinaryPaths(confirmedCustomBinaryPathsByProvider);
-  }, [confirmedCustomBinaryPathsByProvider]);
-  const providerStatuses = useMemo(
-    () =>
-      (serverConfigQuery.data?.providers ?? EMPTY_PROVIDER_STATUSES)
-        .map((status) => {
-          const customBinaryPath = getCustomBinaryPathForProvider(settings, status.provider);
-          return normalizeProviderStatusForLocalConfig({
-            provider: status.provider,
-            status,
-            customBinaryPath,
-            confirmedCustomBinaryPath: confirmedCustomBinaryPathsByProvider[status.provider],
-            disabled: settings.disabledProviders.includes(status.provider),
-          });
-        })
-        .flatMap((status) => (status ? [status] : [])),
-    [confirmedCustomBinaryPathsByProvider, serverConfigQuery.data?.providers, settings],
-  );
+    settings,
+    configuredProviderStatuses: serverConfigQuery.data?.providers,
+  });
   const handoffBadgeLabel = useMemo(
     () => (activeThread ? resolveThreadHandoffBadgeLabel(activeThread) : null),
     [activeThread],
@@ -4347,7 +2291,7 @@ export default function ChatView({
     return () => {
       window.cancelAnimationFrame(frame);
     };
-  }, [secondaryChromeThreadId, shouldDeferSecondaryChrome]);
+  }, [setSecondaryChromeState, secondaryChromeThreadId, shouldDeferSecondaryChrome]);
   const setThreadError = useCallback(
     (targetThreadId: ThreadId | null, error: string | null) => {
       if (!targetThreadId) return;
@@ -4365,7 +2309,7 @@ export default function ChatView({
         };
       });
     },
-    [setStoreThreadError],
+    [setLocalDraftErrorsByThreadId, setStoreThreadError],
   );
   const composerImageAttachmentCount = useCallback(
     () =>
@@ -4403,7 +2347,7 @@ export default function ChatView({
     }
     pendingComposerFocusRef.current = false;
     editor.focusAtEnd();
-  }, [secondaryChromeReady, isComposerEditorDisabled]);
+  }, [composerEditorRef, pendingComposerFocusRef, secondaryChromeReady, isComposerEditorDisabled]);
   const toggleComposerFocus = useCallback(() => {
     const editor = composerEditorRef.current;
     if (secondaryChromeReady && editor?.isFocused()) {
@@ -4412,13 +2356,13 @@ export default function ChatView({
       return;
     }
     focusComposer();
-  }, [focusComposer, secondaryChromeReady]);
+  }, [composerEditorRef, pendingComposerFocusRef, focusComposer, secondaryChromeReady]);
   const scheduleComposerFocus = useCallback(() => {
     pendingComposerFocusRef.current = true;
     window.requestAnimationFrame(() => {
       focusComposer();
     });
-  }, [focusComposer]);
+  }, [pendingComposerFocusRef, focusComposer]);
   // External panels (diff headers, file explorer, preview) bump this nonce after
   // inserting a reference so the composer visibly receives the text.
   const composerFocusRequestNonce = useComposerFocusRequestStore(
@@ -4437,20 +2381,26 @@ export default function ChatView({
     return () => {
       window.cancelAnimationFrame(frame);
     };
-  }, [focusComposer, secondaryChromeReady, secondaryChromeThreadId]);
+  }, [pendingComposerFocusRef, focusComposer, secondaryChromeReady, secondaryChromeThreadId]);
   // Keep the two composer picker menus mutually exclusive so shortcuts always open one surface.
-  const handleModelPickerOpenChange = useCallback((open: boolean) => {
-    setIsModelPickerOpen(open);
-    if (open) {
-      setIsTraitsPickerOpen(false);
-    }
-  }, []);
-  const handleTraitsPickerOpenChange = useCallback((open: boolean) => {
-    setIsTraitsPickerOpen(open);
-    if (open) {
-      setIsModelPickerOpen(false);
-    }
-  }, []);
+  const handleModelPickerOpenChange = useCallback(
+    (open: boolean) => {
+      setIsModelPickerOpen(open);
+      if (open) {
+        setIsTraitsPickerOpen(false);
+      }
+    },
+    [setIsModelPickerOpen, setIsTraitsPickerOpen],
+  );
+  const handleTraitsPickerOpenChange = useCallback(
+    (open: boolean) => {
+      setIsTraitsPickerOpen(open);
+      if (open) {
+        setIsModelPickerOpen(false);
+      }
+    },
+    [setIsModelPickerOpen, setIsTraitsPickerOpen],
+  );
   const appendVoiceTranscriptToComposer = useCallback(
     (transcript: string) => {
       const nextPrompt = appendVoiceTranscriptToPrompt(promptRef.current, transcript);
@@ -4464,7 +2414,7 @@ export default function ChatView({
       setComposerTrigger(detectComposerTrigger(nextPrompt, nextPrompt.length));
       scheduleComposerFocus();
     },
-    [scheduleComposerFocus, setPrompt],
+    [promptRef, setComposerCursor, setComposerTrigger, scheduleComposerFocus, setPrompt],
   );
   const {
     isVoiceRecording,
@@ -4533,6 +2483,10 @@ export default function ChatView({
       });
     },
     [
+      promptRef,
+      setComposerCursor,
+      setComposerTrigger,
+      composerEditorRef,
       activeThreadId,
       composerCursor,
       composerTerminalContexts,
@@ -4548,10 +2502,13 @@ export default function ChatView({
   const addTerminalContextToDraftRef = useRef(addTerminalContextToDraft);
   useLayoutEffect(() => {
     addTerminalContextToDraftRef.current = addTerminalContextToDraft;
-  }, [addTerminalContextToDraft]);
-  const addRegisteredTerminalContextToDraft = useCallback((selection: TerminalContextSelection) => {
-    addTerminalContextToDraftRef.current(selection);
-  }, []);
+  }, [addTerminalContextToDraftRef, addTerminalContextToDraft]);
+  const addRegisteredTerminalContextToDraft = useCallback(
+    (selection: TerminalContextSelection) => {
+      addTerminalContextToDraftRef.current(selection);
+    },
+    [addTerminalContextToDraftRef],
+  );
   useLayoutEffect(() => {
     if (!canAddTerminalContextToChat) {
       return;
@@ -4647,203 +2604,84 @@ export default function ChatView({
   const toggleRightDock = useCallback(() => {
     setRightDockOpen(threadId, !rightDockOpen);
   }, [rightDockOpen, setRightDockOpen, threadId]);
-  const terminalDrawerProps = useMemo(
-    () => ({
-      threadId,
-      onTogglePanel: hasRightDockPanes ? toggleRightDock : undefined,
-      isPanelOpen: hasRightDockPanes ? rightDockOpen : undefined,
-      cwd: gitCwd ?? activeProject?.cwd ?? "",
-      runtimeEnv: threadTerminalRuntimeEnv,
-      height: terminalState.terminalHeight,
-      terminalIds: terminalState.terminalIds,
-      terminalLabelsById: terminalState.terminalLabelsById,
-      terminalTitleOverridesById: terminalState.terminalTitleOverridesById,
-      terminalCliKindsById: terminalState.terminalCliKindsById,
-      terminalAttentionStatesById: terminalState.terminalAttentionStatesById ?? {},
-      runningTerminalIds: terminalState.runningTerminalIds,
-      activeTerminalId: terminalState.activeTerminalId,
-      terminalGroups: terminalState.terminalGroups,
-      activeTerminalGroupId: terminalState.activeTerminalGroupId,
-      focusRequestId: terminalFocusRequestId,
-      onSplitTerminal: splitTerminalRight,
-      onSplitTerminalDown: splitTerminalDown,
-      onNewTerminal: createNewTerminal,
-      onNewTerminalTab: createNewTerminalTab,
-      onMoveTerminalToGroup: moveTerminalToNewGroup,
-      splitShortcutLabel: splitTerminalShortcutLabel ?? undefined,
-      splitDownShortcutLabel: splitTerminalDownShortcutLabel ?? undefined,
-      newShortcutLabel: newTerminalShortcutLabel ?? undefined,
-      closeShortcutLabel: closeTerminalShortcutLabel ?? undefined,
-      workspaceCloseShortcutLabel: closeWorkspaceShortcutLabel ?? undefined,
-      onActiveTerminalChange: activateTerminal,
-      onCloseTerminal: closeTerminal,
-      onTerminalSessionExited: handleTerminalSessionExited,
-      onCloseTerminalGroup: (groupId: string) => {
-        if (!activeThreadId) return;
-        storeCloseTerminalGroup(activeThreadId, groupId);
-      },
-      onHeightChange: setTerminalHeight,
-      onResizeTerminalSplit: (groupId: string, splitId: string, weights: number[]) => {
-        if (!activeThreadId) return;
-        storeResizeTerminalSplit(activeThreadId, groupId, splitId, weights);
-      },
-      onTerminalMetadataChange: (
-        terminalId: string,
-        metadata: {
-          cliKind: "codex" | "claude" | "antigravity" | null;
-          label: string;
-        },
-      ) => {
-        if (!activeThreadId) return;
-        storeSetTerminalMetadata(activeThreadId, terminalId, metadata);
-      },
-      onTerminalActivityChange: (
-        terminalId: string,
-        activity: {
-          hasRunningSubprocess: boolean;
-          agentState: "running" | "attention" | "review" | null;
-        },
-      ) => {
-        if (!activeThreadId) return;
-        storeSetTerminalActivity(activeThreadId, terminalId, activity);
-      },
-      ...(canAddTerminalContextToChat ? { onAddTerminalContext: addTerminalContextToDraft } : {}),
-    }),
-    [
-      activeProject?.cwd,
-      activateTerminal,
-      addTerminalContextToDraft,
-      closeTerminal,
-      handleTerminalSessionExited,
-      closeTerminalShortcutLabel,
-      closeWorkspaceShortcutLabel,
-      createNewTerminal,
-      createNewTerminalTab,
-      moveTerminalToNewGroup,
-      gitCwd,
-      activeThreadId,
-      newTerminalShortcutLabel,
-      setTerminalHeight,
-      splitTerminalRight,
-      splitTerminalDown,
-      splitTerminalShortcutLabel,
-      splitTerminalDownShortcutLabel,
-      storeCloseTerminalGroup,
-      storeResizeTerminalSplit,
-      storeSetTerminalActivity,
-      storeSetTerminalMetadata,
-      terminalFocusRequestId,
-      terminalState.activeTerminalGroupId,
-      terminalState.activeTerminalId,
-      terminalState.terminalAttentionStatesById,
-      terminalState.terminalCliKindsById,
-      terminalState.terminalGroups,
-      terminalState.terminalHeight,
-      terminalState.terminalIds,
-      terminalState.terminalLabelsById,
-      terminalState.terminalTitleOverridesById,
-      terminalState.runningTerminalIds,
-      threadId,
-      threadTerminalRuntimeEnv,
-      toggleRightDock,
-      rightDockOpen,
-      hasRightDockPanes,
-      canAddTerminalContextToChat,
-    ],
-  );
-  const runProjectScript = useCallback(
-    async (
-      script: ProjectScript,
-      options?: ProjectScriptRunOptions,
-    ): Promise<ProjectScriptRunResult | null> => {
-      const api = readNativeApi();
-      if (!api || !activeThreadId || !activeProject || !activeThread) return null;
-      if (options?.rememberAsLastInvoked !== false) {
-        setLastInvokedScriptByProjectId((current) => {
-          if (current[activeProject.id] === script.id) return current;
-          return { ...current, [activeProject.id]: script.id };
-        });
-      }
-      const targetCwd = options?.cwd ?? gitCwd ?? activeProject.cwd;
-      const baseTerminalId =
-        terminalState.activeTerminalId ||
-        terminalState.terminalIds[0] ||
-        DEFAULT_THREAD_TERMINAL_ID;
-      const { shouldCreateNewTerminal, terminalId: targetTerminalId } =
-        resolveProjectScriptTerminalTarget({
-          baseTerminalId,
-          createTerminalId: randomTerminalId,
-          hasRunningTerminal: terminalState.runningTerminalIds.length > 0,
-          preferNewTerminal: options?.preferNewTerminal,
-          terminalOpen: terminalState.terminalOpen,
-        });
-
-      setTerminalOpen(true);
-      if (shouldCreateNewTerminal) {
-        storeNewTerminal(activeThreadId, targetTerminalId);
-      } else {
-        storeSetActiveTerminal(activeThreadId, targetTerminalId);
-      }
-      requestTerminalFocus();
-
-      // Nested function so the `try` body holds no value blocks — see the comment on
-      // `deleteEmptyTerminalThread` above for why React Compiler requires this shape.
-      const runScriptInTargetTerminal = async () => {
-        const { metadata } = await runProjectCommandInTerminal({
-          api,
-          threadId: activeThreadId,
-          terminalId: targetTerminalId,
-          project: {
-            cwd: isStudioContainer ? targetCwd : activeProject.cwd,
-          },
-          cwd: targetCwd,
-          command: script.command,
-          worktreePath: options?.worktreePath ?? activeThread.worktreePath ?? null,
-          ...(options?.env ? { env: options.env } : {}),
-        });
-        if (metadata) {
-          storeSetTerminalMetadata(activeThreadId, targetTerminalId, {
-            cliKind: metadata.cliKind,
-            label: metadata.label,
-          });
-        }
-      };
-
-      try {
-        await runScriptInTargetTerminal();
-        return { terminalId: targetTerminalId };
-      } catch (error) {
-        setThreadError(
-          activeThreadId,
-          error instanceof Error ? error.message : `Failed to run script "${script.name}".`,
-        );
-        if (options?.throwOnError) {
-          throw error instanceof Error
-            ? error
-            : new Error(`Failed to run script "${script.name}".`);
-        }
-        return null;
-      }
+  const terminalDrawerProps = {
+    threadId,
+    onTogglePanel: hasRightDockPanes ? toggleRightDock : undefined,
+    isPanelOpen: hasRightDockPanes ? rightDockOpen : undefined,
+    cwd: gitCwd ?? activeProject?.cwd ?? "",
+    runtimeEnv: threadTerminalRuntimeEnv,
+    height: terminalState.terminalHeight,
+    terminalIds: terminalState.terminalIds,
+    terminalLabelsById: terminalState.terminalLabelsById,
+    terminalTitleOverridesById: terminalState.terminalTitleOverridesById,
+    terminalCliKindsById: terminalState.terminalCliKindsById,
+    terminalAttentionStatesById: terminalState.terminalAttentionStatesById ?? {},
+    runningTerminalIds: terminalState.runningTerminalIds,
+    activeTerminalId: terminalState.activeTerminalId,
+    terminalGroups: terminalState.terminalGroups,
+    activeTerminalGroupId: terminalState.activeTerminalGroupId,
+    focusRequestId: terminalFocusRequestId,
+    onSplitTerminal: splitTerminalRight,
+    onSplitTerminalDown: splitTerminalDown,
+    onNewTerminal: createNewTerminal,
+    onNewTerminalTab: createNewTerminalTab,
+    onMoveTerminalToGroup: moveTerminalToNewGroup,
+    splitShortcutLabel: splitTerminalShortcutLabel ?? undefined,
+    splitDownShortcutLabel: splitTerminalDownShortcutLabel ?? undefined,
+    newShortcutLabel: newTerminalShortcutLabel ?? undefined,
+    closeShortcutLabel: closeTerminalShortcutLabel ?? undefined,
+    workspaceCloseShortcutLabel: closeWorkspaceShortcutLabel ?? undefined,
+    onActiveTerminalChange: activateTerminal,
+    onCloseTerminal: closeTerminal,
+    onTerminalSessionExited: handleTerminalSessionExited,
+    onCloseTerminalGroup: (groupId: string) => {
+      if (!activeThreadId) return;
+      storeCloseTerminalGroup(activeThreadId, groupId);
     },
-    [
-      activeProject,
-      activeThread,
-      activeThreadId,
-      gitCwd,
-      isStudioContainer,
-      requestTerminalFocus,
-      setTerminalOpen,
-      setThreadError,
-      storeNewTerminal,
-      storeSetActiveTerminal,
-      storeSetTerminalMetadata,
-      setLastInvokedScriptByProjectId,
-      terminalState.activeTerminalId,
-      terminalState.terminalOpen,
-      terminalState.runningTerminalIds,
-      terminalState.terminalIds,
-    ],
-  );
+    onHeightChange: setTerminalHeight,
+    onResizeTerminalSplit: (groupId: string, splitId: string, weights: number[]) => {
+      if (!activeThreadId) return;
+      storeResizeTerminalSplit(activeThreadId, groupId, splitId, weights);
+    },
+    onTerminalMetadataChange: (
+      terminalId: string,
+      metadata: {
+        cliKind: "codex" | "claude" | "antigravity" | null;
+        label: string;
+      },
+    ) => {
+      if (!activeThreadId) return;
+      storeSetTerminalMetadata(activeThreadId, terminalId, metadata);
+    },
+    onTerminalActivityChange: (
+      terminalId: string,
+      activity: {
+        hasRunningSubprocess: boolean;
+        agentState: "running" | "attention" | "review" | null;
+      },
+    ) => {
+      if (!activeThreadId) return;
+      storeSetTerminalActivity(activeThreadId, terminalId, activity);
+    },
+    ...(canAddTerminalContextToChat ? { onAddTerminalContext: addTerminalContextToDraft } : {}),
+  };
+  const {
+    runProjectScript,
+    saveProjectScript,
+    updateProjectScript,
+    deleteProjectScript,
+    lastInvokedScriptByProjectId,
+  } = useChatProjectScripts({
+    activeThreadId,
+    activeThread,
+    activeProject,
+    gitCwd,
+    isStudioContainer,
+    terminalState,
+    requestTerminalFocus,
+    setTerminalOpen,
+    setThreadError,
+  });
   const stopActiveThreadSession = useCallback(async () => {
     const api = readNativeApi();
     if (
@@ -4881,282 +2719,27 @@ export default function ChatView({
     stopActiveThreadSession,
     runProjectScript,
   });
-  const persistProjectScripts = useCallback(
-    async (input: {
-      projectId: ProjectId;
-      projectCwd: string;
-      previousScripts: ProjectScript[];
-      nextScripts: ProjectScript[];
-      keybinding?: string | null;
-      keybindingCommand: KeybindingCommand;
-    }) => {
-      const api = readNativeApi();
-      if (!api) return;
 
-      await api.orchestration.dispatchCommand({
-        type: "project.meta.update",
-        commandId: newCommandId(),
-        projectId: input.projectId,
-        scripts: input.nextScripts,
-      });
-
-      const keybindingRule = decodeProjectScriptKeybindingRule({
-        keybinding: input.keybinding,
-        command: input.keybindingCommand,
-      });
-
-      if (isElectron && keybindingRule) {
-        await api.server.upsertKeybinding({ rule: keybindingRule });
-        await queryClient.invalidateQueries({ queryKey: serverQueryKeys.all });
-      }
-    },
-    [queryClient],
-  );
-  const saveProjectScript = useCallback(
-    async (input: NewProjectScriptInput) => {
-      if (!activeProject) return;
-      const nextId = nextProjectScriptId(
-        input.name,
-        activeProject.scripts.map((script) => script.id),
-      );
-      const nextScript: ProjectScript = {
-        id: nextId,
-        name: input.name,
-        command: input.command,
-        icon: input.icon,
-        runOnWorktreeCreate: input.runOnWorktreeCreate,
-      };
-      const nextScripts = input.runOnWorktreeCreate
-        ? [
-            ...activeProject.scripts.map((script) =>
-              script.runOnWorktreeCreate ? { ...script, runOnWorktreeCreate: false } : script,
-            ),
-            nextScript,
-          ]
-        : [...activeProject.scripts, nextScript];
-
-      await persistProjectScripts({
-        projectId: activeProject.id,
-        projectCwd: activeProject.cwd,
-        previousScripts: activeProject.scripts,
-        nextScripts,
-        keybinding: input.keybinding,
-        keybindingCommand: commandForProjectScript(nextId),
-      });
-    },
-    [activeProject, persistProjectScripts],
-  );
-  const updateProjectScript = useCallback(
-    async (scriptId: string, input: NewProjectScriptInput) => {
-      if (!activeProject) return;
-      const existingScript = activeProject.scripts.find((script) => script.id === scriptId);
-      if (!existingScript) {
-        throw new Error("Script not found.");
-      }
-
-      const updatedScript: ProjectScript = {
-        ...existingScript,
-        name: input.name,
-        command: input.command,
-        icon: input.icon,
-        runOnWorktreeCreate: input.runOnWorktreeCreate,
-      };
-      const nextScripts = activeProject.scripts.map((script) =>
-        script.id === scriptId
-          ? updatedScript
-          : input.runOnWorktreeCreate
-            ? { ...script, runOnWorktreeCreate: false }
-            : script,
-      );
-
-      await persistProjectScripts({
-        projectId: activeProject.id,
-        projectCwd: activeProject.cwd,
-        previousScripts: activeProject.scripts,
-        nextScripts,
-        keybinding: input.keybinding,
-        keybindingCommand: commandForProjectScript(scriptId),
-      });
-    },
-    [activeProject, persistProjectScripts],
-  );
-  const deleteProjectScript = useCallback(
-    async (scriptId: string) => {
-      if (!activeProject) return;
-      const nextScripts = activeProject.scripts.filter((script) => script.id !== scriptId);
-
-      const deletedName = activeProject.scripts.find((s) => s.id === scriptId)?.name;
-      // Resolved before the `try`: a value block (`??`) inside a try body makes React
-      // Compiler bail out on the whole component.
-      const deletedScriptToastTitle = `Deleted action "${deletedName ?? "Unknown"}"`;
-
-      try {
-        await persistProjectScripts({
-          projectId: activeProject.id,
-          projectCwd: activeProject.cwd,
-          previousScripts: activeProject.scripts,
-          nextScripts,
-          keybinding: null,
-          keybindingCommand: commandForProjectScript(scriptId),
-        });
-        toastManager.add({
-          type: "success",
-          title: deletedScriptToastTitle,
-        });
-      } catch (error) {
-        toastManager.add({
-          type: "error",
-          title: "Could not delete action",
-          description: error instanceof Error ? error.message : "An unexpected error occurred.",
-        });
-      }
-    },
-    [activeProject, persistProjectScripts],
-  );
-
-  const persistRuntimeModeChange = useCallback(
-    async (mode: RuntimeMode): Promise<boolean> => {
-      let queue = runtimeModePersistenceQueuesRef.current.get(threadId);
-      if (!queue) {
-        queue = createRuntimeModePersistenceQueue(runtimeMode);
-        runtimeModePersistenceQueuesRef.current.set(threadId, queue);
-      }
-      return queue.persist(mode, async (currentMode, nextMode) => {
-        if (serverThread) {
-          const api = readNativeApi();
-          if (!api) {
-            toastManager.add({
-              type: "error",
-              title: "Could not update access mode",
-              description: "Synara is not connected to the server.",
-            });
-            return false;
-          }
-          const persistenceInput = {
-            currentModelSelection: serverThread.modelSelection,
-            ...(nextMode === "auto" ? { nextModelSelection: selectedModelSelection } : {}),
-            currentRuntimeMode: currentMode,
-            nextRuntimeMode: nextMode,
-            persistModelSelection: (modelSelection: ModelSelection) =>
-              api.orchestration.dispatchCommand({
-                type: "thread.meta.update",
-                commandId: newCommandId(),
-                threadId,
-                modelSelection,
-              }),
-            persistRuntimeMode: (runtimeMode: RuntimeMode) =>
-              api.orchestration.dispatchCommand({
-                type: "thread.runtime-mode.set",
-                commandId: newCommandId(),
-                threadId,
-                runtimeMode,
-                createdAt: new Date().toISOString(),
-              }),
-          };
-          try {
-            await persistModelSelectionBeforeRuntimeMode(persistenceInput);
-          } catch (error) {
-            toastManager.add({
-              type: "error",
-              title: "Could not update access mode",
-              description: error instanceof Error ? error.message : "An unexpected error occurred.",
-            });
-            return false;
-          }
-        }
-        setComposerDraftRuntimeMode(threadId, nextMode);
-        if (isLocalDraftThread) {
-          setDraftThreadContext(threadId, { runtimeMode: nextMode });
-        }
-        scheduleComposerFocus();
-        return true;
-      });
-    },
-    [
-      isLocalDraftThread,
-      runtimeMode,
-      scheduleComposerFocus,
-      selectedModelSelection,
-      serverThread,
-      setComposerDraftRuntimeMode,
-      setDraftThreadContext,
-      threadId,
-    ],
-  );
-  const handleRuntimeModeChange = useCallback(
-    (mode: RuntimeMode) => {
-      void persistRuntimeModeChange(mode);
-    },
-    [persistRuntimeModeChange],
-  );
-
-  useEffect(() => {
-    if (
-      activeThread &&
-      runtimeMode === "auto" &&
-      !providerModelSupportsAutoRuntimeMode(
-        selectedProvider,
-        selectedRuntimeModel,
-        activeProviderStatus,
-      )
-    ) {
-      handleRuntimeModeChange("approval-required");
-    }
-  }, [
-    activeProviderStatus,
-    activeThread,
+  const {
+    persistRuntimeModeChange,
     handleRuntimeModeChange,
+    handleInteractionModeChange,
+    toggleInteractionMode,
+    resetInteractionMode,
+    persistThreadSettingsForNextTurn,
+  } = useChatRuntimeModes({
+    threadId,
+    activeThread,
+    serverThread,
+    isLocalDraftThread,
     runtimeMode,
+    interactionMode,
     selectedProvider,
     selectedRuntimeModel,
-  ]);
-
-  const handleInteractionModeChange = useCallback(
-    (mode: ProviderInteractionMode) => {
-      if (mode === interactionMode) return;
-      setComposerDraftInteractionMode(threadId, mode);
-      if (isLocalDraftThread) {
-        setDraftThreadContext(threadId, { interactionMode: mode });
-      }
-      if (serverThread) {
-        const api = readNativeApi();
-        if (api) {
-          void api.orchestration
-            .dispatchCommand({
-              type: "thread.interaction-mode.set",
-              commandId: newCommandId(),
-              threadId,
-              interactionMode: mode,
-              createdAt: new Date().toISOString(),
-            })
-            .catch((error) => {
-              toastManager.add({
-                type: "error",
-                title: "Could not update interaction mode",
-                description:
-                  error instanceof Error ? error.message : "An unexpected error occurred.",
-              });
-            });
-        }
-      }
-      scheduleComposerFocus();
-    },
-    [
-      interactionMode,
-      isLocalDraftThread,
-      scheduleComposerFocus,
-      serverThread,
-      setComposerDraftInteractionMode,
-      setDraftThreadContext,
-      threadId,
-    ],
-  );
-  const toggleInteractionMode = useCallback(() => {
-    handleInteractionModeChange(interactionMode === "plan" ? "default" : "plan");
-  }, [handleInteractionModeChange, interactionMode]);
-  const resetInteractionMode = useCallback(() => {
-    handleInteractionModeChange("default");
-  }, [handleInteractionModeChange]);
+    selectedModelSelection,
+    activeProviderStatus,
+    scheduleComposerFocus,
+  });
   const togglePlanSidebar = useCallback(() => {
     setPlanSidebarOpen((open) => {
       if (open) {
@@ -5167,441 +2750,38 @@ export default function ChatView({
       }
       return !open;
     });
-  }, [activeTaskList?.turnId, sidebarProposedPlan?.turnId]);
-  const persistThreadSettingsForNextTurn = useCallback(
-    async (input: {
-      threadId: ThreadId;
-      createdAt: string;
-      modelSelection?: ModelSelection;
-      runtimeMode: RuntimeMode;
-      interactionMode: ProviderInteractionMode;
-    }) => {
-      if (!serverThread) {
-        return;
-      }
-      const api = readNativeApi();
-      if (!api) {
-        return;
-      }
-
-      await persistModelSelectionBeforeRuntimeMode({
-        currentModelSelection: serverThread.modelSelection,
-        ...(input.modelSelection !== undefined ? { nextModelSelection: input.modelSelection } : {}),
-        currentRuntimeMode: serverThread.runtimeMode,
-        nextRuntimeMode: input.runtimeMode,
-        persistModelSelection: (modelSelection) =>
-          api.orchestration.dispatchCommand({
-            type: "thread.meta.update",
-            commandId: newCommandId(),
-            threadId: input.threadId,
-            modelSelection,
-          }),
-        persistRuntimeMode: (runtimeMode) =>
-          api.orchestration.dispatchCommand({
-            type: "thread.runtime-mode.set",
-            commandId: newCommandId(),
-            threadId: input.threadId,
-            runtimeMode,
-            createdAt: input.createdAt,
-          }),
-      });
-
-      if (input.interactionMode !== serverThread.interactionMode) {
-        await api.orchestration.dispatchCommand({
-          type: "thread.interaction-mode.set",
-          commandId: newCommandId(),
-          threadId: input.threadId,
-          interactionMode: input.interactionMode,
-          createdAt: input.createdAt,
-        });
-      }
-    },
-    [serverThread],
-  );
-
-  // Scroll helpers stay list-owned so transcript updates stop bouncing through
-  // a separate measurement/controller loop during streaming.
-  // Guards isAtEndRef from flipping during reflow-induced scroll events that
-  // fire immediately after an explicit scrollToEnd.
-  const programmaticScrollUntilRef = useRef(0);
-  // User scroll gestures take ownership from streaming auto-follow. Ref updates
-  // are immediate; state updates project into the `followLiveOutput` prop.
-  const [isUserScrollDetached, setIsUserScrollDetached] = useState(false);
-  const isUserScrollDetachedRef = useRef(isUserScrollDetached);
-  const setTranscriptScrollDetached = useCallback((detached: boolean) => {
-    isUserScrollDetachedRef.current = detached;
-    setIsUserScrollDetached(detached);
-  }, []);
-  const pendingScrollGestureRef = useRef<{
-    container: HTMLElement;
-    scrollTop: number;
-    wasFollowing: boolean;
-    keyboard?: boolean;
-  } | null>(null);
-  const pendingScrollGestureFrameRef = useRef<number | null>(null);
-  const cancelPendingScrollGesture = useCallback(() => {
-    const frameId = pendingScrollGestureFrameRef.current;
-    if (frameId !== null) window.cancelAnimationFrame(frameId);
-    pendingScrollGestureFrameRef.current = null;
-    pendingScrollGestureRef.current = null;
-  }, []);
-  useEffect(() => cancelPendingScrollGesture, [activeThread?.id, cancelPendingScrollGesture]);
-  // The arrow's smooth jump is followed by one exact settle after LegendList
-  // has measured the tail. A user gesture invalidates that pending settle.
-  const settledScrollRequestRef = useRef(0);
-  const settledScrollInFlightRef = useRef(false);
-  // Smooth only the first auto-follow after a send; live stream re-sticks stay cheap.
-  const animateNextAutoFollowScrollRef = useRef(false);
-  const scrollToEnd = useCallback((animated = false) => {
-    programmaticScrollUntilRef.current = performance.now() + 200;
-    legendListRef.current?.scrollToEnd?.({ animated });
-  }, []);
-  const armTranscriptAutoFollow = useCallback(
-    (targetThreadId: ThreadId, animated = false) => {
-      cancelPendingScrollGesture();
-      autoFollowThreadIdRef.current = targetThreadId;
-      animateNextAutoFollowScrollRef.current = animated;
-      isAtEndRef.current = true;
-      setTranscriptScrollDetached(false);
-      showScrollDebouncer.current.cancel();
-      setShowScrollToBottom(false);
-    },
-    [cancelPendingScrollGesture, setTranscriptScrollDetached],
-  );
-  const clearTranscriptAutoFollow = useCallback(
-    (synchronous = false) => {
-      cancelPendingScrollGesture();
-      const scrollTarget = settledScrollInFlightRef.current ? legendListRef.current : null;
-      autoFollowThreadIdRef.current = null;
-      animateNextAutoFollowScrollRef.current = false;
-      settledScrollRequestRef.current += 1;
-      settledScrollInFlightRef.current = false;
-      programmaticScrollUntilRef.current = 0;
-      // A user scroll gesture takes over from any in-flight tail-anchor slide.
-      tailAnchorScrollInFlightRef.current = false;
-      const container = legendListRef.current?.getScrollableNode();
-      const detached =
-        container instanceof HTMLElement && container.scrollHeight > container.clientHeight + 1;
-      if (detached !== isUserScrollDetachedRef.current) {
-        // Disable list-owned follow before an already queued animation frame can
-        // run. Continuous wheel events otherwise defer this prop update in React.
-        if (synchronous) flushSync(() => setTranscriptScrollDetached(detached));
-        else setTranscriptScrollDetached(detached);
-      }
-      if (scrollTarget) {
-        void stopTranscriptScrollAtCurrentOffset(scrollTarget);
-      }
-    },
-    [cancelPendingScrollGesture, setTranscriptScrollDetached],
-  );
-  const onTranscriptNavigate = useCallback(() => {
-    // Search can navigate from an effect. Its ref ownership changes immediately,
-    // while React applies the list prop before the animated jump's next frame.
-    clearTranscriptAutoFollow();
-    isAtEndRef.current = false;
-    showScrollDebouncer.current.maybeExecute();
-  }, [clearTranscriptAutoFollow]);
-  const transcriptMessageCount = useMemo(
-    () => timelineEntries.filter((entry) => entry.kind === "message").length,
-    [timelineEntries],
-  );
-  const latestTranscriptMessage = useMemo(() => {
-    for (let index = timelineEntries.length - 1; index >= 0; index -= 1) {
-      const entry = timelineEntries[index];
-      if (entry?.kind === "message") {
-        return entry.message;
-      }
-    }
-    return null;
-  }, [timelineEntries]);
-  const transcriptTailKey = buildTranscriptTailKey(latestTranscriptMessage);
-  const transcriptAutoFollowSignal = buildTranscriptAutoFollowSignal({
-    messageCount: transcriptMessageCount,
-    tailKey: transcriptTailKey,
-  });
-  const onIsAtEndChange = useCallback(
-    (isAtEnd: boolean) => {
-      const container = legendListRef.current?.getScrollableNode();
-      const pending = pendingScrollGestureRef.current;
-      if (pending?.keyboard && container === pending.container) {
-        // Native key scrolling can begin after keyup and after multiple frames.
-        if (container.scrollTop >= pending.scrollTop || isScrollContainerNearBottom(container, 1))
-          return;
-        pendingScrollGestureRef.current = null;
-      }
-      if (!isAtEnd && !isUserScrollDetachedRef.current) {
-        if (
-          hasStreamingAssistantText &&
-          container instanceof HTMLElement &&
-          !isScrollContainerNearBottom(container, 1) &&
-          !tailAnchorScrollInFlightRef.current &&
-          !settledScrollInFlightRef.current &&
-          performance.now() >= programmaticScrollUntilRef.current
-        ) {
-          const request = settledScrollRequestRef.current;
-          programmaticScrollUntilRef.current = performance.now() + 200;
-          window.requestAnimationFrame(() => {
-            if (
-              request === settledScrollRequestRef.current &&
-              !isUserScrollDetachedRef.current &&
-              !tailAnchorScrollInFlightRef.current &&
-              !settledScrollInFlightRef.current &&
-              legendListRef.current?.getScrollableNode() === container &&
-              !isScrollContainerNearBottom(container, 1)
-            )
-              scrollToEnd();
-          });
-        }
-        return;
-      }
-      if (
-        !isAtEnd &&
-        (tailAnchorScrollInFlightRef.current ||
-          settledScrollInFlightRef.current ||
-          performance.now() < programmaticScrollUntilRef.current)
-      ) {
-        return;
-      }
-      // The list can report its content end while the viewport is still inside
-      // the bottom inset. A detached reader resumes only at the actual bottom.
-      const atEnd =
-        isAtEnd &&
-        (!isUserScrollDetachedRef.current ||
-          !(container instanceof HTMLElement) ||
-          isScrollContainerNearBottom(container, 1));
-      if (atEnd === isAtEndRef.current && (!atEnd || !isUserScrollDetachedRef.current)) return;
-      // A gesture can detach without changing the previous edge notification.
-      if (atEnd) {
-        setTranscriptScrollDetached(false);
-        showScrollDebouncer.current.cancel();
-        setShowScrollToBottom(false);
-      } else {
-        // A changing layout can temporarily leave the end during output. Only
-        // user gestures detach live follow; a geometry notification must not.
-        showScrollDebouncer.current.maybeExecute();
-      }
-      isAtEndRef.current = atEnd;
-    },
-    [hasStreamingAssistantText, scrollToEnd, setTranscriptScrollDetached],
-  );
-  const cancelPendingInteractionAnchorAdjustment = useCallback(() => {
-    const pendingFrame = pendingInteractionAnchorFrameRef.current;
-    if (pendingFrame === null) return;
-    pendingInteractionAnchorFrameRef.current = null;
-    window.cancelAnimationFrame(pendingFrame);
-  }, []);
-  const onMessagesClickCaptureBase = useCallback(
-    (event: MouseEvent<HTMLDivElement>) => {
-      const scrollContainer = legendListRef.current?.getScrollableNode?.();
-      if (!(scrollContainer instanceof HTMLElement) || !(event.target instanceof Element)) return;
-
-      const trigger = event.target.closest<HTMLElement>(
-        "button, summary, [role='button'], [data-scroll-anchor-target]",
-      );
-      if (!trigger || !scrollContainer.contains(trigger)) return;
-      if (trigger.closest("[data-scroll-anchor-ignore]")) return;
-
-      pendingInteractionAnchorRef.current = {
-        element: trigger,
-        top: trigger.getBoundingClientRect().top,
-      };
-
-      cancelPendingInteractionAnchorAdjustment();
-      pendingInteractionAnchorFrameRef.current = window.requestAnimationFrame(() => {
-        pendingInteractionAnchorFrameRef.current = null;
-        const anchor = pendingInteractionAnchorRef.current;
-        pendingInteractionAnchorRef.current = null;
-        const activeScrollContainer = legendListRef.current?.getScrollableNode?.();
-        if (!(activeScrollContainer instanceof HTMLElement) || !anchor) return;
-        if (!anchor.element.isConnected || !activeScrollContainer.contains(anchor.element)) return;
-
-        const nextTop = anchor.element.getBoundingClientRect().top;
-        const delta = nextTop - anchor.top;
-        if (Math.abs(delta) < 0.5) return;
-
-        activeScrollContainer.scrollTop += delta;
-      });
-    },
-    [cancelPendingInteractionAnchorAdjustment],
-  );
-  const onMessagesPointerDownBase = useCallback(() => {
-    clearTranscriptAutoFollow(true);
-  }, [clearTranscriptAutoFollow]);
-  const releaseTranscriptScrollGesture = useCallback(() => {
-    const state = legendListRef.current?.getState();
-    if (state) onIsAtEndChange(state.isAtEnd);
-  }, [onIsAtEndChange]);
-  const onMessagesPointerCancelBase = releaseTranscriptScrollGesture;
-  const onMessagesPointerUpBase = releaseTranscriptScrollGesture;
-  const onMessagesScrollBase = useCallback(() => {}, []);
-  const onMessagesTouchEndBase = releaseTranscriptScrollGesture;
-  const onMessagesTouchMoveBase = useCallback(() => {
-    clearTranscriptAutoFollow(true);
-  }, [clearTranscriptAutoFollow]);
-  const onMessagesTouchStartBase = useCallback(() => {
-    clearTranscriptAutoFollow(true);
-  }, [clearTranscriptAutoFollow]);
-  const onMessagesScrollGesture = useCallback(
-    (upward: boolean) => {
-      const container = legendListRef.current?.getScrollableNode();
-      if (!(container instanceof HTMLElement)) return;
-      if (!upward && isAtEndRef.current && isScrollContainerNearBottom(container, 1)) return;
-      const pending = pendingScrollGestureRef.current;
-      const origin =
-        pending?.container === container
-          ? pending
-          : {
-              container,
-              scrollTop: container.scrollTop,
-              wasFollowing:
-                isAtEndRef.current &&
-                !isUserScrollDetachedRef.current &&
-                (!upward || isScrollContainerNearBottom(container, 1)),
-            };
-      clearTranscriptAutoFollow(true);
-      pendingScrollGestureRef.current = origin;
-      // Native scrolling can settle on the next rendering pass. Keep one
-      // pending check per gesture burst, preserving ownership from its first event.
-      pendingScrollGestureFrameRef.current = window.requestAnimationFrame(() => {
-        pendingScrollGestureFrameRef.current = window.requestAnimationFrame(() => {
-          pendingScrollGestureFrameRef.current = null;
-          pendingScrollGestureRef.current = null;
-          if (origin.wasFollowing && container.scrollTop >= origin.scrollTop) {
-            // A nested or no-op wheel must not strand follow, even if new text
-            // increased the distance from the bottom while the gesture settled.
-            setTranscriptScrollDetached(false);
-            onIsAtEndChange(true);
-            scrollToEnd();
-          } else {
-            releaseTranscriptScrollGesture();
-          }
-        });
-      });
-    },
-    [
-      clearTranscriptAutoFollow,
-      onIsAtEndChange,
-      releaseTranscriptScrollGesture,
-      scrollToEnd,
-      setTranscriptScrollDetached,
-    ],
-  );
-  const onMessagesWheelBase = useCallback(
-    (event: WheelEvent<HTMLDivElement>) => {
-      // Horizontal scroll, zoom, and scrolling down at the end do not leave it.
-      if (event.ctrlKey || event.deltaY === 0) return;
-      onMessagesScrollGesture(event.deltaY < 0);
-    },
-    [onMessagesScrollGesture],
-  );
-  useEffect(() => {
-    const onKeyDown = (event: globalThis.KeyboardEvent) => {
-      const container = legendListRef.current?.getScrollableNode();
-      if (
-        !(container instanceof HTMLElement) ||
-        !(event.target instanceof Element) ||
-        !container.contains(event.target) ||
-        event.defaultPrevented ||
-        event.ctrlKey ||
-        event.metaKey ||
-        event.altKey ||
-        isEditableEventTarget(event)
-      )
-        return;
-      if (!["ArrowUp", "ArrowDown", "PageUp", "PageDown", "Home", "End", " "].includes(event.key))
-        return;
-      if (event.key === " " && event.target.closest("button, a, [role='button']")) return;
-      const upward =
-        event.key === "ArrowUp" ||
-        event.key === "PageUp" ||
-        event.key === "Home" ||
-        (event.key === " " && event.shiftKey);
-      if (upward) {
-        if (container.scrollTop <= 0) return;
-        const pending = pendingScrollGestureRef.current;
-        const origin =
-          pending?.keyboard && pending.container === container
-            ? pending
-            : {
-                container,
-                scrollTop: container.scrollTop,
-                wasFollowing: isAtEndRef.current && !isUserScrollDetachedRef.current,
-                keyboard: true,
-              };
-        clearTranscriptAutoFollow(true);
-        pendingScrollGestureRef.current = origin;
-        isAtEndRef.current = false;
-        showScrollDebouncer.current.maybeExecute();
-      } else {
-        onMessagesScrollGesture(false);
-      }
-    };
-    const releaseKeyboardGesture = () => {
-      const origin = pendingScrollGestureRef.current;
-      if (!origin?.keyboard) return;
-      const previousFrame = pendingScrollGestureFrameRef.current;
-      if (previousFrame !== null) window.cancelAnimationFrame(previousFrame);
-      // Native key scrolling may begin after keyup. Give it rendering time to
-      // move, then recover a no-op/nested gesture instead of holding indefinitely.
-      const deadline = performance.now() + 150;
-      const check = () => {
-        pendingScrollGestureFrameRef.current = null;
-        if (pendingScrollGestureRef.current !== origin) return;
-        const movedUp = origin.container.scrollTop < origin.scrollTop - 1;
-        if (!movedUp && performance.now() < deadline) {
-          pendingScrollGestureFrameRef.current = window.requestAnimationFrame(check);
-          return;
-        }
-        pendingScrollGestureRef.current = null;
-        if (origin.wasFollowing && !movedUp) {
-          setTranscriptScrollDetached(false);
-          onIsAtEndChange(true);
-          scrollToEnd();
-        } else {
-          releaseTranscriptScrollGesture();
-        }
-      };
-      pendingScrollGestureFrameRef.current = window.requestAnimationFrame(check);
-    };
-    window.addEventListener("keydown", onKeyDown);
-    window.addEventListener("keyup", releaseKeyboardGesture);
-    window.addEventListener("blur", releaseKeyboardGesture);
-    return () => {
-      window.removeEventListener("keydown", onKeyDown);
-      window.removeEventListener("keyup", releaseKeyboardGesture);
-      window.removeEventListener("blur", releaseKeyboardGesture);
-    };
   }, [
-    clearTranscriptAutoFollow,
-    onIsAtEndChange,
-    onMessagesScrollGesture,
-    releaseTranscriptScrollGesture,
-    scrollToEnd,
-    setTranscriptScrollDetached,
+    setPlanSidebarOpen,
+    planSidebarDismissedForTurnRef,
+    activeTaskList?.turnId,
+    sidebarProposedPlan?.turnId,
   ]);
-  useLayoutEffect(() => {
-    const shouldFollowPendingTurn =
-      activeThread?.id !== undefined && autoFollowThreadIdRef.current === activeThread.id;
-    if (isUserScrollDetachedRef.current || (!isAtEndRef.current && !shouldFollowPendingTurn)) {
-      return;
-    }
-    // Re-apply the bottom stick only for real transcript messages; tool/work
-    // rows can arrive quickly and should not churn scroll/layout work.
-    const frameId = window.requestAnimationFrame(() => {
-      // The tail-anchor slide owns the scroll after a send; a re-snap here
-      // would hard-jump past the smooth slide mid-flight. Once the anchor
-      // settles the spacer keeps the end position exact, so nothing is missed.
-      if (tailAnchorScrollInFlightRef.current || isUserScrollDetachedRef.current) {
-        return;
-      }
-      const shouldAnimate = animateNextAutoFollowScrollRef.current;
-      animateNextAutoFollowScrollRef.current = false;
-      scrollToEnd(shouldAnimate);
-    });
-    return () => {
-      window.cancelAnimationFrame(frameId);
-    };
-  }, [activeThread?.id, scrollToEnd, transcriptAutoFollowSignal]);
+
+  const {
+    showScrollToBottom,
+    isUserScrollDetached,
+    tailAnchorScrollInFlightRef,
+    armTranscriptAutoFollow,
+    onTranscriptNavigate,
+    onIsAtEndChange,
+    onScrollToBottom,
+    onMessagesClickCaptureBase,
+    onMessagesPointerDownBase,
+    onMessagesPointerUpBase,
+    onMessagesPointerCancelBase,
+    onMessagesScrollBase,
+    onMessagesTouchEndBase,
+    onMessagesTouchMoveBase,
+    onMessagesTouchStartBase,
+    onMessagesWheelBase,
+  } = useChatTranscriptScroll({
+    activeThreadId,
+    legendListRef,
+    timelineEntries,
+    hasStreamingAssistantText,
+    composerTranscriptInsetPx,
+    isInactiveSplitPane,
+  });
   const selectionChatEnvMode = useProjectEnvironmentStore((state) =>
     activeProject ? state.envModeByProjectId[activeProject.id] : undefined,
   );
@@ -5715,57 +2895,21 @@ export default function ChatView({
     return () => {
       observer.disconnect();
     };
-  }, [activeThread?.id, composerFooterHasWideActions, isInactiveSplitPane]);
-
-  // A composer that grows (attachments, approval cards, queued turns) eats into the
-  // transcript's bottom content inset, which would push the tail behind the frosted
-  // surface. Re-stick a transcript that was already parked at the end.
-  //
-  // This is driven by the *committed* inset rather than by a ResizeObserver on the
-  // composer: the inset lands a render after the measurement, so a scroll scheduled
-  // from the observer would race the padding it is supposed to compensate for. Here
-  // the new padding is already in the DOM, so the pre-resize viewport is simply the
-  // current one with the inset delta backed out.
-  const previousComposerTranscriptInsetRef = useRef({
-    threadId: activeThread?.id ?? null,
-    insetPx: composerTranscriptInsetPx,
-  });
-  useLayoutEffect(() => {
-    const threadId = activeThread?.id ?? null;
-    const previous = previousComposerTranscriptInsetRef.current;
-    previousComposerTranscriptInsetRef.current = {
-      threadId,
-      insetPx: composerTranscriptInsetPx,
-    };
-    if (previous.threadId !== threadId) return;
-
-    const insetDeltaPx = composerTranscriptInsetPx - previous.insetPx;
-    if (isInactiveSplitPane || Math.abs(insetDeltaPx) < 0.5) return;
-
-    const scrollContainer = legendListRef.current?.getScrollableNode?.();
-    if (!(scrollContainer instanceof HTMLElement)) return;
-    const wasNearEndBeforeResize = isScrollContainerNearBottom({
-      scrollTop: scrollContainer.scrollTop,
-      clientHeight: scrollContainer.clientHeight,
-      scrollHeight: scrollContainer.scrollHeight - insetDeltaPx,
-    });
-    if (!wasNearEndBeforeResize) return;
-
-    // Compensate by the exact inset delta rather than asking the list to scroll to its
-    // end: LegendList re-measures the padded viewport on its own schedule, so an
-    // end-scroll issued in this commit would aim at the pre-padding content height and
-    // land a composer-growth short of the tail.
-    programmaticScrollUntilRef.current = performance.now() + 200;
-    scrollContainer.scrollTop += insetDeltaPx;
-  }, [activeThread?.id, composerTranscriptInsetPx, isInactiveSplitPane]);
+  }, [
+    setIsComposerFooterCompact,
+    setComposerFooterTier,
+    composerFooterTierRef,
+    composerFooterDemotionWidthsRef,
+    composerFooterLayoutSyncRef,
+    setSecondaryChromePlaceholderHeight,
+    composerFormRef,
+    composerFormHeightRef,
+    activeThread?.id,
+    composerFooterHasWideActions,
+    isInactiveSplitPane,
+  ]);
 
   useEffect(() => {
-    isAtEndRef.current = true;
-    settledScrollRequestRef.current += 1;
-    settledScrollInFlightRef.current = false;
-    programmaticScrollUntilRef.current = 0;
-    setTranscriptScrollDetached(false);
-    showScrollDebouncer.current.cancel();
     // Capture the carried sidebar-open intent synchronously (ref reads/writes stay
     // in render->commit order); defer only the setState so this thread-change reset
     // stays out of the render->effect->render cascade.
@@ -5775,11 +2919,18 @@ export default function ChatView({
     const settle = window.setTimeout(() => {
       setPullRequestDialogState(null);
       setRenameDialogOpen(false);
-      setShowScrollToBottom(false);
+
       setPlanSidebarOpen(openPlanSidebar);
     }, 0);
     return () => window.clearTimeout(settle);
-  }, [activeThread?.id, setTranscriptScrollDetached]);
+  }, [
+    setPlanSidebarOpen,
+    planSidebarDismissedForTurnRef,
+    planSidebarOpenOnNextThreadRef,
+    setPullRequestDialogState,
+    setRenameDialogOpen,
+    activeThread?.id,
+  ]);
 
   useEffect(() => {
     if (!composerMenuOpen) {
@@ -5791,7 +2942,7 @@ export default function ChatView({
         ? existing
         : (composerMenuItems[0]?.id ?? null),
     );
-  }, [composerMenuItems, composerMenuOpen]);
+  }, [setComposerHighlightedItemId, composerMenuItems, composerMenuOpen]);
 
   useEffect(() => {
     // Async setState (post-paint) keeps this thread-change reset out of the
@@ -5800,7 +2951,7 @@ export default function ChatView({
       setIsRevertingCheckpoint(false);
     }, 0);
     return () => window.clearTimeout(settle);
-  }, [activeThread?.id]);
+  }, [setIsRevertingCheckpoint, activeThread?.id]);
 
   useEffect(() => {
     if (!activeThread?.id || terminalState.terminalOpen || isInactiveSplitPane) return;
@@ -5812,169 +2963,17 @@ export default function ChatView({
     };
   }, [activeThread?.id, focusComposer, isInactiveSplitPane, terminalState.terminalOpen]);
 
-  useEffect(() => {
-    composerImagesRef.current = composerImages;
-  }, [composerImages]);
-
-  useEffect(() => {
-    composerFilesRef.current = composerFiles;
-  }, [composerFiles]);
-
-  useEffect(() => {
-    composerAssistantSelectionsRef.current = composerAssistantSelections;
-  }, [composerAssistantSelections]);
-
-  useEffect(() => {
-    composerBrowserAnnotationsRef.current = composerBrowserAnnotations;
-  }, [composerBrowserAnnotations]);
-
-  useEffect(() => {
-    composerTerminalContextsRef.current = composerTerminalContexts;
-  }, [composerTerminalContexts]);
-
-  useEffect(() => {
-    composerFileCommentsRef.current = composerFileComments;
-  }, [composerFileComments]);
-
-  useEffect(() => {
-    composerPastedTextsRef.current = composerPastedTexts;
-  }, [composerPastedTexts]);
-
-  useEffect(() => {
-    composerPullRequestContextsRef.current = composerPullRequestContexts;
-  }, [composerPullRequestContexts]);
-
-  useEffect(() => {
-    queuedComposerTurnsRef.current = queuedComposerTurns;
-  }, [queuedComposerTurns]);
-
-  useEffect(() => {
-    autoDispatchingQueuedTurnRef.current = false;
-  }, [threadId]);
-
-  useLayoutEffect(() => {
-    claimQueuedComposerAutoDispatch(threadId);
-    setQueuedSteerGate(getQueuedComposerSteerGate(threadId));
-    return () => {
-      releaseQueuedComposerAutoDispatch(threadId);
-    };
-  }, [threadId]);
-
-  useEffect(() => {
-    if (!activeThread?.id) return;
-    if (activeThread.messages.length === 0) {
-      return;
-    }
-    // No optimistic messages → nothing to reconcile; skip the full-transcript id Set
-    // this effect would otherwise rebuild on every streaming flush.
-    if (optimisticUserMessages.length === 0) {
-      return;
-    }
-    const serverIds = new Set(activeThread.messages.map((message) => message.id));
-    const removedMessages = optimisticUserMessages.filter((message) => serverIds.has(message.id));
-    if (removedMessages.length === 0) {
-      return;
-    }
-    const timer = window.setTimeout(() => {
-      setOptimisticUserMessages((existing) =>
-        existing.filter((message) => !serverIds.has(message.id)),
-      );
-    }, 0);
-    for (const removedMessage of removedMessages) {
-      const previewUrls = collectUserMessageBlobPreviewUrls(removedMessage);
-      if (previewUrls.length > 0) {
-        handoffAttachmentPreviews(removedMessage.id, previewUrls);
-        continue;
-      }
-      revokeUserMessagePreviewUrls(removedMessage);
-    }
-    return () => {
-      window.clearTimeout(timer);
-    };
-  }, [activeThread?.id, activeThread?.messages, handoffAttachmentPreviews, optimisticUserMessages]);
-
-  useEffect(() => {
-    promptRef.current = prompt;
-    if (
-      promptHistoryNavigationRef.current !== null &&
-      prompt !== promptHistoryAppliedPromptRef.current
-    ) {
-      // Another writer (queued-turn restore, automation restore, insertion)
-      // replaced the prompt while a history browse was active. The new prompt
-      // is authoritative: end the browse and drop the saved pre-browse draft
-      // so it cannot clobber this prompt later.
-      promptHistoryNavigationRef.current = null;
-      expectedPromptHistoryPromptRef.current = null;
-      setComposerDraftPromptHistorySavedDraft(threadId, null);
-    }
-    setComposerCursor((existing) => clampCollapsedComposerCursor(prompt, existing));
-  }, [prompt, setComposerDraftPromptHistorySavedDraft, threadId]);
-
-  useLayoutEffect(() => {
-    updateSelectedComposerSkills(composerSkills);
-    updateSelectedComposerMentions(composerMentions);
-  }, [
-    composerMentions,
-    composerSkills,
-    threadId,
-    updateSelectedComposerMentions,
-    updateSelectedComposerSkills,
-  ]);
-
-  useEffect(() => {
-    updateSelectedComposerSkills((existing) => {
-      const nextSkills = filterPromptSkillReferences(prompt, existing, selectedProvider);
-      return providerSkillReferencesEqual(existing, nextSkills) ? existing : nextSkills;
-    });
-  }, [prompt, selectedProvider, updateSelectedComposerSkills]);
-
-  useEffect(() => {
-    updateSelectedComposerMentions((existing) => {
-      const nextMentions = filterPromptProviderMentionReferences(prompt, existing);
-      return providerMentionReferencesEqual(existing, nextMentions) ? existing : nextMentions;
-    });
-  }, [prompt, updateSelectedComposerMentions]);
-
-  // Provider references are provider-specific; keep draft restores from looking like manual switches.
-  useEffect(() => {
-    const previous = previousSelectedProviderRef.current;
-    previousSelectedProviderRef.current = {
-      threadId,
-      provider: selectedProvider,
-    };
-    if (!previous || previous.threadId !== threadId || previous.provider === selectedProvider) {
-      return;
-    }
-    updateSelectedComposerSkills([]);
-    updateSelectedComposerMentions([]);
-  }, [selectedProvider, threadId, updateSelectedComposerMentions, updateSelectedComposerSkills]);
-
   useLayoutEffect(() => {
     // ChatView stays mounted across thread switches, so clear thread-local overlays before paint.
-    setOptimisticUserMessages((existing) => {
-      if (existing.length === 0) return existing;
-      for (const message of existing) {
-        revokeUserMessagePreviewUrls(message);
-      }
-      return [];
-    });
     setExpandedImage(null);
-  }, [threadId]);
+  }, [setExpandedImage, threadId]);
 
   useEffect(() => {
     dragDepthRef.current = 0;
     // Async setState (post-paint) keeps this thread-change reset out of the
-    // render->effect->render cascade. The pre-paint overlay clear (optimistic
-    // messages, expanded image) lives in the layout effect above, so deferring
-    // these residual resets by a tick is imperceptible.
+    // render->effect->render cascade. The expanded image and timeline hook's
+    // optimistic messages clear before paint, so these residual resets can wait.
     const settle = window.setTimeout(() => {
-      setOptimisticUserMessages((existing) => {
-        if (existing.length === 0) return existing;
-        for (const message of existing) {
-          revokeUserMessagePreviewUrls(message);
-        }
-        return [];
-      });
       setLocalDispatch(null);
       setComposerHighlightedItemId(null);
       setComposerCursor(
@@ -5982,95 +2981,38 @@ export default function ChatView({
       );
       setComposerTrigger(detectComposerTrigger(promptRef.current, promptRef.current.length));
       setIsDragOverComposer(false);
-      setExpandedImage(null);
     }, 0);
     return () => window.clearTimeout(settle);
-  }, [threadId]);
-
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      if (composerImages.length === 0) {
-        const hasDeferredBlobAttachment =
-          useComposerDraftStore
-            .getState()
-            .draftsByThreadId[threadId]?.persistedAttachments.some(
-              (attachment) => attachment.blobKey,
-            ) ?? false;
-        if (hasDeferredBlobAttachment) {
-          return;
-        }
-        clearComposerDraftPersistedAttachments(threadId);
-        return;
-      }
-      const staged = await stagePersistedComposerImageAttachments({
-        threadId,
-        images: composerImages,
-        getPersistedAttachments: () =>
-          useComposerDraftStore.getState().draftsByThreadId[threadId]?.persistedAttachments ?? [],
-      });
-      if (cancelled) {
-        return;
-      }
-      // Stage attachments in persisted draft state first so persist middleware can write them.
-      void syncComposerDraftPersistedAttachments(threadId, staged);
-    })();
-    return () => {
-      cancelled = true;
-    };
   }, [
-    clearComposerDraftPersistedAttachments,
-    composerImages,
-    syncComposerDraftPersistedAttachments,
-    threadId,
-  ]);
-
-  useEffect(() => {
-    if (
-      !composerPromptHistorySavedDraftImages ||
-      composerPromptHistorySavedDraftImages.length === 0
-    ) {
-      return;
-    }
-    let cancelled = false;
-    void (async () => {
-      const staged = await stagePersistedComposerImageAttachments({
-        threadId,
-        images: composerPromptHistorySavedDraftImages,
-        getPersistedAttachments: () =>
-          useComposerDraftStore.getState().draftsByThreadId[threadId]?.promptHistorySavedDraft
-            ?.persistedAttachments ?? [],
-      });
-      if (cancelled) {
-        return;
-      }
-      void syncComposerDraftPromptHistorySavedDraftPersistedAttachments(threadId, staged);
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    composerPromptHistorySavedDraftImages,
-    syncComposerDraftPromptHistorySavedDraftPersistedAttachments,
+    promptRef,
+    setComposerCursor,
+    setComposerTrigger,
+    setIsDragOverComposer,
+    setComposerHighlightedItemId,
+    dragDepthRef,
+    setLocalDispatch,
     threadId,
   ]);
 
   const closeExpandedImage = useCallback(() => {
     setExpandedImage(null);
-  }, []);
-  const navigateExpandedImage = useCallback((direction: -1 | 1) => {
-    setExpandedImage((existing) => {
-      if (!existing || existing.images.length <= 1) {
-        return existing;
-      }
-      const nextIndex =
-        (existing.index + direction + existing.images.length) % existing.images.length;
-      if (nextIndex === existing.index) {
-        return existing;
-      }
-      return { ...existing, index: nextIndex };
-    });
-  }, []);
+  }, [setExpandedImage]);
+  const navigateExpandedImage = useCallback(
+    (direction: -1 | 1) => {
+      setExpandedImage((existing) => {
+        if (!existing || existing.images.length <= 1) {
+          return existing;
+        }
+        const nextIndex =
+          (existing.index + direction + existing.images.length) % existing.images.length;
+        if (nextIndex === existing.index) {
+          return existing;
+        }
+        return { ...existing, index: nextIndex };
+      });
+    },
+    [setExpandedImage],
+  );
 
   useEffect(() => {
     if (!expandedImage) {
@@ -6122,7 +3064,12 @@ export default function ChatView({
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [composerMenuOpen]);
+  }, [
+    setComposerTrigger,
+    setComposerCommandPicker,
+    setComposerHighlightedItemId,
+    composerMenuOpen,
+  ]);
 
   const activeWorktreePath = isStudioContainer ? null : activeThread?.worktreePath;
   const envMode: DraftThreadEnvMode = isStudioContainer
@@ -6137,185 +3084,6 @@ export default function ChatView({
     envMode: resolvedThreadEnvMode,
     worktreePath: resolvedThreadWorktreePath,
   });
-
-  const beginLocalDispatch = useCallback(
-    (options?: WorktreeSetupDispatchOptions) => {
-      setLocalDispatch((current) => {
-        const next = resolveNextLocalDispatchSnapshot(
-          options ? { current, activeThread, options } : { current, activeThread },
-        );
-        if (next !== current) {
-          failedWorktreeSetupDispatchStartedAtRef.current = null;
-        }
-        return next;
-      });
-    },
-    [activeThread],
-  );
-
-  const failLocalDispatchWorktreeSetup = useCallback(() => {
-    setLocalDispatch((current) => {
-      if (!current?.worktreeSetup) {
-        return current;
-      }
-      const failed = failWorktreeSetupSnapshot(current.worktreeSetup);
-      failedWorktreeSetupDispatchStartedAtRef.current = current.startedAt;
-      return failed === current.worktreeSetup ? current : { ...current, worktreeSetup: failed };
-    });
-  }, []);
-
-  const resetLocalDispatch = useCallback(() => {
-    failedWorktreeSetupDispatchStartedAtRef.current = null;
-    setLocalDispatch(null);
-  }, []);
-
-  // Clears only the setup stepper from the dispatch marker: after "Work
-  // locally" the send continues (composer stays busy, Thinking shimmer takes
-  // over) but the worktree card animates out.
-  const clearLocalDispatchWorktreeSetup = useCallback(() => {
-    setLocalDispatch((current) =>
-      current?.worktreeSetup ? { ...current, worktreeSetup: null } : current,
-    );
-  }, []);
-
-  const onResolveWorktreeSetup = useCallback((action: WorktreeSetupResolutionAction) => {
-    const resolution = worktreeSetupResolutionRef.current;
-    if (!resolution || resolution.action !== null) {
-      return;
-    }
-    resolution.resolve(action);
-    setWorktreeSetupPendingAction(action);
-  }, []);
-
-  // The dispatch marker normally clears when the thread stream echoes the sent
-  // turn. Once the turn RPC has resolved the server owns the turn, so a stream
-  // that never echoes (dead subscription, lost event) must not lock the
-  // composer forever: this fallback force-clears the marker after a bound. The
-  // startedAt match keeps a stale timer from clearing a newer dispatch, and an
-  // already-acknowledged dispatch is left alone — the send spinner has
-  // released, and the awaiting-turn bridge legitimately keeps `localDispatch`
-  // alive until takeover or its own fail-open bound.
-  const localDispatchStartedAtRef = useRef<string | null>(null);
-  useEffect(() => {
-    localDispatchStartedAtRef.current = localDispatch?.startedAt ?? null;
-  }, [localDispatch]);
-  const serverAcknowledgedLocalDispatchRef = useRef(serverAcknowledgedLocalDispatch);
-  useEffect(() => {
-    serverAcknowledgedLocalDispatchRef.current = serverAcknowledgedLocalDispatch;
-  }, [serverAcknowledgedLocalDispatch]);
-  const localDispatchAckFallbackTimeoutRef = useRef<number | null>(null);
-  const armLocalDispatchAckFallback = useCallback((threadIdForSend: ThreadId) => {
-    // The turn RPC has resolved, so the server provably owns a turn. Re-arm
-    // the cross-component watchdog marker here: pre-dispatch work (worktree
-    // creation, attachment uploads) can outlive the marker's age cap, and this
-    // is the moment its clock should restart.
-    markPendingTurnDispatch(threadIdForSend);
-    const armedStartedAt = localDispatchStartedAtRef.current;
-    if (armedStartedAt === null) {
-      return;
-    }
-    if (localDispatchAckFallbackTimeoutRef.current !== null) {
-      window.clearTimeout(localDispatchAckFallbackTimeoutRef.current);
-    }
-    localDispatchAckFallbackTimeoutRef.current = window.setTimeout(() => {
-      localDispatchAckFallbackTimeoutRef.current = null;
-      if (serverAcknowledgedLocalDispatchRef.current) {
-        return;
-      }
-      setLocalDispatch((current) =>
-        current &&
-        current.startedAt === armedStartedAt &&
-        !worktreeSetupHasError(current.worktreeSetup)
-          ? null
-          : current,
-      );
-    }, LOCAL_DISPATCH_ACK_TIMEOUT_MS);
-  }, []);
-  useEffect(
-    () => () => {
-      if (localDispatchAckFallbackTimeoutRef.current !== null) {
-        window.clearTimeout(localDispatchAckFallbackTimeoutRef.current);
-      }
-    },
-    [],
-  );
-
-  // Fallback cleanup for a failed worktree setup: clears the dispatch after the
-  // error hold unless a newer dispatch already replaced it.
-  const scheduleFailedWorktreeSetupDispatchReset = useCallback(() => {
-    const failedDispatchStartedAt = failedWorktreeSetupDispatchStartedAtRef.current;
-    window.setTimeout(() => {
-      setLocalDispatch((current) => {
-        if (
-          !failedDispatchStartedAt ||
-          !current ||
-          current.startedAt !== failedDispatchStartedAt ||
-          !worktreeSetupHasError(current.worktreeSetup)
-        ) {
-          return current;
-        }
-        failedWorktreeSetupDispatchStartedAtRef.current = null;
-        return null;
-      });
-    }, WORKTREE_SETUP_ERROR_HOLD_MS);
-  }, []);
-
-  const localDispatchWorktreeSetupFailed = worktreeSetupHasError(activeWorktreeSetup);
-  useEffect(() => {
-    if (!turnTakenOver) {
-      return;
-    }
-    // A failed worktree setup would otherwise reset in the same commit that
-    // painted the error (thread errors count as takeover), so hold the
-    // row briefly before letting it animate out.
-    if (localDispatchWorktreeSetupFailed) {
-      const failedDispatchStartedAt = localDispatch?.startedAt;
-      if (!failedDispatchStartedAt) {
-        return;
-      }
-      const holdTimeout = window.setTimeout(() => {
-        setLocalDispatch((current) => {
-          if (
-            !current ||
-            current.startedAt !== failedDispatchStartedAt ||
-            !worktreeSetupHasError(current.worktreeSetup)
-          ) {
-            return current;
-          }
-          failedWorktreeSetupDispatchStartedAtRef.current = null;
-          return null;
-        });
-      }, WORKTREE_SETUP_ERROR_HOLD_MS);
-      return () => window.clearTimeout(holdTimeout);
-    }
-    resetLocalDispatch();
-  }, [
-    localDispatch?.startedAt,
-    localDispatchWorktreeSetupFailed,
-    resetLocalDispatch,
-    turnTakenOver,
-  ]);
-
-  // Fail-open: if takeover never arrives, clear the awaiting-turn bridge so
-  // Thinking cannot stick forever. Skipped while worktree setup is active.
-  useEffect(() => {
-    if (!localDispatch || turnTakenOver || localDispatch.worktreeSetup) {
-      return;
-    }
-    const startedAtMs = Date.parse(localDispatch.startedAt);
-    if (!Number.isFinite(startedAtMs)) {
-      return;
-    }
-    const remainingMs = LOCAL_DISPATCH_TURN_TAKEOVER_TIMEOUT_MS - (Date.now() - startedAtMs);
-    if (remainingMs <= 0) {
-      resetLocalDispatch();
-      return;
-    }
-    const timer = window.setTimeout(() => {
-      resetLocalDispatch();
-    }, remainingMs);
-    return () => window.clearTimeout(timer);
-  }, [localDispatch, resetLocalDispatch, turnTakenOver]);
 
   useEffect(() => {
     if (!activeThreadId) return;
@@ -6337,7 +3105,13 @@ export default function ChatView({
     }
 
     terminalOpenByThreadRef.current[activeThreadId] = current;
-  }, [activeThreadId, focusComposer, requestTerminalFocus, terminalState.terminalOpen]);
+  }, [
+    terminalOpenByThreadRef,
+    activeThreadId,
+    focusComposer,
+    requestTerminalFocus,
+    terminalState.terminalOpen,
+  ]);
 
   useEffect(() => {
     if (!activeThreadId) {
@@ -6352,7 +3126,7 @@ export default function ChatView({
       return;
     }
     storeOpenTerminalThreadPage(activeThreadId);
-  }, [activeThreadId, storeOpenTerminalThreadPage, terminalState.entryPoint]);
+  }, [activatedThreadIdRef, activeThreadId, storeOpenTerminalThreadPage, terminalState.entryPoint]);
 
   useEffect(() => {
     if (!terminalWorkspaceOpen) {
@@ -6548,345 +3322,57 @@ export default function ChatView({
 
   const copyThreadIdToClipboard = useCopyThreadIdToClipboard();
 
-  useEffect(() => {
-    if (surfaceMode === "split" && !isFocusedPane) {
-      return;
-    }
-
-    const handler = (event: globalThis.KeyboardEvent) => {
-      if (!activeThreadId || event.defaultPrevented) return;
-      // Mirror terminal interrupt semantics without stealing regular copy shortcuts.
-      if (
-        hasLiveTurn &&
-        isMacNavigatorPlatform() &&
-        event.ctrlKey &&
-        !event.metaKey &&
-        !event.altKey &&
-        !event.shiftKey &&
-        event.key.toLowerCase() === "c" &&
-        eventTargetsComposer(event, composerFormRef.current)
-      ) {
-        event.preventDefault();
-        event.stopPropagation();
-        onInterruptFromStopControl();
-        return;
-      }
-      // Ctrl+B mirrors the native CLI: background all foreground running
-      // subagents. Literal Ctrl on every platform, but stays out of the
-      // terminal, where Ctrl+B is real shell input (readline cursor-back,
-      // tmux prefix), and out of text-editing surfaces, where Ctrl+B is the
-      // native macOS "move cursor back" binding. Silent no-op (event
-      // untouched) when nothing qualifies.
-      if (
-        event.ctrlKey &&
-        !event.metaKey &&
-        !event.altKey &&
-        !event.shiftKey &&
-        event.key.toLowerCase() === "b" &&
-        !isTerminalFocused() &&
-        !isEditableEventTarget(event) &&
-        collectForegroundRunningSubagentStripItems(composerSubagentStripItems).length > 0
-      ) {
-        event.preventDefault();
-        event.stopPropagation();
-        void onBackgroundAllForegroundSubagentStripItems();
-        return;
-      }
-      const composerPickerShortcutActive =
-        !isTerminalFocused() &&
-        !isVoiceRecording &&
-        !isVoiceTranscribing &&
-        !isComposerApprovalState &&
-        canHandleComposerPickerShortcut(event, composerFormRef.current);
-      const shortcutContext = {
-        terminalFocus: isTerminalFocused(),
-        terminalOpen: Boolean(terminalState.terminalOpen),
-        terminalWorkspaceOpen,
-        terminalWorkspaceTerminalOnly: terminalState.workspaceLayout === "terminal-only",
-        terminalWorkspaceTerminalTabActive,
-        terminalWorkspaceChatTabActive,
-      };
-
-      const command = resolveShortcutCommand(event, keybindings, {
-        context: shortcutContext,
-      });
-      if (!command) return;
-
-      if (command === "composer.focus.toggle") {
-        if (isComposerApprovalState || isVoiceRecording || isVoiceTranscribing) return;
-        event.preventDefault();
-        event.stopPropagation();
-        toggleComposerFocus();
-        return;
-      }
-
-      if (command === "chat.find") {
-        if (
-          !shouldCaptureChatFindShortcut({
-            shouldRenderChatPaneContent,
-            terminalWorkspaceTerminalTabActive,
-            inAppBrowserFocused: eventTargetsInAppBrowser(event.target),
-          })
-        ) {
-          return;
-        }
-        event.preventDefault();
-        event.stopPropagation();
-        setThreadFindOpen(true);
-        setThreadFindFocusNonce((current) => current + 1);
-        return;
-      }
-
-      if (command === "modelPicker.toggle") {
-        if (!composerPickerShortcutActive) return;
-        event.preventDefault();
-        event.stopPropagation();
-        handleModelPickerOpenChange(true);
-        scheduleComposerFocus();
-        return;
-      }
-
-      if (command === "model.next" || command === "model.previous") {
-        if (!composerPickerShortcutActive) return;
-        event.preventDefault();
-        event.stopPropagation();
-        const direction = command === "model.next" ? "next" : "previous";
-        const providerOptions = modelOptionsByProvider[selectedProvider] ?? [];
-        const nextSlug = resolveCycledModelSlug({
-          currentModel: selectedModel,
-          options: providerOptions,
-          favoriteSlugs: readFavoriteModelSlugs(selectedProvider),
-          direction,
-        });
-        if (!nextSlug) return;
-        onProviderModelSelect(selectedProvider, nextSlug as ModelSlug);
-        return;
-      }
-
-      if (command === "traitsPicker.toggle") {
-        if (!composerPickerShortcutActive) return;
-        event.preventDefault();
-        event.stopPropagation();
-        handleTraitsPickerOpenChange(true);
-        scheduleComposerFocus();
-        return;
-      }
-
-      if (command === "terminal.toggle") {
-        event.preventDefault();
-        event.stopPropagation();
-        toggleTerminalVisibility();
-        return;
-      }
-
-      if (command === "terminal.split" || command === "terminal.splitRight") {
-        event.preventDefault();
-        event.stopPropagation();
-        if (!terminalState.terminalOpen) {
-          setTerminalOpen(true);
-        }
-        splitTerminalRight();
-        return;
-      }
-
-      if (command === "terminal.splitLeft") {
-        event.preventDefault();
-        event.stopPropagation();
-        if (!terminalState.terminalOpen) {
-          setTerminalOpen(true);
-        }
-        splitTerminalLeft();
-        return;
-      }
-
-      if (command === "terminal.splitDown") {
-        event.preventDefault();
-        event.stopPropagation();
-        if (!terminalState.terminalOpen) {
-          setTerminalOpen(true);
-        }
-        splitTerminalDown();
-        return;
-      }
-
-      if (command === "terminal.splitUp") {
-        event.preventDefault();
-        event.stopPropagation();
-        if (!terminalState.terminalOpen) {
-          setTerminalOpen(true);
-        }
-        splitTerminalUp();
-        return;
-      }
-
-      if (command === "terminal.close") {
-        event.preventDefault();
-        event.stopPropagation();
-        if (!terminalState.terminalOpen) return;
-        closeTerminal(terminalState.activeTerminalId);
-        return;
-      }
-
-      if (command === "terminal.new") {
-        event.preventDefault();
-        event.stopPropagation();
-        createTerminalFromShortcut();
-        return;
-      }
-
-      if (command === "terminal.workspace.newFullWidth") {
-        event.preventDefault();
-        event.stopPropagation();
-        openNewFullWidthTerminal();
-        return;
-      }
-
-      if (command === "terminal.workspace.closeActive") {
-        event.preventDefault();
-        event.stopPropagation();
-        closeActiveWorkspaceView();
-        return;
-      }
-
-      if (command === "terminal.workspace.terminal") {
-        event.preventDefault();
-        event.stopPropagation();
-        if (!terminalWorkspaceOpen) return;
-        setTerminalWorkspaceTab("terminal");
-        return;
-      }
-
-      if (command === "terminal.workspace.chat") {
-        event.preventDefault();
-        event.stopPropagation();
-        if (!terminalWorkspaceOpen) return;
-        setTerminalWorkspaceTab("chat");
-        return;
-      }
-
-      if (command === "diff.toggle") {
-        event.preventDefault();
-        event.stopPropagation();
-        onToggleDiff();
-        return;
-      }
-
-      if (command === "git.commitAndPush") {
-        if (commitAndPushTriggerRef.current) {
-          event.preventDefault();
-          event.stopPropagation();
-          commitAndPushTriggerRef.current();
-          return;
-        }
-        // No registered trigger inside a git-enabled thread means the action just
-        // isn't runnable right now (clean tree, behind upstream, action in flight)
-        // — tell the user instead of eating the chord silently. Outside git threads
-        // the chord falls through untouched.
-        if (showGitActions && isGitRepo) {
-          event.preventDefault();
-          event.stopPropagation();
-          toastManager.add({
-            type: "info",
-            title: "Nothing to commit or push.",
-          });
-        }
-        return;
-      }
-
-      if (command === "browser.toggle") {
-        event.preventDefault();
-        event.stopPropagation();
-        if (!isElectron) return;
-        onToggleBrowser();
-        return;
-      }
-
-      if (command === "device.toggle") {
-        event.preventDefault();
-        event.stopPropagation();
-        // Unlike the browser this works in a plain tab, but only against a macOS
-        // server; the surface leaves the handler unwired when it cannot host one.
-        onToggleDevicePanel?.();
-        return;
-      }
-
-      if (command === "chat.split") {
-        event.preventDefault();
-        event.stopPropagation();
-        if (surfaceMode === "single" && onSplitSurface) {
-          onSplitSurface();
-        }
-        return;
-      }
-
-      // The handler already bailed out when no thread is open, so the active thread id
-      // is always the one the user is looking at (the focused pane when split).
-      if (command === "thread.copyId") {
-        event.preventDefault();
-        event.stopPropagation();
-        copyThreadIdToClipboard(activeThreadId);
-        return;
-      }
-
-      const scriptId = projectScriptIdFromCommand(command);
-      if (!scriptId || !activeProject) return;
-      const script = activeProject.scripts.find((entry) => entry.id === scriptId);
-      if (!script) return;
-      event.preventDefault();
-      event.stopPropagation();
-      void runProjectScript(script);
-    };
-    window.addEventListener("keydown", handler, { capture: true });
-    return () => window.removeEventListener("keydown", handler, { capture: true });
-  }, [
-    activeProject,
-    terminalState.terminalOpen,
-    terminalState.activeTerminalId,
-    terminalState.workspaceLayout,
-    activeThreadId,
-    closeTerminal,
-    closeActiveWorkspaceView,
-    createTerminalFromShortcut,
-    setTerminalOpen,
-    openNewFullWidthTerminal,
-    runProjectScript,
-    keybindings,
-    splitTerminalDown,
-    splitTerminalLeft,
-    splitTerminalRight,
-    splitTerminalUp,
-    terminalWorkspaceChatTabActive,
-    terminalWorkspaceOpen,
-    terminalWorkspaceTerminalTabActive,
-    onToggleBrowser,
+  useChatKeyboardShortcuts({
     onToggleDevicePanel,
-    onToggleDiff,
-    onInterruptFromStopControl,
     onSplitSurface,
-    showGitActions,
-    isGitRepo,
+    surfaceMode,
+    isFocusedPane,
+    activeThreadId,
+    hasLiveTurn,
+    composerFormRef,
+    onInterruptFromStopControl,
     composerSubagentStripItems,
     onBackgroundAllForegroundSubagentStripItems,
-    isFocusedPane,
-    hasLiveTurn,
-    handleModelPickerOpenChange,
-    handleTraitsPickerOpenChange,
-    shouldRenderChatPaneContent,
-    isComposerApprovalState,
     isVoiceRecording,
     isVoiceTranscribing,
-    setTerminalWorkspaceTab,
-    surfaceMode,
-    scheduleComposerFocus,
+    isComposerApprovalState,
+    terminalState,
+    terminalWorkspaceOpen,
+    terminalWorkspaceTerminalTabActive,
+    terminalWorkspaceChatTabActive,
+    keybindings,
     toggleComposerFocus,
-    toggleTerminalVisibility,
-    activeThread,
+    shouldRenderChatPaneContent,
+    setThreadFindOpen,
+    setThreadFindFocusNonce,
+    handleModelPickerOpenChange,
+    scheduleComposerFocus,
+    modelOptionsByProvider,
     selectedProvider,
     selectedModel,
-    modelOptionsByProvider,
     onProviderModelSelect,
+    handleTraitsPickerOpenChange,
+    toggleTerminalVisibility,
+    setTerminalOpen,
+    splitTerminalRight,
+    splitTerminalLeft,
+    splitTerminalDown,
+    splitTerminalUp,
+    closeTerminal,
+    createTerminalFromShortcut,
+    openNewFullWidthTerminal,
+    closeActiveWorkspaceView,
+    setTerminalWorkspaceTab,
+    onToggleDiff,
+    commitAndPushTriggerRef,
+    showGitActions,
+    isGitRepo,
+    onToggleBrowser,
     copyThreadIdToClipboard,
-  ]);
+    activeProject,
+    runProjectScript,
+    activeThread,
+  });
 
   // Preserve the original "single mic button" contract:
   // first click starts recording, the next click submits/transcribes.
@@ -7045,7 +3531,15 @@ export default function ChatView({
       }
       setIsRevertingCheckpoint(false);
     },
-    [activeThread, hasLiveTurn, isConnecting, isRevertingCheckpoint, isSendBusy, setThreadError],
+    [
+      setIsRevertingCheckpoint,
+      activeThread,
+      hasLiveTurn,
+      isConnecting,
+      isRevertingCheckpoint,
+      isSendBusy,
+      setThreadError,
+    ],
   );
 
   const onUndoTurnFiles = useCallback(
@@ -7102,7 +3596,16 @@ export default function ChatView({
         );
       });
     },
-    [activeThread, hasLiveTurn, isConnecting, isRevertingCheckpoint, isSendBusy, setThreadError],
+    [
+      setIsRevertingCheckpoint,
+      setPendingFileUndo,
+      activeThread,
+      hasLiveTurn,
+      isConnecting,
+      isRevertingCheckpoint,
+      isSendBusy,
+      setThreadError,
+    ],
   );
 
   const onCreateHandoffThread = useCallback(
@@ -7142,6 +3645,13 @@ export default function ChatView({
       setComposerTrigger(null);
     },
     [
+      promptRef,
+      setComposerCursor,
+      setComposerTrigger,
+      promptHistoryNavigationRef,
+      applyingPromptHistoryNavigationRef,
+      expectedPromptHistoryPromptRef,
+      setComposerHighlightedItemId,
       clearComposerDraftContent,
       setRestoredQueuedSourceProposedPlan,
       updateSelectedComposerMentions,
@@ -7149,2802 +3659,257 @@ export default function ChatView({
     ],
   );
 
-  const createAutomationFromForm = useCallback(
-    async (input: {
-      readonly form: AutomationFormState;
-      readonly warnings: readonly AutomationDraftWarning[];
-      readonly acknowledgedWarningIds: ReadonlySet<AutomationDraftWarningId>;
-      readonly providerOptions?: ProviderStartOptions;
-      readonly activityThreadId?: ThreadId | null;
-    }): Promise<boolean> => {
-      const api = readNativeApi();
-      if (!api || !activeProject) {
-        return false;
-      }
-      if (automationDraftSubmittingRef.current) {
-        return false;
-      }
-      if (!isFormSubmittable(input.form)) {
-        return false;
-      }
-      if (hasBlockingAutomationDraftWarnings(input.warnings, input.acknowledgedWarningIds)) {
-        return false;
-      }
-      const acknowledgedRisks = acknowledgedRiskIdsForDraft(
-        input.warnings,
-        input.acknowledgedWarningIds,
-      );
-      const activityThreadId =
-        input.activityThreadId ?? (isServerThread ? (activeThread?.id ?? null) : null);
-      const createdAt = new Date().toISOString();
-      const automationInput = createInputFromForm(
-        input.form,
-        input.providerOptions ?? providerOptionsForDispatch,
-        acknowledgedRisks,
-        activityThreadId,
-      );
-      automationDraftSubmittingRef.current = true;
-      setIsAutomationDraftSubmitting(true);
-      return await (async () => {
-        const definition = await api.automation.create(automationInput);
-        if (activityThreadId) {
-          void (async () => {
-            try {
-              await api.orchestration.dispatchCommand({
-                type: "thread.activity.append",
-                commandId: newCommandId(),
-                threadId: activityThreadId,
-                activity: {
-                  id: EventId.makeUnsafe(randomUUID()),
-                  tone: "info",
-                  kind: "automation.created",
-                  summary: `Created automation: ${definition.name} - ${formatCadence(definition.schedule)}`,
-                  payload: {
-                    source: "chat-composer",
-                    automationId: definition.id,
-                    automationName: definition.name,
-                    mode: definition.mode,
-                    cadenceLabel: formatCadence(definition.schedule),
-                    schedule: automationScheduleActivityPayload(definition.schedule),
-                  },
-                  turnId: null,
-                  createdAt,
-                },
-                createdAt,
-              });
-            } catch {
-              toastManager.add({
-                type: "warning",
-                title: "Thread note not added",
-                description:
-                  "The automation was created, but Synara could not add the activity note.",
-              });
-            }
-          })();
-        }
-        void queryClient.invalidateQueries({ queryKey: automationQueryKey });
-        clearComposerInput(activeThread?.id ?? threadId);
-        resetAutomationDraftState();
-        toastManager.add({
-          type: "success",
-          title: "Automation created",
-          description: `${definition.name} - ${formatCadence(definition.schedule)}`,
-        });
-        return true;
-      })()
-        .catch((error: unknown) => {
-          toastManager.add({
-            type: "error",
-            title: "Could not create automation",
-            description:
-              error instanceof Error ? error.message : "Synara could not save the automation.",
-          });
-          return false;
-        })
-        .finally(() => {
-          automationDraftSubmittingRef.current = false;
-          setIsAutomationDraftSubmitting(false);
-        });
-    },
-    [
+  const { createAutomationFromForm, prepareAutomationFormForCreate, submitAutomationDraft } =
+    useChatAutomationCreation({
+      threadId,
       activeProject,
-      activeThread,
       automationDraftSubmittingRef,
-      clearComposerInput,
       isServerThread,
+      activeThread,
       providerOptionsForDispatch,
-      queryClient,
-      resetAutomationDraftState,
       setIsAutomationDraftSubmitting,
-      threadId,
-    ],
-  );
-
-  const ensureAutomationTargetThread = useCallback(
-    async (input: {
-      readonly titleSeed: string;
-      readonly threadModelSelection: ModelSelection;
-      readonly threadRuntimeMode: RuntimeMode;
-      readonly threadInteractionMode: ProviderInteractionMode;
-    }): Promise<ThreadId | null> => {
-      const api = readNativeApi();
-      if (!api || !activeProject || !activeThread) {
-        toastManager.add({
-          type: "warning",
-          title: "Chat required",
-          description: "Open a chat before creating a chat-bound automation.",
-        });
-        return null;
-      }
-      if (isServerThread) {
-        return activeThread.id;
-      }
-
-      const title = buildPromptThreadTitleFallback(input.titleSeed || GENERIC_CHAT_THREAD_TITLE);
-      // Nested function so the `try` body holds no value blocks — see the comment on
-      // `deleteEmptyTerminalThread` above for why React Compiler requires this shape.
-      const promoteDraftForAutomation = async (): Promise<ThreadId | null> => {
-        const result = await promoteThreadCreate(
-          {
-            type: "thread.create",
-            commandId: newCommandId(),
-            threadId: activeThread.id,
-            projectId: activeProject.id,
-            title,
-            modelSelection: input.threadModelSelection,
-            runtimeMode: input.threadRuntimeMode,
-            interactionMode: input.threadInteractionMode,
-            envMode: activeThread.envMode ?? (activeThread.worktreePath ? "worktree" : "local"),
-            branch: activeThread.branch ?? null,
-            worktreePath: activeThread.worktreePath ?? null,
-            workingDirectory: activeThread.workingDirectory ?? null,
-            associatedWorktreePath: activeThreadAssociatedWorktree.associatedWorktreePath,
-            associatedWorktreeBranch: activeThreadAssociatedWorktree.associatedWorktreeBranch,
-            associatedWorktreeRef: activeThreadAssociatedWorktree.associatedWorktreeRef,
-            lastKnownPr: activeThread.lastKnownPr ?? null,
-            createdAt: activeThread.createdAt,
-          },
-          api,
-          { force: true },
-        );
-        if (result === "unavailable") {
-          toastManager.add({
-            type: "error",
-            title: "Could not create chat",
-            description: "Synara could not promote this draft before saving the automation.",
-          });
-          return null;
-        }
-
-        const inheritedProjectInstructions =
-          useProjectInstructionsStore.getState().instructionsByProjectId[activeProject.id] ?? "";
-        const inheritedThreadNotes = mergeProjectInstructionsIntoThreadNotes({
-          threadNotes,
-          projectInstructions: inheritedProjectInstructions,
-        });
-        if (inheritedThreadNotes !== threadNotes && inheritedThreadNotes.trim().length > 0) {
-          void dispatchThreadNotes(activeThread.id, inheritedThreadNotes).catch(() => undefined);
-        }
-
-        return activeThread.id;
-      };
-
-      try {
-        return await promoteDraftForAutomation();
-      } catch (error) {
-        toastManager.add({
-          type: "error",
-          title: "Could not create chat",
-          description:
-            error instanceof Error
-              ? error.message
-              : "Synara could not promote this draft before saving the automation.",
-        });
-        return null;
-      }
-    },
-    [activeProject, activeThread, activeThreadAssociatedWorktree, isServerThread, threadNotes],
-  );
-
-  const prepareAutomationFormForCreate = useCallback(
-    async (
-      form: AutomationFormState,
-    ): Promise<{
-      readonly form: AutomationFormState;
-      readonly activityThreadId: ThreadId | null;
-    } | null> => {
-      const activityThreadId = isServerThread ? (activeThread?.id ?? null) : null;
-      if (!automationRequiresTargetThread(form.mode) || !activeThread) {
-        return { form, activityThreadId };
-      }
-      if (isServerThread || form.targetThreadId !== activeThread.id) {
-        return { form, activityThreadId };
-      }
-
-      // Draft review can keep the local draft ID in the form; promote it only when
-      // the automation is actually submitted so cancelling review leaves no empty thread.
-      const targetThreadId = await ensureAutomationTargetThread({
-        titleSeed: form.prompt || form.name,
-        threadModelSelection: selectedModelSelection,
-        threadRuntimeMode: runtimeMode,
-        threadInteractionMode: interactionMode,
-      });
-      if (!targetThreadId) {
-        return null;
-      }
-      return {
-        form: { ...form, targetThreadId },
-        activityThreadId: targetThreadId,
-      };
-    },
-    [
-      activeThread,
-      ensureAutomationTargetThread,
-      interactionMode,
-      isServerThread,
-      runtimeMode,
+      queryClient,
+      clearComposerInput,
+      resetAutomationDraftState,
+      activeThreadAssociatedWorktree,
+      threadNotes,
       selectedModelSelection,
-    ],
-  );
-
-  const submitAutomationDraft = useCallback(async () => {
-    if (!automationDraftForm) {
-      return;
-    }
-    if (
-      !isFormSubmittable(automationDraftForm) ||
-      hasBlockingAutomationDraftWarnings(automationDraftWarnings, acknowledgedAutomationWarnings)
-    ) {
-      return;
-    }
-    const preparedCreate = await prepareAutomationFormForCreate(automationDraftForm);
-    if (!preparedCreate) {
-      return;
-    }
-    await createAutomationFromForm({
-      form: preparedCreate.form,
-      warnings: automationDraftWarnings,
-      acknowledgedWarningIds: acknowledgedAutomationWarnings,
-      activityThreadId: preparedCreate.activityThreadId,
+      runtimeMode,
+      interactionMode,
+      automationDraftForm,
+      automationDraftWarnings,
+      acknowledgedAutomationWarnings,
     });
-  }, [
-    acknowledgedAutomationWarnings,
-    automationDraftForm,
-    automationDraftWarnings,
-    createAutomationFromForm,
-    prepareAutomationFormForCreate,
-  ]);
 
-  const restoreQueuedTurnToComposer = useCallback(
-    (queuedTurn: QueuedComposerTurn) => {
-      if (!activeThread) {
-        return;
-      }
-      const nextPrompt = queuedTurn.kind === "chat" ? queuedTurn.prompt : queuedTurn.text;
-      const restoredImages =
-        queuedTurn.kind === "chat" ? queuedTurn.images.map(cloneComposerImageAttachment) : [];
-      const restoredFiles = queuedTurn.kind === "chat" ? queuedTurn.files : [];
-      const restoredAssistantSelections =
-        queuedTurn.kind === "chat" ? queuedTurn.assistantSelections : [];
-      const restoredBrowserAnnotations =
-        queuedTurn.kind === "chat" ? queuedTurn.browserAnnotations : [];
-      const restoredFileComments = queuedTurn.kind === "chat" ? queuedTurn.fileComments : [];
-      promptRef.current = nextPrompt;
-      clearComposerDraftContent(activeThread.id);
-      setComposerDraftPrompt(activeThread.id, nextPrompt);
-      // Editing a queued turn should recreate the same draft state the user queued.
-      setDraftThreadContext(activeThread.id, {
-        runtimeMode: queuedTurn.runtimeMode,
-        interactionMode: queuedTurn.interactionMode,
-        ...(queuedTurn.kind === "chat" ? { envMode: queuedTurn.envMode } : {}),
-      });
-      if (queuedTurn.kind === "chat") {
-        if (restoredImages.length > 0) {
-          addComposerImagesToDraft(restoredImages);
-        }
-        if (restoredFiles.length > 0) {
-          addComposerFilesToDraft(restoredFiles);
-        }
-        for (const selection of restoredAssistantSelections) {
-          addComposerAssistantSelectionToDraft(selection);
-        }
-        if (restoredBrowserAnnotations.length > 0) {
-          addComposerDraftBrowserAnnotations(activeThread.id, restoredBrowserAnnotations);
-        }
-        for (const comment of restoredFileComments) {
-          addComposerFileCommentToDraft(comment);
-        }
-        if (queuedTurn.terminalContexts.length > 0) {
-          addComposerTerminalContextsToDraft(queuedTurn.terminalContexts);
-        }
-        if (queuedTurn.pastedTexts.length > 0) {
-          addComposerPastedTextsToDraft(queuedTurn.pastedTexts);
-        }
-        addComposerPullRequestContextsToDraft(queuedTurn.pullRequestContexts);
-        updateSelectedComposerSkills(queuedTurn.skills);
-        updateSelectedComposerMentions(queuedTurn.mentions);
-      } else {
-        updateSelectedComposerSkills([]);
-        updateSelectedComposerMentions([]);
-      }
-      setRestoredQueuedSourceProposedPlan(
-        activeThread.id,
-        queuedTurn.kind === "chat" && queuedTurn.sourceProposedPlan
-          ? {
-              threadId: activeThread.id,
-              restoredPrompt: nextPrompt,
-              sourceProposedPlan: queuedTurn.sourceProposedPlan,
-            }
-          : null,
-      );
-      setComposerDraftModelSelection(activeThread.id, queuedTurn.modelSelection);
-      setComposerDraftRuntimeMode(activeThread.id, queuedTurn.runtimeMode);
-      setComposerDraftInteractionMode(activeThread.id, queuedTurn.interactionMode);
-      setComposerCursor(collapseExpandedComposerCursor(nextPrompt, nextPrompt.length));
-      setComposerTrigger(detectComposerTrigger(nextPrompt, nextPrompt.length));
-      scheduleComposerFocus();
-    },
-    [
-      activeThread,
-      addComposerAssistantSelectionToDraft,
-      addComposerDraftBrowserAnnotations,
-      addComposerFileCommentToDraft,
-      addComposerFilesToDraft,
-      addComposerImagesToDraft,
-      addComposerTerminalContextsToDraft,
-      addComposerPastedTextsToDraft,
-      addComposerPullRequestContextsToDraft,
-      clearComposerDraftContent,
-      scheduleComposerFocus,
-      setDraftThreadContext,
-      setRestoredQueuedSourceProposedPlan,
-      setComposerDraftInteractionMode,
-      setComposerDraftModelSelection,
-      setComposerDraftPrompt,
-      setComposerDraftRuntimeMode,
-      updateSelectedComposerMentions,
-      updateSelectedComposerSkills,
-    ],
-  );
-
-  const removeQueuedComposerTurn = useCallback(
-    (queuedTurnId: string) => {
-      removeQueuedComposerTurnFromDraft(threadId, queuedTurnId);
-    },
-    [removeQueuedComposerTurnFromDraft, threadId],
-  );
-
-  // See `LateComposerSendHandlers`: declared here so both `dispatchQueuedComposerTurn` (above)
-  // and `onSend` (below) can reach handlers that are only declared further down.
   const lateComposerSendHandlersRef = useRef<LateComposerSendHandlers | null>(null);
-
-  const onSend = async (
-    e?: { preventDefault: () => void },
-    requestedDispatchMode?: "queue" | "steer",
-    queuedTurn?: QueuedComposerChatTurn,
-  ): Promise<boolean> => {
-    const dispatchMode =
-      requestedDispatchMode ??
-      resolveFollowUpDispatchMode({
-        behavior: settings.followUpBehavior,
-        hasLiveTurn,
-      });
-    e?.preventDefault();
-    const api = readNativeApi();
-    const lateSendHandlers = lateComposerSendHandlersRef.current;
-    if (
-      !api ||
-      !lateSendHandlers ||
-      !activeThread ||
-      activeThread.sidechatExpiredAt ||
-      isSendBusy ||
-      isConnecting ||
-      isVoiceTranscribing ||
-      sendPreflightInFlightRef.current ||
-      sendInFlightRef.current
-    ) {
-      return false;
-    }
-    if (!queuedTurn) {
-      sendPreflightInFlightRef.current = true;
-      await waitForPendingComposerImages();
-      sendPreflightInFlightRef.current = false;
-    }
-    if (activePendingProgress) {
-      const activeQuestion = activePendingProgress.activeQuestion;
-      const liveComposerSnapshot = composerEditorRef.current?.readSnapshot() ?? null;
-      const livePendingAnswerText = liveComposerSnapshot?.value ?? promptRef.current;
-      const currentDraftAnswer =
-        activePendingUserInputKey && activeQuestion
-          ? pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey]?.[
-              activeQuestion.id
-            ]
-          : undefined;
-      const answerOverrides =
-        activeQuestion && livePendingAnswerText.trim().length > 0
-          ? {
-              [activeQuestion.id]: setPendingUserInputCustomAnswer(
-                currentDraftAnswer,
-                livePendingAnswerText,
-              ),
-            }
-          : undefined;
-      if (activePendingUserInputKey && answerOverrides) {
-        const nextRequestAnswers = {
-          ...pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey],
-          ...answerOverrides,
-        };
-        pendingUserInputAnswersByRequestIdRef.current = {
-          ...pendingUserInputAnswersByRequestIdRef.current,
-          [activePendingUserInputKey]: nextRequestAnswers,
-        };
-        setPendingUserInputAnswersByRequestId((existing) => ({
-          ...existing,
-          [activePendingUserInputKey]: nextRequestAnswers,
-        }));
-      }
-      return lateSendHandlers.advanceActivePendingUserInput(answerOverrides);
-    }
-    const queuedChatTurn = queuedTurn ?? null;
-    const liveComposerSnapshot =
-      queuedChatTurn === null ? (composerEditorRef.current?.readSnapshot() ?? null) : null;
-    let promptForSend = queuedChatTurn?.prompt ?? liveComposerSnapshot?.value ?? promptRef.current;
-    let composerImagesForSend =
-      queuedChatTurn?.images ??
-      useComposerDraftStore.getState().draftsByThreadId[activeThread.id]?.images ??
-      composerImages;
-    // AppSnap captures persist as IndexedDB blobs and hydrate into `images`
-    // asynchronously (see AppSnapCoordinator). Right after a reload the user can
-    // hit send before that hydration finishes; without this, the not-yet-hydrated
-    // capture would be silently dropped from the message and then have its blob
-    // deleted when the composer clears after send. Live sends only: a queued turn
-    // already captured a fully-resolved image snapshot when it was queued.
-    if (queuedChatTurn === null) {
-      const pendingBlobAttachments = findPendingBlobComposerAttachments({
-        persistedAttachments:
-          useComposerDraftStore.getState().draftsByThreadId[activeThread.id]
-            ?.persistedAttachments ?? [],
-        images: composerImagesForSend,
-      });
-      if (pendingBlobAttachments.length > 0) {
-        const hydratedPendingImages =
-          await hydratePendingBlobComposerAttachments(pendingBlobAttachments);
-        if (hydratedPendingImages.length > 0) {
-          composerImagesForSend = [...composerImagesForSend, ...hydratedPendingImages];
-        }
-      }
-    }
-    const composerFilesForSend = queuedChatTurn?.files ?? composerFiles;
-    const composerAssistantSelectionsForSend =
-      queuedChatTurn?.assistantSelections ?? composerAssistantSelections;
-    const composerBrowserAnnotationsForSend =
-      queuedChatTurn?.browserAnnotations ?? composerBrowserAnnotations;
-    const composerFileCommentsForSend = queuedChatTurn?.fileComments ?? composerFileComments;
-    const composerTerminalContextsForSend =
-      queuedChatTurn?.terminalContexts ?? composerTerminalContexts;
-    const composerPastedTextsForSend = queuedChatTurn?.pastedTexts ?? composerPastedTexts;
-    const composerPullRequestContextsForSend =
-      queuedChatTurn?.pullRequestContexts ?? composerPullRequestContexts;
-    const selectedComposerSkillsForSend =
-      queuedChatTurn?.skills ?? selectedComposerSkillsRef.current;
-    const selectedComposerMentionsForSend =
-      queuedChatTurn?.mentions ?? selectedComposerMentionsRef.current;
-    const selectedProviderForSend = queuedChatTurn?.selectedProvider ?? selectedProvider;
-    const selectedModelForSend = queuedChatTurn?.selectedModel ?? selectedModel;
-    const selectedPromptEffortForSend =
-      queuedChatTurn?.selectedPromptEffort ?? selectedPromptEffort;
-    const selectedModelSelectionForSend = queuedChatTurn?.modelSelection ?? selectedModelSelection;
-    const providerOptionsForDispatchForSend =
-      queuedChatTurn?.providerOptionsForDispatch ?? providerOptionsForDispatch;
-    const runtimeModeForSend = queuedChatTurn?.runtimeMode ?? runtimeMode;
-    let interactionModeForSend = queuedChatTurn?.interactionMode ?? interactionMode;
-    const envModeForSend = queuedChatTurn?.envMode ?? envMode;
-    const {
-      trimmedPrompt: trimmed,
-      sendableTerminalContexts: sendableComposerTerminalContexts,
-      expiredTerminalContextCount,
-      sendablePastedTexts: sendableComposerPastedTexts,
-      sendablePullRequestContexts: sendableComposerPullRequestContexts,
-      hasSendableContent,
-    } = deriveComposerSendState({
-      prompt: promptForSend,
-      imageCount: composerImagesForSend.length,
-      fileCount: composerFilesForSend.length,
-      assistantSelectionCount: composerAssistantSelectionsForSend.length,
-      browserAnnotationCount: composerBrowserAnnotationsForSend.length,
-      fileCommentCount: composerFileCommentsForSend.length,
-      terminalContexts: composerTerminalContextsForSend,
-      pastedTexts: composerPastedTextsForSend,
-      pullRequestContexts: composerPullRequestContextsForSend,
-    });
-    let trimmedPromptForSend = trimmed;
-    const restoredQueuedPlanDraftSource =
-      queuedChatTurn === null &&
-      restoredQueuedSourceProposedPlanRef.current?.threadId === activeThread.id &&
-      composerPromptStillMatchesRestoredQueuedDraft(
-        restoredQueuedSourceProposedPlanRef.current.restoredPrompt,
-        promptForSend,
-      )
-        ? restoredQueuedSourceProposedPlanRef.current
-        : null;
-    const isLivePlanFollowUpSubmission =
-      queuedChatTurn === null &&
-      restoredQueuedPlanDraftSource === null &&
-      showPlanFollowUpPrompt &&
-      activeProposedPlan !== null;
-    const hasStructuredPlanFollowUpContent =
-      composerImagesForSend.length > 0 ||
-      composerFilesForSend.length > 0 ||
-      composerAssistantSelectionsForSend.length > 0 ||
-      composerBrowserAnnotationsForSend.length > 0 ||
-      composerFileCommentsForSend.length > 0 ||
-      sendableComposerTerminalContexts.length > 0 ||
-      sendableComposerPastedTexts.length > 0;
-    // Queued chat turns already captured their intended mode. Live plan follow-ups
-    // with attachments must use the normal send path so references are preserved.
-    if (isLivePlanFollowUpSubmission) {
-      const followUp = resolvePlanFollowUpSubmission({
-        draftText: trimmed,
-        planMarkdown: activeProposedPlan.planMarkdown,
-      });
-      if (hasStructuredPlanFollowUpContent) {
-        promptForSend = followUp.text;
-        interactionModeForSend = followUp.interactionMode;
-        trimmedPromptForSend = followUp.text.trim();
-      } else {
-        if (hasQueueableLiveTurn && dispatchMode === "queue") {
-          clearComposerInput(activeThread.id);
-          scheduleComposerFocus();
-          enqueueQueuedComposerTurn(activeThread.id, {
-            id: randomUUID(),
-            kind: "plan-follow-up",
-            createdAt: new Date().toISOString(),
-            previewText: followUp.text.trim(),
-            text: followUp.text,
-            interactionMode: followUp.interactionMode,
-            selectedProvider,
-            selectedModel,
-            selectedPromptEffort,
-            modelSelection: selectedModelSelection,
-            ...(providerOptionsForDispatch ? { providerOptionsForDispatch } : {}),
-            runtimeMode,
-          });
-          return true;
-        }
-        clearComposerInput(activeThread.id);
-        scheduleComposerFocus();
-        return lateSendHandlers.submitPlanFollowUp({
-          text: followUp.text,
-          interactionMode: followUp.interactionMode,
-          dispatchMode,
-        });
-      }
-    }
-    const hasNoStructuredComposerContext =
-      composerImagesForSend.length === 0 &&
-      composerFilesForSend.length === 0 &&
-      composerAssistantSelectionsForSend.length === 0 &&
-      composerBrowserAnnotationsForSend.length === 0 &&
-      composerFileCommentsForSend.length === 0 &&
-      sendableComposerTerminalContexts.length === 0 &&
-      sendableComposerPastedTexts.length === 0 &&
-      // Provider mentions are structured turn metadata, and automation definitions persist text only.
-      selectedComposerMentionsForSend.length === 0;
-    const hasPromptOnlySendableContent = hasNoStructuredComposerContext;
-    if (hasPromptOnlySendableContent) {
-      const handledSlashCommand =
-        await lateSendHandlers.handleStandaloneSlashCommand(trimmedPromptForSend);
-      if (handledSlashCommand) {
-        // A slash command (e.g. /clear) consumes the composer, so abandon any in-progress
-        // automation setup rather than leaving a stale banner/request behind.
-        pendingAutomationConversationRef.current = null;
-        setPendingAutomationConversation(null);
-        return true;
-      }
-    }
-    const sourceProposedPlanForSend =
-      queuedChatTurn?.sourceProposedPlan ??
-      restoredQueuedPlanDraftSource?.sourceProposedPlan ??
-      (isLivePlanFollowUpSubmission && activeProposedPlan && interactionModeForSend === "default"
-        ? buildSourceProposedPlanReference({
-            threadId: activeThread.id,
-            proposedPlan: activeProposedPlan,
-          })
-        : undefined);
-    if (!hasSendableContent) {
-      if (expiredTerminalContextCount > 0) {
-        const toastCopy = buildExpiredTerminalContextToastCopy(
-          expiredTerminalContextCount,
-          "empty",
-        );
-        toastManager.add({
-          type: "warning",
-          title: toastCopy.title,
-          description: toastCopy.description,
-        });
-      }
-      return false;
-    }
-    if (!activeProject) return false;
-    if (queuedChatTurn === null && !isLivePlanFollowUpSubmission) {
-      const conversation = pendingAutomationConversation;
-      // While gathering missing details, fold the reply into the cleaned request so it
-      // re-resolves as a whole rather than parsing the bare answer (and never re-parses
-      // "could you create an automation" scaffolding as the task).
-      const messageForAutomation = conversation
-        ? `${conversation.accumulatedMessage}\n${trimmedPromptForSend}`
-        : trimmedPromptForSend;
-      const automationRequest = await resolveComposerAutomationRequest({
-        message: messageForAutomation,
-        cwd: threadWorkspaceCwd ?? activeProject.cwd,
-        generateIntent: (request) => api.server.generateAutomationIntent(request),
-      });
-      // Drop a stale resolve: bail if the user switched threads, or cancelled/changed the
-      // setup, while generateAutomationIntent was awaiting.
-      if (
-        activeThreadIdRef.current !== threadId ||
-        pendingAutomationConversationRef.current !== conversation ||
-        (!hasLiveTurn && hasLiveTurnRef.current)
-      ) {
-        return true;
-      }
-      if (automationRequest.type !== "normal-chat") {
-        if (automationRequest.type === "needs-clarification") {
-          // Conversational setup only runs for prompt-only sends while no turn is live:
-          // clearing the composer would drop attachments/mentions Cancel can't restore,
-          // and ephemeral setup bubbles must not anchor a running turn's work rows.
-          if (!hasPromptOnlySendableContent || hasLiveTurn) {
-            toastManager.add({
-              type: "warning",
-              title: "Automation needs a bit more detail",
-              description:
-                automationRequest.reason ??
-                'Add what it should do and how often, e.g. "every weekday at 9am, summarize my PRs".',
-            });
-            return true;
-          }
-          // Render the exchange in-thread: echo the user's words as a bubble and ask for
-          // what's missing as an assistant bubble. Nothing reaches a provider; the cleaned
-          // automationMessage accumulates for the next re-resolve and for Cancel's restore.
-          const question = automationClarificationPrompt(automationRequest.missingFields);
-          const priorBubbles = conversation?.bubbles ?? [];
-          // Drop the submitted request from the composer (it is captured in
-          // accumulatedMessage, so re-folding it would duplicate the scaffold) while
-          // preserving anything typed *after* it during the async resolve.
-          const liveDraft = promptRef.current.trimStart();
-          const leftover = liveDraft.startsWith(trimmedPromptForSend)
-            ? liveDraft.slice(trimmedPromptForSend.length).trimStart()
-            : liveDraft;
-          promptRef.current = leftover;
-          setComposerDraftPrompt(activeThread.id, leftover);
-          setComposerTrigger(null);
-          // Bring the new question into view even if the user had scrolled up.
-          armTranscriptAutoFollow(activeThread.id, true);
-          setPendingAutomationConversation({
-            threadId: activeThread.id,
-            accumulatedMessage: automationRequest.automationMessage,
-            bubbles: [
-              ...priorBubbles,
-              makeAutomationSetupBubble("user", trimmedPromptForSend),
-              makeAutomationSetupBubble("assistant", question),
-            ],
-          });
-          return true;
-        }
-
-        pendingAutomationConversationRef.current = null;
-        setPendingAutomationConversation(null);
-        const automationIntent = automationRequest.resolution.intent;
-        const automationTargetThreadId =
-          automationIntent.executionScope === "thread" ? activeThread.id : null;
-        const automationDraft = buildComposerAutomationDraft({
-          resolution: automationRequest.resolution,
-          projectId: activeProject.id,
-          projectModelSelection: automationProjectModelSelection(
-            automationProjects,
-            activeProject.id,
-          ),
-          selectedModelSelection: selectedModelSelectionForSend,
-          targetThreadId: automationTargetThreadId,
-          hasEphemeralContext: !hasPromptOnlySendableContent,
-        });
-        // A multi-turn setup always confirms before creating, so the user reviews the
-        // parsed task/schedule (and any scaffolding the parser kept) rather than it
-        // silently auto-creating a recurring job.
-        if (automationDraft.needsDraftReview || conversation !== null) {
-          if (conversation !== null) {
-            // Keep the full multi-turn request in the composer so dismissing the review
-            // dialog doesn't lose it (the single-turn path likewise leaves its text).
-            // Restore only the text; any attachments/mentions on the final reply stay.
-            const liveDraft = promptRef.current.trimStart();
-            const leftover = liveDraft.startsWith(trimmedPromptForSend)
-              ? liveDraft.slice(trimmedPromptForSend.length).trimStart()
-              : liveDraft;
-            const restoredPrompt = leftover
-              ? `${messageForAutomation}\n${leftover}`
-              : messageForAutomation;
-            promptRef.current = restoredPrompt;
-            setComposerDraftPrompt(activeThread.id, restoredPrompt);
-          }
-          setAutomationDraftWarningContext(automationDraft.warningContext);
-          setAutomationDraftForm(automationDraft.form);
-          setAutomationDraftWarnings(automationDraft.warnings);
-          setAcknowledgedAutomationWarnings(automationDraft.acknowledgedWarningIds);
-          setAutomationDraftOpen(true);
-          return true;
-        }
-        const preparedAutomation = await prepareAutomationFormForCreate(automationDraft.form);
-        if (!preparedAutomation) {
-          return true;
-        }
-        await createAutomationFromForm({
-          form: preparedAutomation.form,
-          warnings: automationDraft.warnings,
-          acknowledgedWarningIds: automationDraft.acknowledgedWarningIds,
-          activityThreadId: preparedAutomation.activityThreadId,
-          ...(providerOptionsForDispatchForSend
-            ? { providerOptions: providerOptionsForDispatchForSend }
-            : {}),
-        });
-        return true;
-      }
-      if (conversation) {
-        // The combined text no longer reads as an automation; abandon setup and let
-        // this message send as a normal chat turn instead of looping on the question.
-        pendingAutomationConversationRef.current = null;
-        setPendingAutomationConversation(null);
-      }
-    }
-    sendPreflightInFlightRef.current = true;
-    const sendProviderAvailability = await resolveProviderSendAvailabilityWithRefresh({
-      provider: selectedModelSelectionForSend.provider,
-      statuses: providerStatuses,
-      refreshStatuses: () => refreshProviderStatuses({ silent: true }),
-    }).finally(() => {
-      sendPreflightInFlightRef.current = false;
-    });
-    if (!sendProviderAvailability.usable) {
-      toastManager.add({
-        type: "error",
-        title: sendProviderAvailability.unavailableReason,
-      });
-      return false;
-    }
-
-    const browserPromptAttachment: BrowserPromptAttachmentResolution =
-      await maybeResolveBrowserPromptAttachment({
-        api,
-        threadId: activeThread.id,
-        prompt: promptForSend,
-      }).catch(
-        (): BrowserPromptAttachmentResolution => ({
-          requested: false,
-          image: null,
-        }),
-      );
-    if (browserPromptAttachment.image) {
-      const nextAttachmentCount =
-        composerImagesForSend.length +
-        composerFilesForSend.length +
-        composerAssistantSelectionsForSend.length +
-        (browserPromptAttachment.image ? 1 : 0);
-      if (nextAttachmentCount <= PROVIDER_SEND_TURN_MAX_ATTACHMENTS) {
-        composerImagesForSend = [...composerImagesForSend, browserPromptAttachment.image];
-      } else {
-        toastManager.add({
-          type: "warning",
-          title: `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} references per message.`,
-          description:
-            "The current browser screenshot was skipped because this message is already at the attachment limit.",
-        });
-      }
-    } else if (browserPromptAttachment.requested) {
-      const description =
-        browserPromptAttachment.reason === "no-open-browser"
-          ? "Open the in-app browser first, then try again."
-          : browserPromptAttachment.reason === "no-active-tab"
-            ? "The in-app browser has no active tab to capture yet."
-            : browserPromptAttachment.reason === "attachment-processing-failed"
-              ? "The browser screenshot could not be optimized for attachment."
-              : "The current browser context could not be attached.";
-      toastManager.add({
-        type: "warning",
-        title: "Couldn’t attach the in-app browser context",
-        description,
-      });
-    }
-
-    const devicePromptAttachment: DevicePromptAttachmentResolution =
-      await maybeResolveDevicePromptAttachment({
-        api,
-        threadId: activeThread.id,
-        prompt: promptForSend,
-      }).catch(
-        (): DevicePromptAttachmentResolution => ({
-          requested: false,
-          image: null,
-        }),
-      );
-    if (devicePromptAttachment.image) {
-      const nextAttachmentCount =
-        composerImagesForSend.length +
-        composerFilesForSend.length +
-        composerAssistantSelectionsForSend.length +
-        1;
-      if (nextAttachmentCount <= PROVIDER_SEND_TURN_MAX_ATTACHMENTS) {
-        composerImagesForSend = [...composerImagesForSend, devicePromptAttachment.image];
-      } else {
-        toastManager.add({
-          type: "warning",
-          title: `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} references per message.`,
-          description:
-            "The simulator screenshot was skipped because this message is already at the attachment limit.",
-        });
-      }
-    } else if (devicePromptAttachment.requested) {
-      const description =
-        devicePromptAttachment.reason === "no-attached-device"
-          ? "Open the iOS Simulator panel and choose a device first, then try again."
-          : devicePromptAttachment.reason === "device-not-booted"
-            ? "The selected simulator is still starting up."
-            : devicePromptAttachment.reason === "attachment-processing-failed"
-              ? "The simulator screenshot could not be optimized for attachment."
-              : "The current simulator context could not be attached.";
-      toastManager.add({
-        type: "warning",
-        title: "Couldn’t attach the simulator screen",
-        description,
-      });
-    }
-
-    if (hasQueueableLiveTurn && dispatchMode === "queue" && queuedChatTurn === null) {
-      clearComposerInput(activeThread.id);
-      scheduleComposerFocus();
-      const queuedImagesForPersistence = await Promise.all(
-        composerImagesForSend.map(async (image) => {
-          try {
-            return {
-              ...image,
-              previewUrl: await readFileAsDataUrl(image.file),
-            };
-          } catch {
-            return image;
-          }
-        }),
-      );
-      enqueueQueuedComposerTurn(activeThread.id, {
-        id: randomUUID(),
-        kind: "chat",
-        createdAt: new Date().toISOString(),
-        previewText: buildQueuedComposerPreviewText({
-          trimmedPrompt: trimmed,
-          images: queuedImagesForPersistence,
-          files: composerFilesForSend,
-          assistantSelections: composerAssistantSelectionsForSend,
-          browserAnnotations: composerBrowserAnnotationsForSend,
-          terminalContexts: sendableComposerTerminalContexts,
-          fileComments: composerFileCommentsForSend,
-          pastedTexts: sendableComposerPastedTexts,
-          pullRequestContexts: sendableComposerPullRequestContexts,
-        }),
-        prompt: promptForSend,
-        images: queuedImagesForPersistence,
-        files: composerFilesForSend,
-        assistantSelections: composerAssistantSelectionsForSend,
-        browserAnnotations: composerBrowserAnnotationsForSend,
-        fileComments: composerFileCommentsForSend,
-        terminalContexts: sendableComposerTerminalContexts,
-        pastedTexts: sendableComposerPastedTexts,
-        pullRequestContexts: sendableComposerPullRequestContexts,
-        skills: selectedComposerSkillsForSend,
-        mentions: selectedComposerMentionsForSend,
-        selectedProvider: selectedProviderForSend,
-        selectedModel: selectedModelForSend,
-        selectedPromptEffort: selectedPromptEffortForSend,
-        modelSelection: selectedModelSelectionForSend,
-        ...(providerOptionsForDispatchForSend
-          ? { providerOptionsForDispatch: providerOptionsForDispatchForSend }
-          : {}),
-        ...(sourceProposedPlanForSend ? { sourceProposedPlan: sourceProposedPlanForSend } : {}),
-        runtimeMode: runtimeModeForSend,
-        interactionMode: interactionModeForSend,
-        envMode: envModeForSend,
-      });
-      return true;
-    }
-    const threadIdForSend = activeThread.id;
-    const isFirstMessage = !isServerThread || !hasNativeUserMessages;
-    const firstSendCreatedAt = new Date();
-    let firstComposerImageNameForTitle: string | null = null;
-    if (composerImagesForSend.length > 0) {
-      firstComposerImageNameForTitle = composerImagesForSend[0]?.name ?? null;
-    }
-    let titleSeed = trimmedPromptForSend;
-    if (!titleSeed) {
-      if (firstComposerImageNameForTitle) {
-        titleSeed = `Image: ${firstComposerImageNameForTitle}`;
-      } else if (composerFilesForSend.length > 0) {
-        titleSeed = `File: ${composerFilesForSend[0]?.name ?? "attachment"}`;
-      } else if (composerAssistantSelectionsForSend.length > 0) {
-        titleSeed = formatAssistantSelectionTitleSeed(composerAssistantSelectionsForSend.length);
-      } else if (composerBrowserAnnotationsForSend.length > 0) {
-        titleSeed = formatBrowserAnnotationLabel(composerBrowserAnnotationsForSend[0]!);
-      } else if (sendableComposerTerminalContexts.length > 0) {
-        titleSeed = formatTerminalContextLabel(sendableComposerTerminalContexts[0]!);
-      } else if (composerFileCommentsForSend.length > 0) {
-        titleSeed = formatFileCommentTitleSeed(composerFileCommentsForSend.length);
-      } else if (sendableComposerPastedTexts.length > 0) {
-        titleSeed =
-          formatPastedTextTitleSeed(sendableComposerPastedTexts) ?? GENERIC_CHAT_THREAD_TITLE;
-      } else {
-        titleSeed = GENERIC_CHAT_THREAD_TITLE;
-      }
-    }
-    // Keep the optimistic label short while the server asks Codex for a better summary.
-    const title = buildPromptThreadTitleFallback(titleSeed);
-    const currentStoreState = useStore.getState();
-    // Keep an optimistically selected Space across the command/snapshot race. The server
-    // validates this best-effort target and degrades genuinely stale/deleted ids to Void.
-    const activeSpaceIdForSend = readActiveSpaceId();
-    const firstSendDefaultModelSelection = buildModelSelection(
-      selectedModelSelectionForSend.provider,
-      selectedModelSelectionForSend.model ||
-        selectedModelForSend ||
-        getDefaultModel(selectedModelSelectionForSend.provider) ||
-        DEFAULT_MODEL_BY_PROVIDER.codex,
-      selectedModelSelectionForSend.options,
-    );
-    const firstSendTarget = resolveFirstSendTarget({
-      activeProject,
-      chatWorkspaceRoot,
-      createdAt: firstSendCreatedAt,
-      defaultModelSelection: firstSendDefaultModelSelection,
-      isFirstMessage,
-      isHomeChatContainer,
-      isStudioContainer,
-      projects: currentStoreState.projects,
-      // Studio reference folders change the thread cwd without moving the chat out of
-      // the managed Studio project. Home-chat folder selection keeps its project routing.
-      selectedWorkspaceRoot: isHomeChatContainer ? (resolvedThreadWorktreePath ?? null) : null,
-      title,
-      titleSeed,
-    });
-    let {
-      targetProjectId: targetProjectIdForSend,
-      targetProjectKind: targetProjectKindForSend,
-      targetProjectCwd: targetProjectCwdForSend,
-      targetProjectScripts: targetProjectScriptsForSend,
-      targetProjectDefaultModelSelection: targetProjectDefaultModelSelectionForSend,
-    } = firstSendTarget.kind === "create-project"
-      ? {
-          targetProjectId: activeProject.id,
-          targetProjectKind: activeProject.kind,
-          targetProjectCwd: activeProject.cwd,
-          targetProjectScripts: activeProject.kind === "project" ? activeProject.scripts : [],
-          targetProjectDefaultModelSelection: activeProject.defaultModelSelection ?? null,
-        }
-      : firstSendTarget.target;
-    let nextRuntimeModeForSend = runtimeModeForSend;
-    let nextThreadEnvMode = envModeForSend;
-    let nextThreadBranch = isStudioContainer ? null : activeThread.branch;
-    let nextThreadWorktreePath = isStudioContainer ? null : activeThread.worktreePath;
-    let nextThreadWorkingDirectory = isStudioContainer
-      ? resolvedThreadWorkingDirectory
-      : (activeThread.workingDirectory ?? null);
-    let nextAssociatedWorktreePath = isStudioContainer
-      ? null
-      : (activeThread.associatedWorktreePath ?? null);
-    let nextAssociatedWorktreeBranch = isStudioContainer
-      ? null
-      : (activeThread.associatedWorktreeBranch ?? null);
-    let nextAssociatedWorktreeRef = isStudioContainer
-      ? null
-      : (activeThread.associatedWorktreeRef ?? null);
-    const shouldResumeSettledLocalThread =
-      isServerThread &&
-      activeThread.settledAt != null &&
-      nextThreadEnvMode === "local" &&
-      nextThreadWorktreePath === null;
-    let currentActiveGitBranchForSend = currentActiveGitBranch;
-
-    if (isFirstMessage && isContainerLandingProject && firstSendTarget.kind !== "current") {
-      if (firstSendTarget.kind === "create-project") {
-        const projectId = newProjectId();
-        const createdAt = firstSendCreatedAt.toISOString();
-        // Managed chat rows stay global; a folder mention creates an ordinary project and
-        // should inherit the Space where the first send originated. Resolved before the
-        // `try`: a value block inside a try body makes React Compiler bail out on the whole
-        // component.
-        const createProjectSpaceFields =
-          firstSendTarget.creation.kind === "project" ? { spaceId: activeSpaceIdForSend } : {};
-        try {
-          await api.orchestration.dispatchCommand({
-            type: "project.create",
-            commandId: newCommandId(),
-            projectId,
-            kind: firstSendTarget.creation.kind,
-            title: firstSendTarget.creation.title,
-            workspaceRoot: firstSendTarget.creation.workspaceRoot,
-            createWorkspaceRootIfMissing: firstSendTarget.creation.createWorkspaceRootIfMissing,
-            defaultModelSelection: firstSendTarget.creation.defaultModelSelection,
-            ...createProjectSpaceFields,
-            createdAt,
-          });
-          targetProjectIdForSend = projectId;
-          targetProjectKindForSend = firstSendTarget.creation.kind;
-          targetProjectCwdForSend = firstSendTarget.creation.workspaceRoot;
-          targetProjectScriptsForSend = [];
-          targetProjectDefaultModelSelectionForSend =
-            firstSendTarget.creation.defaultModelSelection;
-        } catch (error) {
-          const description =
-            error instanceof Error ? error.message : "Failed to create the selected project.";
-          if (!isDuplicateProjectCreateError(description)) {
-            throw error;
-          }
-
-          // If the server already knows this workspace root, reuse that project and continue.
-          const { snapshot, project: recoveredProject } =
-            await waitForRecoverableProjectForDuplicateCreate({
-              message: description,
-              workspaceRoot: firstSendTarget.creation.workspaceRoot,
-              loadSnapshot: () => api.orchestration.getShellSnapshot().catch(() => null),
-            });
-          if (!snapshot || !recoveredProject) {
-            throw error;
-          }
-
-          syncServerShellSnapshot(snapshot);
-          targetProjectIdForSend = recoveredProject.id;
-          targetProjectKindForSend = recoveredProject.kind ?? firstSendTarget.creation.kind;
-          targetProjectCwdForSend = recoveredProject.workspaceRoot;
-          targetProjectScriptsForSend =
-            (recoveredProject.kind ?? firstSendTarget.creation.kind) === "project"
-              ? [...recoveredProject.scripts]
-              : [];
-          targetProjectDefaultModelSelectionForSend =
-            recoveredProject.defaultModelSelection ??
-            firstSendTarget.creation.defaultModelSelection;
-        }
-      }
-
-      clearProjectDraftThreadId(targetProjectIdForSend);
-      setDraftThreadContext(threadIdForSend, {
-        projectId: targetProjectIdForSend,
-        envMode: "local",
-        worktreePath: null,
-        workingDirectory: null,
-        branch: null,
-      });
-      nextThreadEnvMode = "local";
-      nextThreadBranch = null;
-      nextThreadWorktreePath = null;
-      nextThreadWorkingDirectory = null;
-      nextAssociatedWorktreePath = null;
-      nextAssociatedWorktreeBranch = null;
-      nextAssociatedWorktreeRef = null;
-    }
-
-    // The branch query can finish just after the user chooses New worktree. Use the
-    // resolved active branch at send time instead of rejecting an otherwise valid fast send.
-    if (
-      isFirstMessage &&
-      nextThreadEnvMode === "worktree" &&
-      !nextThreadWorktreePath &&
-      !nextThreadBranch
-    ) {
-      nextThreadBranch = activeRootBranch ?? null;
-    }
-
-    // A settled local thread keeps its historical branch until the user resumes it, so the
-    // composer can explain the branch change. Refresh Git status before sending because the
-    // cached branch query may still be loading or may lag behind an out-of-band checkout.
-    if (shouldResumeSettledLocalThread) {
-      if (!gitBranchSourceCwd) {
-        setStoreThreadError(threadIdForSend, "Unable to determine the current branch.");
-        return false;
-      }
-
-      try {
-        const gitStatus = await queryClient.fetchQuery({
-          ...gitStatusQueryOptions(gitBranchSourceCwd),
-          staleTime: 0,
-        });
-        currentActiveGitBranchForSend = gitStatus.branch;
-      } catch {
-        setStoreThreadError(
-          threadIdForSend,
-          "Unable to determine the current branch. Try again before sending.",
-        );
-        return false;
-      }
-
-      if (currentActiveGitBranchForSend !== null) {
-        nextThreadBranch = currentActiveGitBranchForSend;
-      }
-    }
-
-    const baseBranchForWorktree =
-      isFirstMessage && nextThreadEnvMode === "worktree" && !nextThreadWorktreePath
-        ? nextThreadBranch
-        : null;
-
-    // In worktree mode, require an explicit base branch so we don't silently
-    // fall back to local execution when branch selection is missing.
-    const shouldCreateWorktree =
-      isFirstMessage && nextThreadEnvMode === "worktree" && !nextThreadWorktreePath;
-    if (shouldCreateWorktree && !nextThreadBranch) {
-      setStoreThreadError(
-        threadIdForSend,
-        "Select a base branch before sending in New worktree mode.",
-      );
-      return false;
-    }
-
-    const setupScriptForWorktree = baseBranchForWorktree
-      ? setupProjectScript(targetProjectScriptsForSend)
-      : null;
-    const worktreeSetupScriptName = setupScriptForWorktree?.name ?? null;
-    // Branching off the checkout's current branch also carries its uncommitted
-    // changes into the worktree, which the setup card surfaces as its own step.
-    const worktreeCopiesLocalChanges =
-      Boolean(baseBranchForWorktree) && baseBranchForWorktree === activeRootBranch;
-    const messageIdForSend = newMessageId();
-    const worktreeSetupResolution = baseBranchForWorktree ? createWorktreeSetupResolution() : null;
-    worktreeSetupResolutionRef.current = worktreeSetupResolution;
-    if (worktreeSetupResolution) {
-      setWorktreeSetupPendingAction(null);
-    }
-
-    sendInFlightRef.current = true;
-    beginLocalDispatch({
-      expectedUserMessageId: messageIdForSend,
-      ...(baseBranchForWorktree
-        ? {
-            worktreeSetupStepId: "create-branch" as const,
-            setupScriptName: worktreeSetupScriptName,
-            copyLocalChanges: worktreeCopiesLocalChanges,
-          }
-        : {}),
-    });
-
-    const composerImagesSnapshot = [...composerImagesForSend];
-    const composerFilesSnapshot = [...composerFilesForSend];
-    const composerAssistantSelectionsSnapshot = [...composerAssistantSelectionsForSend];
-    const composerBrowserAnnotationsSnapshot = composerBrowserAnnotationsForSend.map(
-      (annotation) => ({ ...annotation, source: { ...annotation.source } }),
-    );
-    const composerFileCommentsSnapshot = [...composerFileCommentsForSend];
-    const composerTerminalContextsSnapshot = [...sendableComposerTerminalContexts];
-    const composerPastedTextsSnapshot = [...sendableComposerPastedTexts];
-    const composerPullRequestContextsSnapshot = [...sendableComposerPullRequestContexts];
-    const composerSkillsSnapshot = [...selectedComposerSkillsForSend];
-    const composerMentionsSnapshot = [...selectedComposerMentionsForSend];
-    // Trailing blocks are appended innermost-to-outermost: assistant selections,
-    // terminal contexts, file comments, pasted text, pull request contexts, then
-    // browser annotations (outermost). The display extractors unwrap them in the
-    // reverse order.
-    const messageTextForSend = appendBrowserAnnotationsToPrompt(
-      appendPullRequestContextsToPrompt(
-        appendPastedTextsToPrompt(
-          appendFileCommentsToPrompt(
-            appendTerminalContextsToPrompt(
-              appendAssistantSelectionsToPrompt(promptForSend, composerAssistantSelectionsSnapshot),
-              composerTerminalContextsSnapshot,
-            ),
-            composerFileCommentsSnapshot,
-          ),
-          composerPastedTextsSnapshot,
-        ),
-        composerPullRequestContextsSnapshot,
-      ),
-      composerBrowserAnnotationsSnapshot,
-      messageIdForSend,
-    );
-    const messageCreatedAt = new Date().toISOString();
-    const outgoingTextSeed =
-      messageTextForSend || (composerImagesSnapshot.length > 0 ? IMAGE_ONLY_BOOTSTRAP_PROMPT : "");
-    const outgoingMessageText = formatOutgoingComposerPrompt({
-      provider: selectedProviderForSend,
-      model: selectedModelForSend,
-      effort: selectedPromptEffortForSend,
-      text: outgoingTextSeed,
-    });
-    const mentionedSkillsForSend = filterPromptSkillReferences(
-      outgoingMessageText,
-      selectedComposerSkillsForSend,
-      selectedProviderForSend,
-    );
-    const mentionedPluginMentionsForSend = filterPromptProviderMentionReferences(
-      outgoingMessageText,
-      selectedComposerMentionsForSend,
-    );
-    const turnAttachmentsPromise = stageUploadComposerAttachments({
-      threadId: threadIdForSend,
-      images: composerImagesSnapshot,
-      files: composerFilesSnapshot,
-      assistantSelections: composerAssistantSelectionsSnapshot,
-    });
-    const optimisticAttachments = [
-      ...composerAssistantSelectionsSnapshot,
-      ...composerImagesSnapshot.map((image) => ({
-        type: "image" as const,
-        id: image.id,
-        name: image.name,
-        mimeType: image.mimeType,
-        sizeBytes: image.sizeBytes,
-        previewUrl: image.previewUrl,
-      })),
-      ...composerFilesSnapshot.map((file) => ({
-        type: "file" as const,
-        id: file.id,
-        name: file.name,
-        mimeType: file.mimeType,
-        sizeBytes: file.sizeBytes,
-      })),
-    ];
-    // Sending the first message flips the centered empty landing into a normal
-    // transcript. Clear session-only landing overrides when default-open is enabled;
-    // otherwise keep the transition closed.
-    if (isCenteredEmptyLanding) {
-      setEnvironmentPanelPreferenceOpen(
-        resolveEnvironmentPanelPreferenceAfterFirstSend({
-          isCenteredEmptyLanding,
-          settingsDefaultOpen: settings.environmentPanelDefaultOpen,
-          currentPreferenceOpen: environmentPanelPreferenceOpen,
-        }),
-      );
-    }
-    setOptimisticUserMessages((existing) => [
-      ...existing,
-      {
-        id: messageIdForSend,
-        role: "user",
-        text: outgoingMessageText,
-        dispatchMode,
-        ...(optimisticAttachments.length > 0 ? { attachments: optimisticAttachments } : {}),
-        ...(mentionedSkillsForSend.length > 0 ? { skills: mentionedSkillsForSend } : {}),
-        ...(mentionedPluginMentionsForSend.length > 0
-          ? { mentions: mentionedPluginMentionsForSend }
-          : {}),
-        createdAt: messageCreatedAt,
-        streaming: false,
-        source: "native",
-      },
-    ]);
-    // Mark the transcript as anchored before the optimistic row lands. The tail
-    // anchor sizes the spacer that lets this message sit at the viewport top,
-    // and its hook owns the slide; auto-follow stays armed for bookkeeping but
-    // pauses until the in-flight flag clears.
-    armTranscriptAutoFollow(threadIdForSend, true);
-    tailAnchorScrollInFlightRef.current = true;
-    setTailAnchor({ threadId: threadIdForSend, messageId: messageIdForSend });
-
-    setThreadError(threadIdForSend, null);
-    if (expiredTerminalContextCount > 0) {
-      const toastCopy = buildExpiredTerminalContextToastCopy(
-        expiredTerminalContextCount,
-        "omitted",
-      );
-      toastManager.add({
-        type: "warning",
-        title: toastCopy.title,
-        description: toastCopy.description,
-      });
-    }
-    // Queued turns are dispatched from their captured snapshot, so this send path
-    // must not clear a separate live draft the user may already be editing.
-    if (queuedChatTurn === null) {
-      promptHistoryNavigationRef.current = null;
-      applyingPromptHistoryNavigationRef.current = false;
-      expectedPromptHistoryPromptRef.current = null;
-      promptRef.current = "";
-      clearComposerDraftContent(threadIdForSend, { preservePreviewUrls: true });
-      if (isLivePlanFollowUpSubmission) {
-        setComposerDraftInteractionMode(threadIdForSend, interactionModeForSend);
-      }
-      setComposerHighlightedItemId(null);
-      setComposerCursor(0);
-      setComposerTrigger(null);
-      // A clicked submit button steals focus; return it after the controlled
-      // draft reset so rapid follow-up typing lands in the composer.
-      scheduleComposerFocus();
-    }
-
-    let createdServerThreadForLocalDraft = false;
-    let createdWorktreeForSendPath: string | null = null;
-    let switchedToLocalCheckout = false;
-    let turnStartSucceeded = false;
-    let settledLocalBranchUpdatedForSend = false;
-    await (async () => {
-      // "Work locally" from the setup card: drop any prepared worktree and
-      // point the send (and the thread's metadata) back at the project
-      // checkout. Awaited before the turn dispatch so the session resolves the
-      // local cwd instead of the abandoned worktree.
-      const applyWorkLocallySwitch = async () => {
-        switchedToLocalCheckout = true;
-        nextThreadEnvMode = "local";
-        nextThreadBranch = null;
-        nextThreadWorktreePath = null;
-        nextAssociatedWorktreePath = null;
-        nextAssociatedWorktreeBranch = null;
-        nextAssociatedWorktreeRef = null;
-        const worktreePathToRemove = createdWorktreeForSendPath;
-        createdWorktreeForSendPath = null;
-        if (worktreePathToRemove) {
-          // Best-effort: a leftover worktree is inert and reclaimable later.
-          void api.git
-            .removeWorktree({
-              cwd: targetProjectCwdForSend,
-              path: worktreePathToRemove,
-              force: true,
-              reclaimTemporaryBranch: true,
-            })
-            .catch(() => undefined);
-        }
-        if (isServerThread || createdServerThreadForLocalDraft) {
-          await api.orchestration.dispatchCommand({
-            type: "thread.meta.update",
-            commandId: newCommandId(),
-            threadId: threadIdForSend,
-            envMode: "local",
-            branch: null,
-            worktreePath: null,
-            associatedWorktreePath: null,
-            associatedWorktreeBranch: null,
-            associatedWorktreeRef: null,
-          });
-          setStoreThreadWorkspace(threadIdForSend, {
-            envMode: "local",
-            branch: null,
-            worktreePath: null,
-            associatedWorktreePath: null,
-            associatedWorktreeBranch: null,
-            associatedWorktreeRef: null,
-          });
-        }
-        clearLocalDispatchWorktreeSetup();
-      };
-
-      // Honors a Cancel / Work locally choice at a step boundary. Cancel
-      // unwinds through the shared send-failure path below; the cancelled
-      // sentinel keeps that path from painting error state.
-      const consumeWorktreeSetupResolution = async () => {
-        const action = worktreeSetupResolution?.action ?? null;
-        if (action === null || switchedToLocalCheckout) {
-          return;
-        }
-        if (action === "cancel") {
-          throw new WorktreeSetupCancelledError();
-        }
-        await applyWorkLocallySwitch();
-      };
-
-      // On first message: lock in branch + create worktree if needed.
-      if (baseBranchForWorktree && worktreeSetupResolution) {
-        // The server streams each real setup phase (branch → worktree → copy
-        // changes); advance the card's rows from those events instead of
-        // letting one row spin through the whole creation.
-        const worktreeProgressId = randomUUID();
-        const creationFlow = await runWorktreeCreationFlow({
-          progressId: worktreeProgressId,
-          subscribeToProgress: (listener) => api.git.onWorktreeSetupProgress(listener),
-          startCreation: () =>
-            createWorktreeMutation.mutateAsync({
-              cwd: targetProjectCwdForSend,
-              ref: baseBranchForWorktree,
-              newBranch: buildTemporaryWorktreeBranchName(),
-              progressId: worktreeProgressId,
-              ...(worktreeCopiesLocalChanges ? { copyChangesFrom: targetProjectCwdForSend } : {}),
-            }),
-          resolution: worktreeSetupResolution,
-          onCreationStep: (stepId) =>
-            beginLocalDispatch({
-              worktreeSetupStepId: stepId,
-              setupScriptName: worktreeSetupScriptName,
-              copyLocalChanges: worktreeCopiesLocalChanges,
-            }),
-          removeWorktree: (worktreePath) =>
-            api.git.removeWorktree({
-              cwd: targetProjectCwdForSend,
-              path: worktreePath,
-              force: true,
-              reclaimTemporaryBranch: true,
-            }),
-        });
-        if (creationFlow.outcome === "resolved") {
-          await consumeWorktreeSetupResolution();
-        } else {
-          const result = creationFlow.result;
-          beginLocalDispatch({
-            worktreeSetupStepId: "prepare-thread",
-            setupScriptName: worktreeSetupScriptName,
-            copyLocalChanges: worktreeCopiesLocalChanges,
-          });
-          nextThreadBranch = result.worktree.branch;
-          nextThreadWorktreePath = result.worktree.path;
-          createdWorktreeForSendPath = result.worktree.path;
-          const nextAssociatedWorktree = {
-            associatedWorktreePath: result.worktree.path,
-            associatedWorktreeBranch: result.worktree.branch,
-            associatedWorktreeRef: result.worktree.ref,
-          };
-          nextAssociatedWorktreePath = nextAssociatedWorktree.associatedWorktreePath;
-          nextAssociatedWorktreeBranch = nextAssociatedWorktree.associatedWorktreeBranch;
-          nextAssociatedWorktreeRef = nextAssociatedWorktree.associatedWorktreeRef;
-          if (isServerThread) {
-            await api.orchestration.dispatchCommand({
-              type: "thread.meta.update",
-              commandId: newCommandId(),
-              threadId: threadIdForSend,
-              envMode: "worktree",
-              branch: result.worktree.branch,
-              worktreePath: result.worktree.path,
-              associatedWorktreePath: nextAssociatedWorktree.associatedWorktreePath,
-              associatedWorktreeBranch: nextAssociatedWorktree.associatedWorktreeBranch,
-              associatedWorktreeRef: nextAssociatedWorktree.associatedWorktreeRef,
-            });
-            // Keep local thread state in sync immediately so terminal drawer opens
-            // with the worktree cwd/env instead of briefly using the project root.
-            setStoreThreadWorkspace(threadIdForSend, {
-              branch: result.worktree.branch,
-              worktreePath: result.worktree.path,
-              ...nextAssociatedWorktree,
-            });
-          }
-        }
-      }
-
-      const threadCreateModelSelection: ModelSelection = buildModelSelection(
-        selectedModelSelectionForSend.provider,
-        selectedModelSelectionForSend.model ||
-          selectedModelForSend ||
-          targetProjectDefaultModelSelectionForSend?.model ||
-          getDefaultModel(selectedModelSelectionForSend.provider) ||
-          DEFAULT_MODEL_BY_PROVIDER.codex,
-        selectedModelSelectionForSend.options,
-        selectedModelSelectionForSend.provider === "claudeAgent"
-          ? selectedModelSelectionForSend.supportsAutoMode
-          : undefined,
-      );
-
-      if (isLocalDraftThread) {
-        const inheritedProjectInstructions =
-          useProjectInstructionsStore.getState().instructionsByProjectId[targetProjectIdForSend] ??
-          "";
-        const inheritedThreadNotes = mergeProjectInstructionsIntoThreadNotes({
-          threadNotes,
-          projectInstructions: inheritedProjectInstructions,
-        });
-        await promoteThreadCreate(
-          {
-            type: "thread.create",
-            commandId: newCommandId(),
-            threadId: threadIdForSend,
-            projectId: targetProjectIdForSend,
-            title,
-            modelSelection: threadCreateModelSelection,
-            runtimeMode: nextRuntimeModeForSend,
-            interactionMode: interactionModeForSend,
-            envMode: nextThreadEnvMode,
-            branch: nextThreadBranch,
-            worktreePath: nextThreadWorktreePath,
-            workingDirectory: nextThreadWorkingDirectory,
-            associatedWorktreePath: nextAssociatedWorktreePath,
-            associatedWorktreeBranch: nextAssociatedWorktreeBranch,
-            associatedWorktreeRef: nextAssociatedWorktreeRef,
-            lastKnownPr: activeThread.lastKnownPr ?? null,
-            createdAt: activeThread.createdAt,
-          },
-          api,
-        );
-        // `thread.create` does not carry notes, so seed the freshly created
-        // server thread's notepad with the inherited project instructions via a
-        // dedicated meta update. Best-effort: a failure here must not abort the turn.
-        if (inheritedThreadNotes !== threadNotes && inheritedThreadNotes.trim().length > 0) {
-          try {
-            await dispatchThreadNotes(threadIdForSend, inheritedThreadNotes);
-          } catch {
-            // Seeding is non-critical; project instructions can still be copied
-            // into the notepad manually from the Environment panel.
-          }
-        }
-        // Same for a goal staged on the draft via /goal: persist it now so the
-        // decider stamps goalStartedAt when the thread actually starts working.
-        const draftGoalForSend = activeThread.goal?.trim() ?? "";
-        if (draftGoalForSend.length > 0) {
-          try {
-            await dispatchThreadGoal(threadIdForSend, draftGoalForSend, {
-              startBehavior: "defer",
-            });
-          } catch {
-            // Non-critical: the goal can be set again with /goal on the live thread.
-          }
-        }
-        if (targetProjectKindForSend === "chat") {
-          await api.orchestration.dispatchCommand({
-            type: "project.meta.update",
-            commandId: newCommandId(),
-            projectId: targetProjectIdForSend,
-            title,
-          });
-        }
-        createdServerThreadForLocalDraft = true;
-      }
-
-      const setupScript = switchedToLocalCheckout ? null : setupScriptForWorktree;
-      if (setupScript) {
-        let shouldRunSetupScript = false;
-        if (isServerThread) {
-          shouldRunSetupScript = true;
-        } else {
-          if (createdServerThreadForLocalDraft) {
-            shouldRunSetupScript = true;
-          }
-        }
-        if (shouldRunSetupScript) {
-          beginLocalDispatch({
-            worktreeSetupStepId: "run-setup-action",
-            setupScriptName: setupScript.name,
-            copyLocalChanges: worktreeCopiesLocalChanges,
-          });
-          const setupScriptOptions: Parameters<typeof runProjectScript>[1] = {
-            worktreePath: nextThreadWorktreePath,
-            rememberAsLastInvoked: false,
-            throwOnError: true,
-          };
-          if (nextThreadWorktreePath) {
-            setupScriptOptions.cwd = nextThreadWorktreePath;
-          }
-          const setupTerminal = await runProjectScript(setupScript, setupScriptOptions);
-          if (setupTerminal) {
-            const setupActivityAbortController = new AbortController();
-            const setupActivityWait = waitForSetupScriptTerminalActivity({
-              threadId: threadIdForSend,
-              terminalId: setupTerminal.terminalId,
-              signal: setupActivityAbortController.signal,
-            });
-            // Setup scripts can run for minutes; let Cancel / Work locally win
-            // the wait. The script itself keeps running — a cancelled worktree
-            // is force-removed, a local switch just stops waiting on it.
-            await (
-              worktreeSetupResolution
-                ? Promise.race([setupActivityWait, worktreeSetupResolution.promise])
-                : setupActivityWait
-            ).finally(() => setupActivityAbortController.abort());
-          }
-        }
-      }
-      // Covers a resolution set while the thread was linked or the setup
-      // script ran (the creation-step race above only guards the first step).
-      await consumeWorktreeSetupResolution();
-
-      if (isServerThread) {
-        await persistThreadSettingsForNextTurn({
-          threadId: threadIdForSend,
-          createdAt: messageCreatedAt,
-          modelSelection: selectedModelSelectionForSend,
-          runtimeMode: nextRuntimeModeForSend,
-          interactionMode: interactionModeForSend,
-        });
-      }
-
-      const stagedTurnAttachments = await turnAttachmentsPromise;
-
-      if (
-        isServerThread &&
-        activeThread.settledAt != null &&
-        nextThreadEnvMode === "local" &&
-        nextThreadWorktreePath === null &&
-        nextThreadBranch !== activeThread.branch
-      ) {
-        await api.orchestration.dispatchCommand({
-          type: "thread.meta.update",
-          commandId: newCommandId(),
-          threadId: threadIdForSend,
-          envMode: "local",
-          branch: nextThreadBranch,
-          worktreePath: null,
-          associatedWorktreePath: nextAssociatedWorktreePath,
-          associatedWorktreeBranch: nextAssociatedWorktreeBranch,
-          associatedWorktreeRef: nextAssociatedWorktreeRef,
-        });
-        settledLocalBranchUpdatedForSend = true;
-        setStoreThreadWorkspace(threadIdForSend, {
-          envMode: "local",
-          branch: nextThreadBranch,
-          worktreePath: null,
-          associatedWorktreePath: nextAssociatedWorktreePath,
-          associatedWorktreeBranch: nextAssociatedWorktreeBranch,
-          associatedWorktreeRef: nextAssociatedWorktreeRef,
-        });
-      }
-      // Keep setup resolvable while attachment uploads are still preparing the
-      // turn. Once they settle, consume the last possible choice before the
-      // card advances to the non-resolvable "Starting session" step.
-      await consumeWorktreeSetupResolution();
-      // Carry the expected message id so a snapshot rebuilt after an interim
-      // reset (thread switch, ack effect) keeps the message-echo ack signal.
-      beginLocalDispatch({
-        expectedUserMessageId: messageIdForSend,
-        ...(baseBranchForWorktree && !switchedToLocalCheckout
-          ? {
-              worktreeSetupStepId: "start-session" as const,
-              setupScriptName: worktreeSetupScriptName,
-              copyLocalChanges: worktreeCopiesLocalChanges,
-            }
-          : {}),
-      });
-      rememberCustomBinaryPathForDispatch({
-        threadId: threadIdForSend,
-        provider: selectedModelSelectionForSend.provider,
-        providerOptions: providerOptionsForDispatchForSend,
-      });
-      await stagedTurnAttachments.runWithDispatch((turnAttachments) =>
-        api.orchestration.dispatchCommand({
-          type: "thread.turn.start",
-          commandId: newCommandId(),
-          threadId: threadIdForSend,
-          message: {
-            messageId: messageIdForSend,
-            role: "user",
-            text: outgoingMessageText,
-            attachments: turnAttachments,
-            ...(mentionedSkillsForSend.length > 0 ? { skills: mentionedSkillsForSend } : {}),
-            ...(mentionedPluginMentionsForSend.length > 0
-              ? { mentions: mentionedPluginMentionsForSend }
-              : {}),
-          },
-          modelSelection: selectedModelSelectionForSend,
-          ...(providerOptionsForDispatchForSend
-            ? { providerOptions: providerOptionsForDispatchForSend }
-            : {}),
-          assistantDeliveryMode,
-          dispatchMode,
-          runtimeMode: nextRuntimeModeForSend,
-          interactionMode: interactionModeForSend,
-          ...(sourceProposedPlanForSend ? { sourceProposedPlan: sourceProposedPlanForSend } : {}),
-          createdAt: messageCreatedAt,
-        }),
-      );
-      turnStartSucceeded = true;
-      if (
-        shouldResumeSettledLocalThread &&
-        currentActiveGitBranchForSend !== null &&
-        nextThreadBranch === currentActiveGitBranchForSend
-      ) {
-        setSettledThreadBranchWarningDismissedThreadId(threadIdForSend);
-      }
-      armLocalDispatchAckFallback(threadIdForSend);
-      // Steers on providers without native mid-turn steering interrupt the live
-      // turn before re-dispatching; hold queued auto-dispatch through that gap
-      // so it can't race the steer. The live session provider decides the
-      // interrupt path server-side, so the gate keys off it rather than the
-      // requested model selection.
-      const liveProviderForSteerGate =
-        activeThread?.session?.provider ?? selectedModelSelectionForSend.provider;
-      if (
-        dispatchMode === "steer" &&
-        !providerSupportsNativeTurnSteering(liveProviderForSteerGate)
-      ) {
-        const nextSteerGate = {
-          sawInterruptGap: false,
-          gapStartedAt: null,
-          armedActiveTurnId: activeThread?.session?.activeTurnId ?? null,
-        };
-        setQueuedSteerGate(nextSteerGate);
-        armQueuedComposerSteerGate(threadId, nextSteerGate);
-      }
-      if (sourceProposedPlanForSend) {
-        planSidebarDismissedForTurnRef.current = null;
-        setPlanSidebarOpen(true);
-      }
-      if (queuedChatTurn === null) {
-        setRestoredQueuedSourceProposedPlan(threadIdForSend, null);
-      }
-    })().catch(async (err: unknown) => {
-      // A user-cancelled worktree setup unwinds through this same rollback,
-      // but silently: no error styling on the step row, no thread error.
-      const setupCancelled = err instanceof WorktreeSetupCancelledError;
-      // Uploads start in parallel with workspace/session preparation. If any
-      // earlier step fails, settle that promise and release every staged blob.
-      await turnAttachmentsPromise.then(
-        (staged) => staged.cleanup(),
-        () => undefined,
-      );
-      // Surface the failure on whichever setup step was active (no-op for
-      // sends without a worktree setup in flight).
-      if (!setupCancelled) {
-        failLocalDispatchWorktreeSetup();
-      }
-      if (!turnStartSucceeded) {
-        // The turn RPC never resolved, so no server turn exists for the
-        // watchdog to recover — drop the marker armed when the dispatch began.
-        clearPendingTurnDispatch(threadIdForSend);
-      }
-      if (settledLocalBranchUpdatedForSend && !turnStartSucceeded) {
-        await api.orchestration
-          .dispatchCommand({
-            type: "thread.meta.update",
-            commandId: newCommandId(),
-            threadId: threadIdForSend,
-            envMode: "local",
-            branch: activeThread.branch,
-            worktreePath: null,
-            associatedWorktreePath: activeThread.associatedWorktreePath ?? null,
-            associatedWorktreeBranch: activeThread.associatedWorktreeBranch ?? null,
-            associatedWorktreeRef: activeThread.associatedWorktreeRef ?? null,
-          })
-          .then(
-            () =>
-              setStoreThreadWorkspace(threadIdForSend, {
-                envMode: "local",
-                branch: activeThread.branch,
-                worktreePath: null,
-                associatedWorktreePath: activeThread.associatedWorktreePath ?? null,
-                associatedWorktreeBranch: activeThread.associatedWorktreeBranch ?? null,
-                associatedWorktreeRef: activeThread.associatedWorktreeRef ?? null,
-              }),
-            () => undefined,
-          );
-      }
-      if (createdServerThreadForLocalDraft && !turnStartSucceeded) {
-        // This rollback cleans up a retryable draft promotion; do not tombstone the draft id.
-        await api.orchestration
-          .dispatchCommand({
-            type: "thread.delete",
-            commandId: newCommandId(),
-            threadId: threadIdForSend,
-          })
-          .catch(() => undefined);
-      }
-      if (createdWorktreeForSendPath && !turnStartSucceeded) {
-        const removed = await api.git
-          .removeWorktree({
-            cwd: targetProjectCwdForSend,
-            path: createdWorktreeForSendPath,
-            force: true,
-            reclaimTemporaryBranch: true,
-          })
-          .then(
-            () => true,
-            () => false,
-          );
-        if (removed && isServerThread) {
-          await api.orchestration
-            .dispatchCommand({
-              type: "thread.meta.update",
-              commandId: newCommandId(),
-              threadId: threadIdForSend,
-              envMode: "local",
-              branch: null,
-              worktreePath: null,
-              associatedWorktreePath: null,
-              associatedWorktreeBranch: null,
-              associatedWorktreeRef: null,
-            })
-            .then(
-              () =>
-                setStoreThreadWorkspace(threadIdForSend, {
-                  branch: null,
-                  worktreePath: null,
-                  associatedWorktreePath: null,
-                  associatedWorktreeBranch: null,
-                  associatedWorktreeRef: null,
-                }),
-              () => undefined,
-            );
-        }
-      }
-      if (queuedChatTurn !== null && !turnStartSucceeded) {
-        // The queued snapshot remains available for retry/edit after a rejected
-        // dispatch. Drop only this attempt's optimistic transcript row; its
-        // attachment preview URLs still belong to the queued snapshot.
-        setOptimisticUserMessages((existing) => {
-          const next = existing.filter((message) => message.id !== messageIdForSend);
-          return next.length === existing.length ? existing : next;
-        });
-      }
-      if (
-        queuedChatTurn === null &&
-        !turnStartSucceeded &&
-        promptRef.current.length === 0 &&
-        composerImagesRef.current.length === 0 &&
-        composerFilesRef.current.length === 0 &&
-        composerAssistantSelectionsRef.current.length === 0 &&
-        composerBrowserAnnotationsRef.current.length === 0 &&
-        composerFileCommentsRef.current.length === 0 &&
-        composerTerminalContextsRef.current.length === 0 &&
-        composerPastedTextsRef.current.length === 0 &&
-        composerPullRequestContextsRef.current.length === 0
-      ) {
-        setOptimisticUserMessages((existing) => {
-          const removed = existing.filter((message) => message.id === messageIdForSend);
-          for (const message of removed) {
-            revokeUserMessagePreviewUrls(message);
-          }
-          const next = existing.filter((message) => message.id !== messageIdForSend);
-          return next.length === existing.length ? existing : next;
-        });
-        promptRef.current = promptForSend;
-        setPrompt(promptForSend);
-        if (sourceProposedPlanForSend) {
-          setRestoredQueuedSourceProposedPlan(threadIdForSend, {
-            threadId: threadIdForSend,
-            restoredPrompt: promptForSend,
-            sourceProposedPlan: sourceProposedPlanForSend,
-          });
-        }
-        setComposerCursor(collapseExpandedComposerCursor(promptForSend, promptForSend.length));
-        addComposerImagesToDraft(composerImagesSnapshot.map(cloneComposerImageAttachment));
-        addComposerFilesToDraft(composerFilesSnapshot);
-        for (const selection of composerAssistantSelectionsSnapshot) {
-          addComposerAssistantSelectionToDraft(selection);
-        }
-        addComposerDraftBrowserAnnotations(threadIdForSend, composerBrowserAnnotationsSnapshot);
-        for (const comment of composerFileCommentsSnapshot) {
-          addComposerFileCommentToDraft(comment);
-        }
-        addComposerTerminalContextsToDraft(composerTerminalContextsSnapshot);
-        addComposerPastedTextsToDraft(composerPastedTextsSnapshot);
-        addComposerPullRequestContextsToDraft(composerPullRequestContextsSnapshot);
-        updateSelectedComposerSkills(composerSkillsSnapshot);
-        updateSelectedComposerMentions(composerMentionsSnapshot);
-        setComposerTrigger(detectComposerTrigger(promptForSend, promptForSend.length));
-      }
-      if (!setupCancelled) {
-        setThreadError(
-          threadIdForSend,
-          err instanceof Error ? err.message : "Failed to send message.",
-        );
-      }
-    });
-    sendInFlightRef.current = false;
-    worktreeSetupResolutionRef.current = null;
-    if (!turnStartSucceeded) {
-      if (baseBranchForWorktree && (worktreeSetupResolution?.action ?? null) === null) {
-        scheduleFailedWorktreeSetupDispatchReset();
-      } else {
-        // A resolved setup (cancelled, or switched to local and then failed)
-        // has no error step to hold on screen — release the marker directly.
-        resetLocalDispatch();
-      }
-    }
-    return turnStartSucceeded;
-  };
-
-  const onRespondToApproval = useCallback(
-    async (
-      requestId: ApprovalRequestId,
-      decision: ProviderApprovalDecision,
-      lifecycleGeneration?: string,
-      requestKind?: ProviderRequestKind,
-    ) => {
-      const api = readNativeApi();
-      if (!api || !activeThreadId) return;
-      const requestKey = pendingRequestInstanceKey(requestId, lifecycleGeneration);
-
-      setRespondingRequestKeys((existing) =>
-        existing.includes(requestKey) ? existing : [...existing, requestKey],
-      );
-      // Persist supervised "always allow" client-side so the next turn (after an
-      // idle-stop or runtime restart) uses full access. Auto remains the durable
-      // thread policy; its server-side override applies only to the live session.
-      const durableRuntimeMode = resolveRuntimeModeAfterApprovalDecision(
-        runtimeMode,
-        decision,
-        requestKind,
-      );
-      if (durableRuntimeMode) {
-        setComposerDraftRuntimeMode(activeThreadId, durableRuntimeMode);
-      }
-      await api.orchestration
-        .dispatchCommand({
-          type: "thread.approval.respond",
-          commandId: newCommandId(),
-          threadId: activeThreadId,
-          requestId,
-          decision,
-          ...(lifecycleGeneration !== undefined ? { lifecycleGeneration } : {}),
-          createdAt: new Date().toISOString(),
-        })
-        .catch(async (err: unknown) => {
-          if (
-            collectErrorMessages(err).some((message) =>
-              message.includes(APPROVAL_ALREADY_ANSWERED_INVARIANT_MARKER),
-            )
-          ) {
-            // The authoritative response won the race. Force a full detail
-            // snapshot so a stale local card cannot immediately submit again.
-            clearThreadDetailResumeCursor(activeThreadId);
-            await api.orchestration
-              .subscribeThread(buildThreadSubscribeInput(activeThreadId))
-              .catch(() => {
-                setStoreThreadError(
-                  activeThreadId,
-                  "Approval was already recorded, but the conversation could not be refreshed.",
-                );
-              });
-            return;
-          }
-          setStoreThreadError(
-            activeThreadId,
-            describeErrorMessage(err, "Failed to submit approval decision."),
-          );
-          setRespondingRequestKeys((existing) => existing.filter((key) => key !== requestKey));
-          throw err;
-        });
-      setRespondingRequestKeys((existing) => existing.filter((key) => key !== requestKey));
-    },
-    [activeThreadId, runtimeMode, setComposerDraftRuntimeMode, setStoreThreadError],
-  );
-
-  const userInputSubmissionsRef = useRef(new Set<string>());
-  const [userInputSubmissionVersion, setUserInputSubmissionVersion] = useState(0);
-  const onRespondToUserInput = useCallback(
-    async (
-      requestId: ApprovalRequestId,
-      answers: ProviderUserInputAnswers,
-      lifecycleGeneration?: string,
-    ) => {
-      const api = readNativeApi();
-      if (!api || !activeThreadId) return;
-      const requestKey = pendingRequestInstanceKey(requestId, lifecycleGeneration);
-      const submissionKey = `${activeThreadId}:${requestKey}`;
-      if (userInputSubmissionsRef.current.has(submissionKey)) return;
-      userInputSubmissionsRef.current.add(submissionKey);
-      setUserInputSubmissionVersion((version) => version + 1);
-      const dispatchAnswers = hasCompletePendingUserInputAnswers(answers)
-        ? answers
-        : omitNullPendingUserInputAnswers(answers);
-
-      setRespondingUserInputRequestKeys((existing) =>
-        existing.includes(requestKey) ? existing : [...existing, requestKey],
-      );
-      await Promise.resolve()
-        .then(async () => {
-          await api.orchestration.dispatchCommand({
-            type: "thread.user-input.respond",
-            commandId: newCommandId(),
-            threadId: activeThreadId,
-            requestId,
-            answers: dispatchAnswers,
-            ...(lifecycleGeneration !== undefined ? { lifecycleGeneration } : {}),
-            createdAt: new Date().toISOString(),
-          });
-          // Refresh identities and settlement after command acceptance; acceptance
-          // alone does not mean Claude received the answer.
-          clearThreadDetailResumeCursor(activeThreadId);
-          await api.orchestration.subscribeThread(buildThreadSubscribeInput(activeThreadId));
-        })
-        .catch((err: unknown) => {
-          setStoreThreadError(
-            activeThreadId,
-            describeErrorMessage(
-              err,
-              "Could not submit or refresh the answer. Your answers are saved.",
-            ),
-          );
-        })
-        .finally(() => {
-          userInputSubmissionsRef.current.delete(submissionKey);
-          setRespondingUserInputRequestKeys((existing) =>
-            existing.filter((key) => key !== requestKey),
-          );
-        });
-    },
-    [activeThreadId, setStoreThreadError],
-  );
-
-  const onCancelActivePendingUserInput = useCallback(() => {
-    if (!activePendingUserInput || activePendingIsResponding) {
-      return;
-    }
-    promptRef.current = "";
-    setPrompt("");
-    setComposerCursor(0);
-    setComposerTrigger(null);
-    void onRespondToUserInput(
-      activePendingUserInput.requestId,
-      {},
-      activePendingUserInput.lifecycleGeneration,
-    );
-  }, [activePendingIsResponding, activePendingUserInput, onRespondToUserInput, setPrompt]);
-
-  const setActivePendingUserInputQuestionIndex = useCallback(
-    (nextQuestionIndex: number) => {
-      if (!activePendingUserInputKey) {
-        return;
-      }
-      setPendingUserInputQuestionIndexByRequestId((existing) => ({
-        ...existing,
-        [activePendingUserInputKey]: nextQuestionIndex,
-      }));
-    },
-    [activePendingUserInputKey],
-  );
-
-  const onToggleActivePendingUserInputOption = useCallback(
-    (questionId: string, optionLabel: string) => {
-      if (!activePendingUserInput || !activePendingUserInputKey) {
-        return null;
-      }
-      const question = activePendingUserInput.questions.find((entry) => entry.id === questionId);
-      if (!question) {
-        return null;
-      }
-      const nextDraftAnswer = togglePendingUserInputOptionSelection(
-        question,
-        pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey]?.[questionId],
-        optionLabel,
-      );
-      const nextRequestAnswers = {
-        ...pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey],
-        [questionId]: nextDraftAnswer,
-      };
-      pendingUserInputAnswersByRequestIdRef.current = {
-        ...pendingUserInputAnswersByRequestIdRef.current,
-        [activePendingUserInputKey]: nextRequestAnswers,
-      };
-      setPendingUserInputAnswersByRequestId((existing) => ({
-        ...existing,
-        [activePendingUserInputKey]: nextRequestAnswers,
-      }));
-      promptRef.current = "";
-      setComposerCursor(0);
-      setComposerTrigger(null);
-      return nextDraftAnswer;
-    },
-    [
-      activePendingUserInput,
-      activePendingUserInputKey,
-      pendingUserInputAnswersByRequestIdRef,
-      setPendingUserInputAnswersByRequestId,
-    ],
-  );
-
-  const onChangeActivePendingUserInputCustomAnswer = useCallback(
-    (
-      questionId: string,
-      value: string,
-      nextCursor: number,
-      expandedCursor: number,
-      cursorAdjacentToMention: boolean,
-    ) => {
-      if (!activePendingUserInputKey) {
-        return;
-      }
-      promptRef.current = value;
-      const nextDraftAnswer = setPendingUserInputCustomAnswer(
-        pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey]?.[questionId],
-        value,
-      );
-      const nextRequestAnswers = {
-        ...pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey],
-        [questionId]: nextDraftAnswer,
-      };
-      pendingUserInputAnswersByRequestIdRef.current = {
-        ...pendingUserInputAnswersByRequestIdRef.current,
-        [activePendingUserInputKey]: nextRequestAnswers,
-      };
-      setPendingUserInputAnswersByRequestId((existing) => ({
-        ...existing,
-        [activePendingUserInputKey]: nextRequestAnswers,
-      }));
-      setComposerCursor(nextCursor);
-      setComposerTrigger(
-        cursorAdjacentToMention ? null : detectComposerTrigger(value, expandedCursor),
-      );
-    },
-    [
-      activePendingUserInputKey,
-      pendingUserInputAnswersByRequestIdRef,
-      setPendingUserInputAnswersByRequestId,
-    ],
-  );
-
-  const onAdvanceActivePendingUserInput = useCallback(
-    (answerOverrides?: Record<string, PendingUserInputDraftAnswer>): boolean => {
-      if (!activePendingUserInput || !activePendingUserInputKey || !activePendingProgress) {
-        return false;
-      }
-      const pendingDraftAnswers =
-        answerOverrides && Object.keys(answerOverrides).length > 0
-          ? {
-              ...pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey],
-              ...answerOverrides,
-            }
-          : (pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey] ??
-            activePendingDraftAnswers);
-      if (answerOverrides && Object.keys(answerOverrides).length > 0) {
-        pendingUserInputAnswersByRequestIdRef.current = {
-          ...pendingUserInputAnswersByRequestIdRef.current,
-          [activePendingUserInputKey]: pendingDraftAnswers,
-        };
-        setPendingUserInputAnswersByRequestId((existing) => ({
-          ...existing,
-          [activePendingUserInputKey]: pendingDraftAnswers,
-        }));
-      }
-      const resolvedAnswers = buildPendingUserInputAnswers(
-        activePendingUserInput.questions,
-        pendingDraftAnswers,
-      );
-      if (activePendingProgress.isLastQuestion) {
-        if (resolvedAnswers) {
-          void onRespondToUserInput(
-            activePendingUserInput.requestId,
-            resolvedAnswers,
-            activePendingUserInput.lifecycleGeneration,
-          );
-          return true;
-        }
-        return false;
-      }
-      const activeQuestionId = activePendingProgress.activeQuestion?.id ?? null;
-      const hasActiveOverride = activeQuestionId
-        ? answerOverrides?.[activeQuestionId] !== undefined
-        : false;
-      if (!activePendingProgress.canAdvance && !hasActiveOverride) {
-        return false;
-      }
-      setActivePendingUserInputQuestionIndex(activePendingProgress.questionIndex + 1);
-      return true;
-    },
-    [
-      activePendingDraftAnswers,
-      activePendingProgress,
-      activePendingUserInput,
-      activePendingUserInputKey,
-      onRespondToUserInput,
-      setActivePendingUserInputQuestionIndex,
-      setPendingUserInputAnswersByRequestId,
-      pendingUserInputAnswersByRequestIdRef,
-    ],
-  );
-
-  const onPreviousActivePendingUserInputQuestion = useCallback(() => {
-    if (!activePendingProgress) {
-      return;
-    }
-    setActivePendingUserInputQuestionIndex(Math.max(activePendingProgress.questionIndex - 1, 0));
-  }, [activePendingProgress, setActivePendingUserInputQuestionIndex]);
-
-  async function onSubmitPlanFollowUp({
-    text,
-    interactionMode: nextInteractionMode,
-    dispatchMode,
-    queuedTurn,
-  }: {
-    text: string;
-    interactionMode: "default" | "plan";
-    dispatchMode: "queue" | "steer";
-    queuedTurn?: QueuedComposerPlanFollowUp;
-  }): Promise<boolean> {
-    const api = readNativeApi();
-    if (
-      !api ||
-      !activeThread ||
-      !isServerThread ||
-      isSendBusy ||
-      isConnecting ||
-      sendInFlightRef.current
-    ) {
-      return false;
-    }
-
-    const trimmed = text.trim();
-    if (!trimmed) {
-      return false;
-    }
-
-    const threadIdForSend = activeThread.id;
-    const messageIdForSend = newMessageId();
-    const messageCreatedAt = new Date().toISOString();
-    const outgoingMessageText = formatOutgoingComposerPrompt({
-      provider: queuedTurn?.selectedProvider ?? selectedProvider,
-      model: queuedTurn?.selectedModel ?? selectedModel,
-      effort: queuedTurn?.selectedPromptEffort ?? selectedPromptEffort,
-      text: trimmed,
-    });
-
-    sendInFlightRef.current = true;
-    beginLocalDispatch({ expectedUserMessageId: messageIdForSend });
-    setThreadError(threadIdForSend, null);
-    setOptimisticUserMessages((existing) => [
-      ...existing,
-      {
-        id: messageIdForSend,
-        role: "user",
-        text: outgoingMessageText,
-        dispatchMode,
-        createdAt: messageCreatedAt,
-        streaming: false,
-        source: "native",
-      },
-    ]);
-    armTranscriptAutoFollow(threadIdForSend, true);
-    tailAnchorScrollInFlightRef.current = true;
-    setTailAnchor({ threadId: threadIdForSend, messageId: messageIdForSend });
-
-    // Nested function so the `try` body holds no value blocks — see the comment on
-    // `deleteEmptyTerminalThread` above for why React Compiler requires this shape.
-    const dispatchPlanFollowUpTurn = async () => {
-      await persistThreadSettingsForNextTurn({
-        threadId: threadIdForSend,
-        createdAt: messageCreatedAt,
-        modelSelection: queuedTurn?.modelSelection ?? selectedModelSelection,
-        runtimeMode: queuedTurn?.runtimeMode ?? runtimeMode,
-        interactionMode: nextInteractionMode,
-      });
-
-      // Keep the mode toggle and plan-follow-up banner in sync immediately
-      // while the same-thread implementation turn is starting.
-      setComposerDraftInteractionMode(threadIdForSend, nextInteractionMode);
-
-      const providerOptionsForPlanDispatch =
-        queuedTurn?.providerOptionsForDispatch ?? providerOptionsForDispatch;
-      const modelSelectionForPlanDispatch = queuedTurn?.modelSelection ?? selectedModelSelection;
-      const sourceProposedPlan =
-        nextInteractionMode === "default"
-          ? buildSourceProposedPlanReference({
-              threadId: activeThread.id,
-              proposedPlan: activeProposedPlan,
-            })
-          : undefined;
-      rememberCustomBinaryPathForDispatch({
-        threadId: threadIdForSend,
-        provider: modelSelectionForPlanDispatch.provider,
-        providerOptions: providerOptionsForPlanDispatch,
-      });
-      await api.orchestration.dispatchCommand({
-        type: "thread.turn.start",
-        commandId: newCommandId(),
-        threadId: threadIdForSend,
-        message: {
-          messageId: messageIdForSend,
-          role: "user",
-          text: outgoingMessageText,
-          attachments: [],
-        },
-        modelSelection: modelSelectionForPlanDispatch,
-        ...(providerOptionsForPlanDispatch
-          ? {
-              providerOptions: providerOptionsForPlanDispatch,
-            }
-          : {}),
-        assistantDeliveryMode,
-        dispatchMode,
-        runtimeMode: queuedTurn?.runtimeMode ?? runtimeMode,
-        interactionMode: nextInteractionMode,
-        ...(sourceProposedPlan ? { sourceProposedPlan } : {}),
-        createdAt: messageCreatedAt,
-      });
-      // Steers on providers without native mid-turn steering interrupt the live
-      // turn before re-dispatching; hold queued auto-dispatch through that gap
-      // so it can't race the steer. The live session provider decides the
-      // interrupt path server-side, so the gate keys off it rather than the
-      // requested model selection.
-      const livePlanProviderForSteerGate =
-        activeThread?.session?.provider ?? modelSelectionForPlanDispatch.provider;
-      if (
-        dispatchMode === "steer" &&
-        !providerSupportsNativeTurnSteering(livePlanProviderForSteerGate)
-      ) {
-        const nextSteerGate = {
-          sawInterruptGap: false,
-          gapStartedAt: null,
-          armedActiveTurnId: activeThread?.session?.activeTurnId ?? null,
-        };
-        setQueuedSteerGate(nextSteerGate);
-        armQueuedComposerSteerGate(threadId, nextSteerGate);
-      }
-      // Optimistically open the plan sidebar when implementing (not refining).
-      // "default" mode here means the agent is executing the plan, which produces
-      // step-tracking activities that the sidebar will display.
-      if (nextInteractionMode === "default") {
-        planSidebarDismissedForTurnRef.current = null;
-        setPlanSidebarOpen(true);
-      }
-    };
-
-    try {
-      await dispatchPlanFollowUpTurn();
-      armLocalDispatchAckFallback(threadIdForSend);
-      sendInFlightRef.current = false;
-      return true;
-    } catch (err) {
-      setOptimisticUserMessages((existing) =>
-        existing.filter((message) => message.id !== messageIdForSend),
-      );
-      setThreadError(
-        threadIdForSend,
-        err instanceof Error ? err.message : "Failed to send plan follow-up.",
-      );
-      sendInFlightRef.current = false;
-      // The turn RPC failed, so no server turn exists for the watchdog to
-      // recover — drop the marker armed when the dispatch began.
-      clearPendingTurnDispatch(threadIdForSend);
-      resetLocalDispatch();
-      return false;
-    }
-  }
-
-  const onEditUserMessage = useCallback(
-    async (messageId: MessageId, text: string): Promise<boolean> => {
-      const api = readNativeApi();
-      if (!api || !activeThread || !isServerThread || isRevertingCheckpoint) {
-        return false;
-      }
-      const editTarget = resolveTailUserMessageEditTarget({
-        messages: activeThread.messages,
-        messageId,
-        activeTurnId:
-          activeThread.session?.orchestrationStatus === "running"
-            ? (activeThread.session.activeTurnId ?? null)
-            : null,
-      });
-      if (!editTarget.editable) {
-        setThreadError(activeThread.id, "Only the latest rollbackable user message can be edited.");
-        return false;
-      }
-      const originalMessage = activeThread.messages[editTarget.messageIndex];
-      if (!originalMessage || originalMessage.role !== "user") {
-        setThreadError(activeThread.id, "Only the latest rollbackable user message can be edited.");
-        return false;
-      }
-      if (isSendBusy || isConnecting || sendInFlightRef.current) {
-        setThreadError(activeThread.id, "Wait for the current send to start before editing.");
-        return false;
-      }
-
-      setIsRevertingCheckpoint(true);
-      setThreadError(activeThread.id, null);
-      const messageCreatedAt = new Date().toISOString();
-      const editedTextWithOriginalContext = appendOriginalComposerPromptBlocks({
-        editedPrompt: text,
-        originalPrompt: originalMessage.text,
-        messageId,
-      });
-      const outgoingMessageText = formatOutgoingComposerPrompt({
-        provider: selectedProvider,
-        model: selectedModel,
-        effort: selectedPromptEffort,
-        text: editedTextWithOriginalContext,
-      });
-      return await (async () => {
-        await persistThreadSettingsForNextTurn({
-          threadId: activeThread.id,
-          createdAt: messageCreatedAt,
-          modelSelection: selectedModelSelection,
-          runtimeMode,
-          interactionMode,
-        });
-        await api.orchestration.dispatchCommand({
-          type: "thread.message.edit-and-resend",
-          commandId: newCommandId(),
-          threadId: activeThread.id,
-          messageId,
-          text: outgoingMessageText,
-          modelSelection: selectedModelSelection,
-          ...(providerOptionsForDispatch ? { providerOptions: providerOptionsForDispatch } : {}),
-          assistantDeliveryMode,
-          runtimeMode,
-          interactionMode,
-          createdAt: messageCreatedAt,
-        });
-        return true;
-      })()
-        .catch((err: unknown) => {
-          setThreadError(
-            activeThread.id,
-            err instanceof Error ? err.message : "Failed to edit message.",
-          );
-          return false;
-        })
-        .finally(() => {
-          setIsRevertingCheckpoint(false);
-        });
-    },
-    [
-      activeThread,
-      isConnecting,
-      isRevertingCheckpoint,
-      isSendBusy,
-      isServerThread,
-      interactionMode,
-      persistThreadSettingsForNextTurn,
-      providerOptionsForDispatch,
-      runtimeMode,
-      selectedModel,
-      selectedModelSelection,
-      selectedPromptEffort,
-      selectedProvider,
-      setThreadError,
-      assistantDeliveryMode,
-    ],
-  );
-
-  const dispatchQueuedComposerTurn = useCallback(
-    async (queuedTurn: QueuedComposerTurn, dispatchMode: "queue" | "steer"): Promise<boolean> => {
-      const lateSendHandlers = lateComposerSendHandlersRef.current;
-      if (!lateSendHandlers) {
-        return false;
-      }
-      if (queuedTurn.kind === "chat") {
-        return lateSendHandlers.send(undefined, dispatchMode, queuedTurn);
-      }
-      return lateSendHandlers.submitPlanFollowUp({
-        text: queuedTurn.text,
-        interactionMode: queuedTurn.interactionMode,
-        dispatchMode,
-        queuedTurn,
-      });
-    },
-    [],
-  );
-
-  // Resuming a workflow is a normal composer turn instructing the agent to
-  // re-invoke the Workflow tool against the persisted script; completed agent()
-  // calls replay from cache, so a paused run picks up where it stopped. Sent as
-  // a pre-built chat turn so it takes the exact send path a queued turn does.
-  const onResumeWorkflowRun = useCallback(async () => {
-    if (!workflowRunState?.scriptPath || !workflowRunState.runId) return;
-    const lateSendHandlers = lateComposerSendHandlersRef.current;
-    if (!lateSendHandlers) return;
-    const { workflowTaskId } = workflowRunState;
-    const prompt = buildWorkflowResumePrompt(workflowRunState.scriptPath, workflowRunState.runId);
-    const sent = await lateSendHandlers.send(undefined, "queue", {
-      id: randomUUID(),
-      kind: "chat",
-      createdAt: new Date().toISOString(),
-      previewText: prompt,
-      prompt,
-      images: [],
-      files: [],
-      assistantSelections: [],
-      browserAnnotations: [],
-      terminalContexts: [],
-      fileComments: [],
-      pastedTexts: [],
-      pullRequestContexts: [],
-      skills: [],
-      mentions: [],
-      selectedProvider,
-      selectedModel,
-      selectedPromptEffort,
-      modelSelection: selectedModelSelection,
-      ...(providerOptionsForDispatch ? { providerOptionsForDispatch } : {}),
-      runtimeMode,
-      interactionMode,
-      envMode,
-    });
-    if (sent && activeThreadId) {
-      markWorkflowRunDismissed(activeThreadId, workflowTaskId);
-    }
-  }, [
-    activeThreadId,
-    envMode,
-    interactionMode,
-    markWorkflowRunDismissed,
-    providerOptionsForDispatch,
-    runtimeMode,
-    selectedModel,
-    selectedModelSelection,
-    selectedPromptEffort,
-    selectedProvider,
-    workflowRunState,
-  ]);
-
-  const onSteerQueuedComposerTurn = useCallback(
-    async (queuedTurn: QueuedComposerTurn) => {
-      const previousQueue = queuedComposerTurnsRef.current;
-      const queuedIndex = previousQueue.findIndex((entry) => entry.id === queuedTurn.id);
-      if (queuedIndex < 0) {
-        return;
-      }
-      removeQueuedComposerTurnFromDraft(threadId, queuedTurn.id);
-      const succeeded = await dispatchQueuedComposerTurn(queuedTurn, "steer");
-      if (succeeded) {
-        clearQueuedComposerAutoDispatchRetry(threadId);
-        return;
-      }
-      insertQueuedComposerTurn(threadId, queuedTurn, queuedIndex);
-      recordQueuedComposerAutoDispatchFailure(threadId, queuedTurn.id);
-      setQueuedAutoDispatchTick((tick) => tick + 1);
-    },
-    [
-      dispatchQueuedComposerTurn,
-      insertQueuedComposerTurn,
-      removeQueuedComposerTurnFromDraft,
-      threadId,
-    ],
-  );
-
-  const onEditQueuedComposerTurn = useCallback(
-    (queuedTurn: QueuedComposerTurn) => {
-      removeQueuedComposerTurn(queuedTurn.id);
-      restoreQueuedTurnToComposer(queuedTurn);
-    },
-    [removeQueuedComposerTurn, restoreQueuedTurnToComposer],
-  );
-
-  // Advance/expire the steer gate as the session moves through the
-  // interrupt→steered-turn handoff (or fails out of it).
-  const sessionErroredForSteerGate = activeThread?.session?.status === "error";
-  const activeTurnIdForSteerGate = activeThread?.session?.activeTurnId ?? null;
-  useEffect(() => {
-    if (!queuedSteerGate) {
-      return;
-    }
-    const transition = resolveQueuedSteerGateTransition({
-      gate: queuedSteerGate,
-      phase,
-      sessionErrored: sessionErroredForSteerGate,
-      activeTurnId: activeTurnIdForSteerGate,
-      now: Date.now(),
-    });
-    if (transition.kind === "clear") {
-      setQueuedSteerGate(null);
-      clearQueuedComposerSteerGate(threadId);
-      return;
-    }
-    if (
-      transition.gate.sawInterruptGap !== queuedSteerGate.sawInterruptGap ||
-      transition.gate.gapStartedAt !== queuedSteerGate.gapStartedAt ||
-      transition.gate.armedActiveTurnId !== queuedSteerGate.armedActiveTurnId
-    ) {
-      setQueuedSteerGate(transition.gate);
-      armQueuedComposerSteerGate(threadId, transition.gate);
-      return;
-    }
-    if (transition.expiresInMs === null) {
-      return;
-    }
-    const timer = window.setTimeout(() => {
-      setQueuedSteerGate(null);
-      clearQueuedComposerSteerGate(threadId);
-    }, transition.expiresInMs);
-    return () => window.clearTimeout(timer);
-  }, [activeTurnIdForSteerGate, phase, queuedSteerGate, sessionErroredForSteerGate, threadId]);
-
-  useEffect(() => {
-    if (
-      isQueuedComposerAwaitingTurnStart(threadId) ||
-      resolveQueuedComposerAutoDispatchHold({
-        localDispatch,
-        // A mini-composer submission queues the first turn before the draft has a session.
-        phase: isLocalDraftThread ? "ready" : phase,
-        latestTurn: activeLatestTurn,
-        session: activeThread?.session ?? null,
-        messages: activeThread?.messages ?? EMPTY_MESSAGES,
-        isConnecting,
-        queuedSteerGate: getQueuedComposerSteerGate(threadId) ?? queuedSteerGate,
-        hasPendingApproval: activePendingApproval !== null,
-        hasPendingProgress: activePendingProgress !== null,
-        hasPendingUserInput: pendingUserInputs.length > 0,
-        queuedTurnCount: queuedComposerTurns.length,
-        threadError: activeThread?.error,
-        now: Date.now(),
-      })
-    ) {
-      return;
-    }
-    if (
-      autoDispatchingQueuedTurnRef.current ||
-      sendInFlightRef.current ||
-      sendPreflightInFlightRef.current
-    ) {
-      // These guards are refs, so nothing re-triggers this effect once they
-      // reset; poll until the in-flight send settles instead of leaving the
-      // queue stuck at the end of a turn.
-      const timer = window.setTimeout(() => setQueuedAutoDispatchTick((tick) => tick + 1), 250);
-      return () => window.clearTimeout(timer);
-    }
-    const nextQueuedTurn = queuedComposerTurns[0];
-    if (!nextQueuedTurn) {
-      return;
-    }
-    const retryDelay = getQueuedComposerAutoDispatchRetryDelay(threadId, nextQueuedTurn.id);
-    if (retryDelay === null) {
-      return;
-    }
-    if (retryDelay !== undefined && retryDelay > 0) {
-      const timer = window.setTimeout(
-        () => setQueuedAutoDispatchTick((tick) => tick + 1),
-        retryDelay,
-      );
-      return () => window.clearTimeout(timer);
-    }
-    if (!tryBeginQueuedComposerAutoDispatch(threadId)) {
-      // The watcher already owns this thread's queue head (background drain
-      // started before this ChatView claimed). Poll until that send settles.
-      const timer = window.setTimeout(() => setQueuedAutoDispatchTick((tick) => tick + 1), 250);
-      return () => window.clearTimeout(timer);
-    }
-    autoDispatchingQueuedTurnRef.current = true;
-    void runLockedQueuedComposerAutoDispatch({
-      threadId,
-      run: async () => {
-        const succeeded = await dispatchQueuedComposerTurn(nextQueuedTurn, "queue");
-        if (succeeded) {
-          clearQueuedComposerAutoDispatchRetry(threadId);
-          removeQueuedComposerTurnFromDraft(threadId, nextQueuedTurn.id);
-          return;
-        }
-        recordQueuedComposerAutoDispatchFailure(threadId, nextQueuedTurn.id);
-        setQueuedAutoDispatchTick((tick) => tick + 1);
-      },
-      onSettled: () => {
-        autoDispatchingQueuedTurnRef.current = false;
-      },
-    });
-  }, [
+  const {
+    setQueuedSteerGate,
+    removeQueuedComposerTurn,
+    onSteerQueuedComposerTurn,
+    onEditQueuedComposerTurn,
+  } = useChatQueuedTurns({
+    threadId,
+    queuedComposerTurns,
+    activeThread,
+    promptRef,
+    clearComposerDraftContent,
+    setComposerDraftPrompt,
+    setDraftThreadContext,
+    addComposerImagesToDraft,
+    addComposerFilesToDraft,
+    addComposerAssistantSelectionToDraft,
+    addComposerDraftBrowserAnnotations,
+    addComposerFileCommentToDraft,
+    addComposerTerminalContextsToDraft,
+    addComposerPastedTextsToDraft,
+    addComposerPullRequestContextsToDraft,
+    updateSelectedComposerSkills,
+    updateSelectedComposerMentions,
+    setRestoredQueuedSourceProposedPlan,
+    setComposerDraftModelSelection,
+    setComposerDraftRuntimeMode,
+    setComposerDraftInteractionMode,
+    setComposerCursor,
+    setComposerTrigger,
+    scheduleComposerFocus,
+    removeQueuedComposerTurnFromDraft,
+    lateComposerSendHandlersRef,
+    insertQueuedComposerTurn,
+    phase,
+    localDispatch,
+    isLocalDraftThread,
     activeLatestTurn,
+    isConnecting,
     activePendingApproval,
     activePendingProgress,
-    activeThread?.error,
-    activeThread?.messages,
-    activeThread?.session,
-    dispatchQueuedComposerTurn,
-    isConnecting,
-    isLocalDraftThread,
-    localDispatch,
-    pendingUserInputs.length,
-    phase,
-    queuedAutoDispatchTick,
-    queuedComposerTurns,
-    queuedSteerGate,
-    removeQueuedComposerTurnFromDraft,
+    pendingUserInputs,
+    sendInFlightRef,
+    sendPreflightInFlightRef,
+  });
+
+  const { onSend } = useChatTurnSubmission({
     threadId,
-  ]);
-
-  const onImplementPlanInNewThread = useCallback(async () => {
-    const api = readNativeApi();
-    if (
-      !api ||
-      !activeThread ||
-      !activeProject ||
-      !activeProposedPlan ||
-      !isServerThread ||
-      isSendBusy ||
-      isConnecting ||
-      sendInFlightRef.current
-    ) {
-      return;
-    }
-
-    const createdAt = new Date().toISOString();
-    const nextThreadId = newThreadId();
-    const planMarkdown = activeProposedPlan.planMarkdown;
-    const implementationPrompt = buildPlanImplementationPrompt(planMarkdown);
-    const outgoingImplementationPrompt = formatOutgoingComposerPrompt({
-      provider: selectedProvider,
-      model: selectedModel,
-      effort: selectedPromptEffort,
-      text: implementationPrompt,
-    });
-    const nextThreadTitle = truncateTitle(buildPlanImplementationThreadTitle(planMarkdown));
-    const nextThreadModelSelection: ModelSelection = selectedModelSelection;
-    const sourceProposedPlan = buildSourceProposedPlanReference({
-      threadId: activeThread.id,
-      proposedPlan: activeProposedPlan,
-    });
-
-    sendInFlightRef.current = true;
-    beginLocalDispatch();
-    const finish = () => {
-      sendInFlightRef.current = false;
-      resetLocalDispatch();
-    };
-
-    await api.orchestration
-      .dispatchCommand({
-        type: "thread.create",
-        commandId: newCommandId(),
-        threadId: nextThreadId,
-        projectId: activeProject.id,
-        title: nextThreadTitle,
-        modelSelection: nextThreadModelSelection,
-        runtimeMode,
-        interactionMode: "default",
-        envMode: activeThread.envMode ?? (activeThread.worktreePath ? "worktree" : "local"),
-        branch: activeThread.branch,
-        worktreePath: activeThread.worktreePath,
-        workingDirectory: activeThread.workingDirectory ?? null,
-        lastKnownPr: activeThread.lastKnownPr ?? null,
-        associatedWorktreePath: activeThreadAssociatedWorktree.associatedWorktreePath,
-        associatedWorktreeBranch: activeThreadAssociatedWorktree.associatedWorktreeBranch,
-        associatedWorktreeRef: activeThreadAssociatedWorktree.associatedWorktreeRef,
-        createdAt,
-      })
-      .then(() => {
-        rememberCustomBinaryPathForDispatch({
-          threadId: nextThreadId,
-          provider: selectedModelSelection.provider,
-          providerOptions: providerOptionsForDispatch,
-        });
-        return api.orchestration.dispatchCommand({
-          type: "thread.turn.start",
-          commandId: newCommandId(),
-          threadId: nextThreadId,
-          message: {
-            messageId: newMessageId(),
-            role: "user",
-            text: outgoingImplementationPrompt,
-            attachments: [],
-          },
-          modelSelection: selectedModelSelection,
-          ...(providerOptionsForDispatch ? { providerOptions: providerOptionsForDispatch } : {}),
-          assistantDeliveryMode,
-          dispatchMode: "queue",
-          runtimeMode,
-          interactionMode: "default",
-          ...(sourceProposedPlan ? { sourceProposedPlan } : {}),
-          createdAt,
-        });
-      })
-      .then(() => {
-        // The turn RPC resolved for a thread this view never made active, so
-        // arm the watchdog marker with that exact thread id before navigation.
-        markPendingTurnDispatch(nextThreadId);
-        return api.orchestration.getShellSnapshot();
-      })
-      .then((snapshot) => {
-        syncServerShellSnapshot(snapshot);
-        // Signal that the plan sidebar should open on the new thread.
-        planSidebarOpenOnNextThreadRef.current = true;
-        return navigate({
-          to: "/$threadId",
-          params: { threadId: nextThreadId },
-        });
-      })
-      .catch(async (err) => {
-        const deletedOnServer = await api.orchestration
-          .dispatchCommand({
-            type: "thread.delete",
-            commandId: newCommandId(),
-            threadId: nextThreadId,
-          })
-          .then(() => true)
-          .catch(() => false);
-        if (deletedOnServer) {
-          clearPendingTurnDispatch(nextThreadId);
-          void reconcileDeletedThreadFromClient({
-            threadId: nextThreadId,
-            removeDeletedThreadFromClientState:
-              useStore.getState().removeDeletedThreadFromClientState,
-          });
-        }
-        toastManager.add({
-          type: "error",
-          title: "Could not start implementation thread",
-          description:
-            err instanceof Error ? err.message : "An error occurred while creating the new thread.",
-        });
-      })
-      .then(finish, finish);
-  }, [
-    activeProject,
-    activeProposedPlan,
+    hasLiveTurn,
+    lateComposerSendHandlersRef,
     activeThread,
-    activeThreadAssociatedWorktree,
-    beginLocalDispatch,
     isConnecting,
-    isSendBusy,
-    isServerThread,
-    navigate,
-    resetLocalDispatch,
+    sendPreflightInFlightRef,
+    sendInFlightRef,
     runtimeMode,
+    interactionMode,
+    envMode,
+    showPlanFollowUpPrompt,
+    activeProposedPlan,
+    hasQueueableLiveTurn,
+    clearComposerInput,
+    scheduleComposerFocus,
+    activeProject,
+    threadWorkspaceCwd,
+    refreshProviderStatuses,
+    isServerThread,
+    hasNativeUserMessages,
+    chatWorkspaceRoot,
+    isHomeChatContainer,
+    isStudioContainer,
+    resolvedThreadWorktreePath,
+    resolvedThreadWorkingDirectory,
+    currentActiveGitBranch,
+    isContainerLandingProject,
+    syncServerShellSnapshot,
+    activeRootBranch,
+    gitBranchSourceCwd,
+    setStoreThreadError,
+    queryClient,
+    isCenteredEmptyLanding,
+    setEnvironmentPanelPreferenceOpen,
+    environmentPanelPreferenceOpen,
+    setTailAnchor,
+    setThreadError,
+    setComposerHighlightedItemId,
+    setStoreThreadWorkspace,
+    createWorktreeMutation,
+    isLocalDraftThread,
+    threadNotes,
+    assistantDeliveryMode,
+    setSettledThreadBranchWarningDismissedThreadId,
+    setQueuedSteerGate,
+    planSidebarDismissedForTurnRef,
+    setPlanSidebarOpen,
+    settings,
+    isSendBusy,
+    worktreeSetupResolutionRef,
+    setWorktreeSetupPendingAction,
+    beginLocalDispatch,
+    clearLocalDispatchWorktreeSetup,
+    armLocalDispatchAckFallback,
+    failLocalDispatchWorktreeSetup,
+    scheduleFailedWorktreeSetupDispatchReset,
+    resetLocalDispatch,
+    isVoiceTranscribing,
+    waitForPendingComposerImages,
+    activePendingProgress,
+    activePendingUserInputKey,
+    pendingUserInputAnswersByRequestIdRef,
+    setPendingUserInputAnswersByRequestId,
+    composerEditorRef,
+    promptRef,
+    composerImages,
+    composerFiles,
+    composerAssistantSelections,
+    composerBrowserAnnotations,
+    composerFileComments,
+    composerTerminalContexts,
+    composerPastedTexts,
+    composerPullRequestContexts,
+    restoredQueuedSourceProposedPlanRef,
+    enqueueQueuedComposerTurn,
+    setComposerDraftPrompt,
+    setComposerTrigger,
+    clearProjectDraftThreadId,
+    setDraftThreadContext,
+    promptHistoryNavigationRef,
+    applyingPromptHistoryNavigationRef,
+    expectedPromptHistoryPromptRef,
+    clearComposerDraftContent,
+    setComposerDraftInteractionMode,
+    setComposerCursor,
+    setRestoredQueuedSourceProposedPlan,
+    composerImagesRef,
+    composerFilesRef,
+    composerAssistantSelectionsRef,
+    composerBrowserAnnotationsRef,
+    composerFileCommentsRef,
+    composerTerminalContextsRef,
+    composerPastedTextsRef,
+    composerPullRequestContextsRef,
+    setPrompt,
+    addComposerImagesToDraft,
+    addComposerFilesToDraft,
+    addComposerAssistantSelectionToDraft,
+    addComposerDraftBrowserAnnotations,
+    addComposerFileCommentToDraft,
+    addComposerTerminalContextsToDraft,
+    addComposerPastedTextsToDraft,
+    addComposerPullRequestContextsToDraft,
+    selectedComposerSkillsRef,
+    selectedComposerMentionsRef,
+    updateSelectedComposerSkills,
+    updateSelectedComposerMentions,
+    selectedProvider,
+    selectedModel,
     selectedPromptEffort,
     selectedModelSelection,
     providerOptionsForDispatch,
+    pendingAutomationConversationRef,
+    setPendingAutomationConversation,
+    pendingAutomationConversation,
+    activeThreadIdRef,
+    hasLiveTurnRef,
+    automationProjects,
+    setAutomationDraftWarningContext,
+    setAutomationDraftForm,
+    setAutomationDraftWarnings,
+    setAcknowledgedAutomationWarnings,
+    setAutomationDraftOpen,
+    armTranscriptAutoFollow,
+    tailAnchorScrollInFlightRef,
+    prepareAutomationFormForCreate,
+    createAutomationFromForm,
+    providerStatuses,
     rememberCustomBinaryPathForDispatch,
-    selectedProvider,
+    setOptimisticUserMessages,
+    runProjectScript,
+    persistThreadSettingsForNextTurn,
+  });
+
+  const {
+    onSubmitPlanFollowUp,
+    onEditUserMessage,
+    onResumeWorkflowRun,
+    onImplementPlanInNewThread,
+  } = useChatTurnFollowUps({
+    threadId,
+    activeThread,
+    isServerThread,
+    isConnecting,
+    sendInFlightRef,
+    setThreadError,
+    setTailAnchor,
+    runtimeMode,
+    activeProposedPlan,
     assistantDeliveryMode,
-    syncServerShellSnapshot,
+    setQueuedSteerGate,
+    planSidebarDismissedForTurnRef,
+    setPlanSidebarOpen,
+    isRevertingCheckpoint,
+    setIsRevertingCheckpoint,
+    interactionMode,
+    isSendBusy,
+    beginLocalDispatch,
+    armLocalDispatchAckFallback,
+    resetLocalDispatch,
+    selectedProvider,
     selectedModel,
-  ]);
+    selectedPromptEffort,
+    selectedModelSelection,
+    providerOptionsForDispatch,
+    setOptimisticUserMessages,
+    armTranscriptAutoFollow,
+    tailAnchorScrollInFlightRef,
+    persistThreadSettingsForNextTurn,
+    setComposerDraftInteractionMode,
+    rememberCustomBinaryPathForDispatch,
+    workflowRunState,
+    lateComposerSendHandlersRef,
+    envMode,
+    activeThreadId,
+    markWorkflowRunDismissed,
+    activeProject,
+    activeThreadAssociatedWorktree,
+    syncServerShellSnapshot,
+    planSidebarOpenOnNextThreadRef,
+    navigate,
+  });
 
   const setPromptFromTraits = useCallback(
     (nextPrompt: string) => {
@@ -9960,7 +3925,7 @@ export default function ChatView({
       setComposerTrigger(detectComposerTrigger(nextPrompt, nextPrompt.length));
       scheduleComposerFocus();
     },
-    [scheduleComposerFocus, setPrompt],
+    [promptRef, setComposerCursor, setComposerTrigger, scheduleComposerFocus, setPrompt],
   );
   const selectedProviderModelOptions = composerModelOptions?.[selectedProvider];
   const composerTraitSelection = getComposerTraitSelection(
@@ -10027,12 +3992,18 @@ export default function ChatView({
     composerFooterTierRef.current = 0;
     setComposerFooterTier(0);
     composerFooterLayoutSyncRef.current?.();
-  }, [composerFooterPlanInputsKey]);
+  }, [
+    setComposerFooterTier,
+    composerFooterTierRef,
+    composerFooterDemotionWidthsRef,
+    composerFooterLayoutSyncRef,
+    composerFooterPlanInputsKey,
+  ]);
   // After a tier renders, re-measure before paint: a still-overflowing footer
   // demotes another step until it fits (bounded by COMPOSER_FOOTER_MAX_TIER).
   useLayoutEffect(() => {
     composerFooterLayoutSyncRef.current?.();
-  }, [composerFooterTier]);
+  }, [composerFooterLayoutSyncRef, composerFooterTier]);
   const composerModelPickerWidthClassName = isComposerFooterCompact ? "w-32" : "w-36 sm:w-44";
   const composerOptionsPickerWidthClassName = isComposerFooterCompact ? "w-28" : "w-32";
   const composerModelEffortPickerWidthClassName = isComposerFooterCompact ? "w-40" : "w-44 sm:w-52";
@@ -10046,7 +4017,7 @@ export default function ChatView({
         setIsTraitsPickerOpen(false);
       }
     },
-    [handleModelPickerOpenChange],
+    [setIsModelPickerOpen, setIsTraitsPickerOpen, handleModelPickerOpenChange],
   );
   const composerPickerControls = showComposerModelBootstrapSkeleton ? (
     useSplitComposerPickerControls ? (
@@ -10152,508 +4123,53 @@ export default function ChatView({
     setComposerDraftProviderModelOptions,
     threadId,
   ]);
-  const onEnvModeChange = useCallback(
-    (mode: DraftThreadEnvMode) => {
-      if (activeProject) {
-        useProjectEnvironmentStore.getState().setProjectEnvMode(activeProject.id, mode);
-      }
-      const nextBranch =
-        mode === "worktree"
-          ? (activeThread?.branch ?? draftThread?.branch ?? activeRootBranch ?? null)
-          : (activeThread?.branch ?? draftThread?.branch ?? null);
-      if (isLocalDraftThread) {
-        setDraftThreadContext(threadId, {
-          envMode: mode,
-          ...(mode === "local" ? { worktreePath: null } : {}),
-          ...(nextBranch ? { branch: nextBranch } : {}),
-        });
-      }
-      if (isServerThread && activeThread && !hasNativeUserMessages && !activeThread.session) {
-        const api = readNativeApi();
-        if (api) {
-          void api.orchestration.dispatchCommand({
-            type: "thread.meta.update",
-            commandId: newCommandId(),
-            threadId,
-            envMode: mode,
-            ...(nextBranch ? { branch: nextBranch } : {}),
-            ...(mode === "local" ? { worktreePath: null } : {}),
-          });
-        }
-      }
-      scheduleComposerFocus();
-    },
-    [
-      activeProject,
-      activeThread,
-      activeRootBranch,
-      draftThread?.branch,
-      hasNativeUserMessages,
-      isLocalDraftThread,
-      isServerThread,
-      scheduleComposerFocus,
-      setDraftThreadContext,
-      threadId,
-    ],
-  );
-
-  const moveEmptyDraftToLocalProject = useCallback(
-    (
-      projectId: ProjectId,
-      options?: {
-        restoreComposerFocus?: boolean;
-      },
-    ) => {
-      // Project moves reset branch; the previous project's current branch may not exist here.
-      moveDraftThreadToProject(threadId, projectId, LOCAL_PROJECT_DRAFT_CONTEXT);
-      if (options?.restoreComposerFocus ?? true) {
-        scheduleComposerFocus();
-      }
-    },
-    [moveDraftThreadToProject, scheduleComposerFocus, threadId],
-  );
-
-  const handleResetWorkspaceToHome = useCallback(() => {
-    // The inline reset action prevents pointer-down from stealing editor focus. Avoid refocusing
-    // an already-focused editor: focusAtEnd would move its cursor and schedule a redundant frame.
-    // Picker-menu resets still restore focus because the editor is no longer active in that path.
-    const restoreComposerFocus = !composerEditorRef.current?.isFocused();
-    if (isLocalDraftThread) {
-      if (isStudioContainer) {
-        setDraftThreadContext(threadId, {
-          envMode: "local",
-          branch: null,
-          worktreePath: null,
-          workingDirectory: null,
-          lastKnownPr: null,
-        });
-        if (restoreComposerFocus) {
-          scheduleComposerFocus();
-        }
-        return;
-      }
-      if (!isHomeChatContainer) {
-        return (async () => {
-          if (!homeDir) {
-            throw new Error("Home folder is not available yet.");
-          }
-          const homeProjectId = await ensureHomeChatProject({ homeDir, chatWorkspaceRoot });
-          if (!homeProjectId) {
-            throw new Error("Unable to prepare a normal chat.");
-          }
-          const api = readNativeApi();
-          if (!api) {
-            throw new Error("App is still connecting. Try again in a moment.");
-          }
-          const hasHomeProjectInStore = useStore
-            .getState()
-            .projects.some((project) => project.id === homeProjectId);
-          if (!hasHomeProjectInStore) {
-            const { project, snapshot } = await waitForShellProjectById(api, homeProjectId);
-            if (!project || !snapshot) {
-              throw new Error(PROJECT_CREATE_SYNC_ERROR);
-            }
-            syncServerShellSnapshot(snapshot);
-          }
-          moveEmptyDraftToLocalProject(homeProjectId, { restoreComposerFocus });
-        })();
-      }
-      setDraftThreadContext(threadId, {
-        envMode: "local",
-        worktreePath: null,
-        workingDirectory: null,
-        branch: null,
-        lastKnownPr: null,
-      });
-      if (restoreComposerFocus) {
-        scheduleComposerFocus();
-      }
-      return;
-    }
-
-    if (activeThread) {
-      setStoreThreadWorkspace(activeThread.id, {
-        envMode: "local",
-        worktreePath: null,
-        ...(isStudioContainer ? { workingDirectory: null } : {}),
-      });
-      const api = readNativeApi();
-      if (api && !hasNativeUserMessages && !activeThread.session) {
-        void api.orchestration.dispatchCommand({
-          type: "thread.meta.update",
-          commandId: newCommandId(),
-          threadId: activeThread.id,
-          envMode: "local",
-          worktreePath: null,
-          ...(isStudioContainer ? { workingDirectory: null } : {}),
-        });
-      }
-    }
-    if (restoreComposerFocus) {
-      scheduleComposerFocus();
-    }
-  }, [
-    activeThread,
-    chatWorkspaceRoot,
-    hasNativeUserMessages,
-    homeDir,
-    isHomeChatContainer,
-    isLocalDraftThread,
-    isStudioContainer,
-    moveEmptyDraftToLocalProject,
-    scheduleComposerFocus,
-    setDraftThreadContext,
-    setStoreThreadWorkspace,
-    studioWorkspaceRoot,
-    syncServerShellSnapshot,
+  const {
+    onEnvModeChange,
+    handleResetWorkspaceToHome,
+    handleSelectWorkspaceRoot,
+    handleSelectProjectForEmptyDraft,
+    handleCreateProjectFromPickerPath,
+  } = useChatWorkspaceSelection({
     threadId,
-  ]);
+    activeThread,
+    activeProject,
+    activeRootBranch,
+    isServerThread,
+    isLocalDraftThread,
+    isHomeChatContainer,
+    isStudioContainer,
+    hasNativeUserMessages,
+    composerEditorRef,
+    scheduleComposerFocus,
+    defaultProvider: settings.defaultProvider,
+  });
 
-  const handleSelectWorkspaceRoot = useCallback(
-    (workspaceRoot: string) => {
-      if (isStudioContainer) {
-        if (isLocalDraftThread) {
-          setDraftThreadContext(threadId, {
-            envMode: "local",
-            branch: null,
-            worktreePath: null,
-            workingDirectory: workspaceRoot,
-          });
-        } else if (activeThread) {
-          setStoreThreadWorkspace(activeThread.id, {
-            envMode: "local",
-            branch: null,
-            worktreePath: null,
-            workingDirectory: workspaceRoot,
-          });
-          if (!hasNativeUserMessages && !activeThread.session) {
-            const api = readNativeApi();
-            if (api) {
-              void api.orchestration.dispatchCommand({
-                type: "thread.meta.update",
-                commandId: newCommandId(),
-                threadId: activeThread.id,
-                envMode: "local",
-                branch: null,
-                worktreePath: null,
-                workingDirectory: workspaceRoot,
-              });
-            }
-          }
-        }
-        scheduleComposerFocus();
-        return;
-      }
-      if (isLocalDraftThread) {
-        setDraftThreadContext(threadId, {
-          envMode: "worktree",
-          worktreePath: workspaceRoot,
-        });
-        scheduleComposerFocus();
-        return;
-      }
-
-      if (activeThread) {
-        setStoreThreadWorkspace(activeThread.id, {
-          envMode: "worktree",
-          worktreePath: workspaceRoot,
-        });
-      }
-      scheduleComposerFocus();
-    },
-    [
-      activeThread,
-      hasNativeUserMessages,
-      isLocalDraftThread,
-      isStudioContainer,
-      scheduleComposerFocus,
-      setDraftThreadContext,
-      setStoreThreadWorkspace,
-      threadId,
-    ],
-  );
-
-  const handleSelectProjectForEmptyDraft = useCallback(
-    (projectId: ProjectId) => {
-      if (!isLocalDraftThread) {
-        return;
-      }
-      const project = useStore
-        .getState()
-        .projects.find((candidate) => candidate.id === projectId && candidate.kind === "project");
-      if (!project) {
-        throw new Error("Selected project is not available.");
-      }
-      if (draftThread?.projectId === projectId) {
-        scheduleComposerFocus();
-        return;
-      }
-      moveEmptyDraftToLocalProject(projectId);
-    },
-    [
-      draftThread?.projectId,
-      isLocalDraftThread,
-      moveEmptyDraftToLocalProject,
-      scheduleComposerFocus,
-    ],
-  );
-
-  const handleCreateProjectFromPickerPath = useCallback(
-    async (workspaceRoot: string) => {
-      if (!isLocalDraftThread) {
-        return;
-      }
-      const api = readNativeApi();
-      if (!api) {
-        throw new Error("App is still connecting. Try again in a moment.");
-      }
-
-      const existingProject = useStore
-        .getState()
-        .projects.find(
-          (project) =>
-            project.kind === "project" && workspaceRootsEqual(project.cwd, workspaceRoot),
-        );
-      if (existingProject) {
-        handleSelectProjectForEmptyDraft(existingProject.id);
-        return;
-      }
-
-      const creationResult = await createOrRecoverProjectFromPath({
-        api,
-        workspaceRoot,
-        createIfMissing: false,
-        defaultProvider: settings.defaultProvider,
-        loadSnapshot: () => api.orchestration.getShellSnapshot().catch(() => null),
-      });
-      if (creationResult.snapshot) {
-        syncServerShellSnapshot(creationResult.snapshot);
-      }
-      if (!creationResult.created && !creationResult.project) {
-        throw new Error(PROJECT_CREATE_EXISTING_SYNC_ERROR);
-      }
-      if (!creationResult.project) {
-        throw new Error(PROJECT_CREATE_SYNC_ERROR);
-      }
-      moveEmptyDraftToLocalProject(creationResult.project.id);
-    },
-    [
-      handleSelectProjectForEmptyDraft,
-      isLocalDraftThread,
-      moveEmptyDraftToLocalProject,
-      settings.defaultProvider,
-      syncServerShellSnapshot,
-    ],
-  );
-
-  const applyPromptReplacement = useCallback(
-    (
-      rangeStart: number,
-      rangeEnd: number,
-      replacement: string,
-      options?: { expectedText?: string; cursorOffset?: number },
-    ): number | false => {
-      const currentText = promptRef.current;
-      const safeStart = Math.max(0, Math.min(currentText.length, rangeStart));
-      const safeEnd = Math.max(safeStart, Math.min(currentText.length, rangeEnd));
-      if (
-        options?.expectedText !== undefined &&
-        currentText.slice(safeStart, safeEnd) !== options.expectedText
-      ) {
-        return false;
-      }
-      const next = replaceTextRange(promptRef.current, rangeStart, rangeEnd, replacement);
-      let nextCursor = collapseExpandedComposerCursor(next.text, next.cursor);
-      // Apply cursor offset if specified (e.g., -1 to position inside parentheses)
-      if (options?.cursorOffset !== undefined) {
-        nextCursor = Math.max(0, nextCursor + options.cursorOffset);
-      }
-      promptRef.current = next.text;
-      const activePendingQuestion = activePendingProgress?.activeQuestion;
-      if (activePendingQuestion && activePendingUserInputKey) {
-        const nextDraftAnswer = setPendingUserInputCustomAnswer(
-          pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey]?.[
-            activePendingQuestion.id
-          ],
-          next.text,
-        );
-        const nextRequestAnswers = {
-          ...pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey],
-          [activePendingQuestion.id]: nextDraftAnswer,
-        };
-        pendingUserInputAnswersByRequestIdRef.current = {
-          ...pendingUserInputAnswersByRequestIdRef.current,
-          [activePendingUserInputKey]: nextRequestAnswers,
-        };
-        setPendingUserInputAnswersByRequestId((existing) => ({
-          ...existing,
-          [activePendingUserInputKey]: nextRequestAnswers,
-        }));
-      } else {
-        setPrompt(next.text);
-      }
-      setComposerCursor(nextCursor);
-      setComposerTrigger(
-        detectComposerTrigger(next.text, expandCollapsedComposerCursor(next.text, nextCursor)),
-      );
-      window.requestAnimationFrame(() => {
-        composerEditorRef.current?.focusAt(nextCursor);
-      });
-      return nextCursor;
-    },
-    [
-      activePendingProgress?.activeQuestion,
-      activePendingUserInputKey,
-      setPrompt,
-      setPendingUserInputAnswersByRequestId,
-      pendingUserInputAnswersByRequestIdRef,
-    ],
-  );
-
-  const readComposerSnapshot = useCallback((): {
-    value: string;
-    cursor: number;
-    expandedCursor: number;
-    selectionCollapsed: boolean;
-    terminalContextIds: string[];
-  } => {
-    const editorSnapshot = composerEditorRef.current?.readSnapshot();
-    if (editorSnapshot) {
-      return editorSnapshot;
-    }
-    return {
-      value: promptRef.current,
-      cursor: composerCursor,
-      expandedCursor: expandCollapsedComposerCursor(promptRef.current, composerCursor),
-      selectionCollapsed: true,
-      terminalContextIds: composerTerminalContexts.map((context) => context.id),
-    };
-  }, [composerCursor, composerTerminalContexts]);
-
-  const resolveActiveComposerTrigger = useCallback((): {
-    snapshot: {
-      value: string;
-      cursor: number;
-      expandedCursor: number;
-      selectionCollapsed: boolean;
-    };
-    trigger: ComposerTrigger | null;
-  } => {
-    const snapshot = readComposerSnapshot();
-    return {
-      snapshot,
-      trigger: detectComposerTrigger(snapshot.value, snapshot.expandedCursor),
-    };
-  }, [readComposerSnapshot]);
-
-  // Shared insertion path for picker selections (mentions, plugins, skills,
-  // agents, provider-native commands, local folders). Guarantees the replacement
-  // is flanked by a leading space when landing next to a non-whitespace char and
-  // absorbs an existing trailing space so we don't end up with double spaces.
-  const applyComposerTriggerReplacement = useCallback(
-    (params: {
-      snapshot: { value: string };
-      trigger: ComposerTrigger;
-      base: string;
-      cursorOffset?: number;
-      onApplied?: () => void;
-    }): number | false => {
-      const { snapshot, trigger, base, cursorOffset, onApplied } = params;
-      const replacement = ensureLeadingSpaceForReplacement(
-        snapshot.value,
-        trigger.rangeStart,
-        base,
-      );
-      const replacementRangeEnd = extendReplacementRangeForTrailingSpace(
-        snapshot.value,
-        trigger.rangeEnd,
-        replacement,
-      );
-      const options: { expectedText: string; cursorOffset?: number } = {
-        expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd),
-      };
-      if (cursorOffset !== undefined) {
-        options.cursorOffset = cursorOffset;
-      }
-      const applied = applyPromptReplacement(
-        trigger.rangeStart,
-        replacementRangeEnd,
-        replacement,
-        options,
-      );
-      if (applied !== false) {
-        onApplied?.();
-        setComposerHighlightedItemId(null);
-      }
-      return applied;
-    },
-    [applyPromptReplacement],
-  );
-
-  // Replaces the active `@...` token with a completed absolute folder mention.
-  const handleSelectLocalDirectoryMention = useCallback(
-    (absolutePath: string) => {
-      const { snapshot, trigger } = resolveActiveComposerTrigger();
-      if (!trigger) return;
-      applyComposerTriggerReplacement({
-        snapshot,
-        trigger,
-        base: `${formatComposerMentionToken(absolutePath)} `,
-      });
-    },
-    [applyComposerTriggerReplacement, resolveActiveComposerTrigger],
-  );
-
-  // Rewrites the active `@...` mention to an absolute folder path with a trailing separator
-  // so the local-folder picker stays open and the user can keep browsing by clicking or typing.
-  // Paths that need quoting (spaces, parentheses, …) are written as an unclosed
-  // `@"...` so detectComposerTrigger keeps matching while the user descends (#351).
-  const handleNavigateLocalFolder = useCallback(
-    (absolutePath: string) => {
-      const { snapshot, trigger } = resolveActiveComposerTrigger();
-      if (!trigger) return;
-      const separator = absolutePath.includes("\\") ? "\\" : "/";
-      const withTrailingSeparator = absolutePath.endsWith(separator)
-        ? absolutePath
-        : `${absolutePath}${separator}`;
-      const base = composerMentionPathNeedsQuoting(withTrailingSeparator)
-        ? `@"${withTrailingSeparator}`
-        : `@${withTrailingSeparator}`;
-      applyComposerTriggerReplacement({ snapshot, trigger, base });
-    },
-    [applyComposerTriggerReplacement, resolveActiveComposerTrigger],
-  );
-
-  const setComposerPromptValue = useCallback(
-    (nextPrompt: string) => {
-      setRestoredQueuedSourceProposedPlan(threadId, null);
-      promptRef.current = nextPrompt;
-      setPrompt(nextPrompt);
-      const nextCursor = collapseExpandedComposerCursor(nextPrompt, nextPrompt.length);
-      setComposerCursor(nextCursor);
-      setComposerTrigger(detectComposerTrigger(nextPrompt, nextPrompt.length));
-      setComposerHighlightedItemId(null);
-      window.requestAnimationFrame(() => {
-        composerEditorRef.current?.focusAt(nextCursor);
-      });
-    },
-    [setPrompt, setRestoredQueuedSourceProposedPlan, threadId],
-  );
-
-  const clearComposerSlashDraft = useCallback(() => {
-    promptRef.current = "";
-    setRestoredQueuedSourceProposedPlan(threadId, null);
-    clearComposerDraftContent(threadId);
-    setComposerHighlightedItemId(null);
-    setComposerCursor(0);
-    setComposerTrigger(null);
-    scheduleComposerFocus();
-  }, [
+  const {
+    applyPromptReplacement,
+    resolveActiveComposerTrigger,
+    applyComposerTriggerReplacement,
+    handleSelectLocalDirectoryMention,
+    handleNavigateLocalFolder,
+    setComposerPromptValue,
+    clearComposerSlashDraft,
+  } = useChatComposerEditing({
+    threadId,
+    promptRef,
+    activePendingProgress,
+    activePendingUserInputKey,
+    pendingUserInputAnswersByRequestIdRef,
+    setPendingUserInputAnswersByRequestId,
+    setPrompt,
+    setComposerCursor,
+    setComposerTrigger,
+    composerEditorRef,
+    composerCursor,
+    composerTerminalContexts,
+    setComposerHighlightedItemId,
+    setRestoredQueuedSourceProposedPlan,
     clearComposerDraftContent,
     scheduleComposerFocus,
-    setRestoredQueuedSourceProposedPlan,
-    threadId,
-  ]);
+  });
 
   const slashEditorActions = useMemo(
     () => ({
@@ -10665,6 +4181,7 @@ export default function ChatView({
       setComposerHighlightedItemId,
     }),
     [
+      setComposerHighlightedItemId,
       applyPromptReplacement,
       clearComposerSlashDraft,
       resolveActiveComposerTrigger,
@@ -10691,7 +4208,7 @@ export default function ChatView({
     isLocalDraftThread,
     supportsFastSlashCommand,
     canOfferCompactCommand:
-      supportsThreadCompaction(providerComposerCapabilitiesQuery.data) &&
+      canCompactThread &&
       isServerThread &&
       activeThread?.session !== null &&
       activeThread?.session?.status !== "closed",
@@ -10701,7 +4218,7 @@ export default function ChatView({
     supportsTextNativeReviewCommand,
     fastModeEnabled,
     providerNativeCommands,
-    providerCommandDiscoveryCwd: composerSkillCwd,
+    providerCommandDiscoveryCwd: providerModelDiscoveryCwd,
     selectedProvider,
     currentProviderModelOptions,
     selectedModelSelection,
@@ -10754,7 +4271,15 @@ export default function ChatView({
     setComposerCursor(collapseExpandedComposerCursor(nextPrompt, nextPrompt.length));
     setComposerTrigger(detectComposerTrigger(nextPrompt, nextPrompt.length));
     scheduleComposerFocus();
-  }, [activeThread, clearComposerDraftContent, scheduleComposerFocus, setComposerDraftPrompt]);
+  }, [
+    promptRef,
+    setComposerCursor,
+    setComposerTrigger,
+    activeThread,
+    clearComposerDraftContent,
+    scheduleComposerFocus,
+    setComposerDraftPrompt,
+  ]);
 
   // Refreshed on every commit, in a layout effect rather than a passive one: the queued
   // dispatcher can run from the same commit's follow-up work, so there must be no window
@@ -10768,466 +4293,71 @@ export default function ChatView({
     };
   });
 
-  const onSelectComposerItem = useCallback(
-    (item: ComposerCommandItem) => {
-      if (composerSelectLockRef.current) return;
-      composerSelectLockRef.current = true;
-      window.requestAnimationFrame(() => {
-        composerSelectLockRef.current = false;
-      });
-      if (item.type === "fork-target") {
-        setComposerCommandPicker(null);
-        setComposerHighlightedItemId(null);
-        void handleForkTargetSelection(item.target);
-        return;
-      }
-      if (item.type === "review-target") {
-        setComposerCommandPicker(null);
-        setComposerHighlightedItemId(null);
-        void handleReviewTargetSelection(item.target);
-        return;
-      }
-      const { snapshot, trigger } = resolveActiveComposerTrigger();
-      if (!trigger) return;
-      if (item.type === "path") {
-        applyComposerTriggerReplacement({
-          snapshot,
-          trigger,
-          base: `${formatComposerMentionToken(item.path)} `,
-        });
-        return;
-      }
-      if (item.type === "local-root") {
-        handleNavigateLocalFolder(localFolderBrowseRootPath ?? "/");
-        return;
-      }
-      if (item.type === "slash-command") {
-        handleSlashCommandSelection(item);
-        return;
-      }
-      if (item.type === "provider-native-command") {
-        if (selectedProvider === "codex" && item.command.toLowerCase() === "review") {
-          setComposerCommandPicker("review-target");
-          setComposerHighlightedItemId("review-target:changes");
-          scheduleComposerFocus();
-          return;
-        }
-        applyComposerTriggerReplacement({
-          snapshot,
-          trigger,
-          base: `/${item.command} `,
-        });
-        return;
-      }
-      if (item.type === "skill") {
-        applyComposerTriggerReplacement({
-          snapshot,
-          trigger,
-          base: `${skillMentionPrefix(selectedProvider)}${item.skill.name} `,
-          onApplied: () => {
-            updateSelectedComposerSkills((existing) => {
-              const nextSkill = {
-                name: item.skill.name,
-                path: item.skill.path,
-              } satisfies ProviderSkillReference;
-              return existing.some(
-                (skill) => skill.name === nextSkill.name && skill.path === nextSkill.path,
-              )
-                ? existing
-                : [...existing, nextSkill];
-            });
-          },
-        });
-        return;
-      }
-      if (item.type === "plugin" || item.type === "thread") {
-        applyComposerTriggerReplacement({
-          snapshot,
-          trigger,
-          base: `${formatComposerMentionToken(item.mention.name)} `,
-          onApplied: () => {
-            updateSelectedComposerMentions((existing) => {
-              const nextMention = item.mention;
-              const nextWithoutSameName = existing.filter(
-                (mention) => mention.name !== nextMention.name,
-              );
-              return [...nextWithoutSameName, nextMention];
-            });
-          },
-        });
-        return;
-      }
-      if (item.type === "model") {
-        onProviderModelSelect(item.provider, item.model);
-        applyComposerTriggerReplacement({ snapshot, trigger, base: "" });
-        return;
-      }
-      if (item.type === "agent") {
-        // Insert @alias() and position cursor inside the parentheses.
-        applyComposerTriggerReplacement({
-          snapshot,
-          trigger,
-          base: `@${item.alias}()`,
-          cursorOffset: -1,
-        });
-      }
+  const {
+    onSelectComposerItem,
+    onComposerMenuItemHighlighted,
+    onPromptChange,
+    onComposerCommandKey,
+  } = useChatComposerCommands({
+    threadId,
+    composerSelectLockRef,
+    setComposerCommandPicker,
+    setComposerHighlightedItemId,
+    handleForkTargetSelection,
+    handleReviewTargetSelection,
+    resolveActiveComposerTrigger,
+    applyComposerTriggerReplacement,
+    handleNavigateLocalFolder,
+    localFolderBrowseRootPath,
+    handleSlashCommandSelection,
+    selectedProvider,
+    scheduleComposerFocus,
+    updateSelectedComposerSkills,
+    updateSelectedComposerMentions,
+    onProviderModelSelect,
+    composerMenuItems,
+    composerHighlightedItemId,
+    activePendingQuestion,
+    activePendingUserInput,
+    promptHistoryNavigationRef,
+    restoreComposerDraftPromptHistorySavedDraft,
+    promptRef,
+    setPrompt,
+    expectedPromptHistoryPromptRef,
+    onChangeActivePendingUserInputCustomAnswer,
+    setComposerDraftPromptHistorySavedDraft,
+    applyingPromptHistoryNavigationRef,
+    promptHistory,
+    promptHistoryAppliedPromptRef,
+    restoredQueuedSourceProposedPlanRef,
+    setRestoredQueuedSourceProposedPlan,
+    composerCommandPicker,
+    composerTerminalContexts,
+    setComposerDraftTerminalContexts,
+    setComposerCursor,
+    setComposerTrigger,
+    clearComposerSlashDraft,
+    toggleInteractionMode,
+    composerMenuOpenRef,
+    onSend,
+    settings,
+    hasLiveTurn,
+    isLocalFolderBrowserOpen,
+    localDirectoryMenuRef,
+    composerMenuItemsRef,
+    activeComposerMenuItemRef,
+    activePendingProgress,
+    isComposerApprovalState,
+    pendingUserInputs,
+    composerDraft,
+  });
+  const onExpandTimelineImage = useCallback(
+    (preview: ExpandedImagePreview) => {
+      setExpandedImage(preview);
     },
-    [
-      applyComposerTriggerReplacement,
-      scheduleComposerFocus,
-      handleForkTargetSelection,
-      handleNavigateLocalFolder,
-      handleReviewTargetSelection,
-      handleSlashCommandSelection,
-      onProviderModelSelect,
-      setComposerCommandPicker,
-      localFolderBrowseRootPath,
-      selectedProvider,
-      updateSelectedComposerMentions,
-      updateSelectedComposerSkills,
-      resolveActiveComposerTrigger,
-    ],
-  );
-  const onComposerMenuItemHighlighted = useCallback((itemId: string | null) => {
-    setComposerHighlightedItemId(itemId);
-  }, []);
-  const nudgeComposerMenuHighlight = useCallback(
-    (key: "ArrowDown" | "ArrowUp") => {
-      if (composerMenuItems.length === 0) {
-        return;
-      }
-      const highlightedIndex = composerMenuItems.findIndex(
-        (item) => item.id === composerHighlightedItemId,
-      );
-      const normalizedIndex =
-        highlightedIndex >= 0 ? highlightedIndex : key === "ArrowDown" ? -1 : 0;
-      const offset = key === "ArrowDown" ? 1 : -1;
-      const nextIndex =
-        (normalizedIndex + offset + composerMenuItems.length) % composerMenuItems.length;
-      const nextItem = composerMenuItems[nextIndex];
-      setComposerHighlightedItemId(nextItem?.id ?? null);
-    },
-    [composerHighlightedItemId, composerMenuItems],
-  );
-  const isComposerMenuLoading =
-    (composerTriggerKind === "mention" &&
-      ((mentionTriggerQuery.length > 0 && composerPathQueryDebouncer.state.isPending) ||
-        workspaceEntriesQuery.isLoading ||
-        workspaceEntriesQuery.isFetching ||
-        providerPluginsQuery.isLoading ||
-        providerPluginsQuery.isFetching)) ||
-    (composerTriggerKind === "slash-command" &&
-      (providerCommandsQuery.isLoading ||
-        providerCommandsQuery.isFetching ||
-        providerSkillsQuery.isLoading ||
-        providerSkillsQuery.isFetching)) ||
-    (composerTriggerKind === "skill" &&
-      (providerComposerCapabilitiesQuery.isLoading ||
-        providerComposerCapabilitiesQuery.isFetching ||
-        providerSkillsQuery.isLoading ||
-        providerSkillsQuery.isFetching));
-
-  const onPromptChange = useCallback(
-    (
-      nextPrompt: string,
-      nextCursor: number,
-      expandedCursor: number,
-      cursorAdjacentToMention: boolean,
-      terminalContextIds: string[],
-    ) => {
-      if (activePendingQuestion && activePendingUserInput) {
-        const interruptedNavigation = promptHistoryNavigationRef.current;
-        if (interruptedNavigation !== null) {
-          // An active question ended the history browse while the persisted
-          // prompt still held a recalled entry; put the real draft back.
-          promptHistoryNavigationRef.current = null;
-          restoreComposerDraftPromptHistorySavedDraft(threadId);
-          promptRef.current = interruptedNavigation.draft;
-          setPrompt(interruptedNavigation.draft);
-        }
-        expectedPromptHistoryPromptRef.current = null;
-        onChangeActivePendingUserInputCustomAnswer(
-          activePendingQuestion.id,
-          nextPrompt,
-          nextCursor,
-          expandedCursor,
-          cursorAdjacentToMention,
-        );
-        return;
-      }
-      const expectedPromptHistoryPrompt = expectedPromptHistoryPromptRef.current;
-      if (expectedPromptHistoryPrompt !== null) {
-        if (nextPrompt === expectedPromptHistoryPrompt) {
-          expectedPromptHistoryPromptRef.current = null;
-        } else {
-          // The user edited past the recalled entry: the edited text is the
-          // draft now, so the saved pre-browse draft must not be restored.
-          promptHistoryNavigationRef.current = null;
-          expectedPromptHistoryPromptRef.current = null;
-          setComposerDraftPromptHistorySavedDraft(threadId, null);
-        }
-      } else if (!applyingPromptHistoryNavigationRef.current) {
-        const activePromptHistoryNavigation = promptHistoryNavigationRef.current;
-        if (
-          activePromptHistoryNavigation !== null &&
-          !promptStillMatchesActiveHistoryBrowse({
-            state: activePromptHistoryNavigation,
-            history: promptHistory,
-            nextPrompt,
-            appliedPrompt: promptHistoryAppliedPromptRef.current,
-          })
-        ) {
-          promptHistoryNavigationRef.current = null;
-          setComposerDraftPromptHistorySavedDraft(threadId, null);
-        }
-      }
-      const restoredQueuedSource = restoredQueuedSourceProposedPlanRef.current;
-      if (
-        restoredQueuedSource?.threadId === threadId &&
-        !composerPromptStillMatchesRestoredQueuedDraft(
-          restoredQueuedSource.restoredPrompt,
-          nextPrompt,
-        )
-      ) {
-        setRestoredQueuedSourceProposedPlan(threadId, null);
-      }
-      promptRef.current = nextPrompt;
-      setPrompt(nextPrompt);
-      if (composerCommandPicker !== null && nextPrompt.trim().length > 0) {
-        setComposerCommandPicker(null);
-      }
-      if (!terminalContextIdListsEqual(composerTerminalContexts, terminalContextIds)) {
-        setComposerDraftTerminalContexts(
-          threadId,
-          syncTerminalContextsByIds(composerTerminalContexts, terminalContextIds),
-        );
-      }
-      setComposerCursor(nextCursor);
-      setComposerTrigger(
-        cursorAdjacentToMention ? null : detectComposerTrigger(nextPrompt, expandedCursor),
-      );
-    },
-    [
-      activePendingQuestion,
-      activePendingUserInput,
-      composerTerminalContexts,
-      composerCommandPicker,
-      onChangeActivePendingUserInputCustomAnswer,
-      promptHistory,
-      restoreComposerDraftPromptHistorySavedDraft,
-      setPrompt,
-      setComposerDraftPromptHistorySavedDraft,
-      setComposerDraftTerminalContexts,
-      setComposerCommandPicker,
-      setRestoredQueuedSourceProposedPlan,
-      threadId,
-    ],
+    [setExpandedImage],
   );
 
-  const onComposerCommandKey = (
-    key: "ArrowDown" | "ArrowUp" | "Enter" | "Tab" | "Slash",
-    event: KeyboardEvent,
-  ) => {
-    if (key === "Slash" && !event.metaKey && !event.ctrlKey && !event.altKey) {
-      const { snapshot, trigger } = resolveActiveComposerTrigger();
-      const slashTriggerText =
-        trigger && (trigger.kind === "slash-command" || trigger.kind === "slash-model")
-          ? snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd)
-          : null;
-
-      if (slashTriggerText === "/" && snapshot.expandedCursor === trigger?.rangeEnd) {
-        // Pressing `/` again on a lone `/` dismisses the picker. Only wipe the
-        // draft when the slash IS the whole prompt; a mid-line slash (e.g. after
-        // an existing chip) must keep surrounding content, so let it type through.
-        if (trigger.rangeStart === 0 && trigger.rangeEnd === snapshot.value.length) {
-          clearComposerSlashDraft();
-          return true;
-        }
-        return false;
-      }
-      return false;
-    }
-
-    if (key === "Tab" && event.shiftKey) {
-      toggleInteractionMode();
-      return true;
-    }
-
-    const { snapshot, trigger } = resolveActiveComposerTrigger();
-    const menuIsActive = composerMenuOpenRef.current || trigger !== null;
-    if (
-      key === "Enter" &&
-      !event.shiftKey &&
-      !menuIsActive &&
-      extractChatAutomationInvocation(snapshot.value) !== null
-    ) {
-      void onSend(
-        undefined,
-        resolveFollowUpDispatchMode({
-          behavior: settings.followUpBehavior,
-          hasLiveTurn,
-          useOppositeBehavior: event.metaKey || event.ctrlKey,
-        }),
-      );
-      return true;
-    }
-
-    if (menuIsActive && isLocalFolderBrowserOpen) {
-      if (key === "ArrowDown") {
-        localDirectoryMenuRef.current?.moveHighlight("down");
-        return true;
-      }
-      if (key === "ArrowUp") {
-        localDirectoryMenuRef.current?.moveHighlight("up");
-        return true;
-      }
-      if (key === "Enter" || key === "Tab") {
-        localDirectoryMenuRef.current?.activateHighlighted();
-        return true;
-      }
-    }
-
-    if (menuIsActive) {
-      const currentItems = composerMenuItemsRef.current;
-      if (key === "ArrowDown" && currentItems.length > 0) {
-        nudgeComposerMenuHighlight("ArrowDown");
-        return true;
-      }
-      if (key === "ArrowUp" && currentItems.length > 0) {
-        nudgeComposerMenuHighlight("ArrowUp");
-        return true;
-      }
-      if (key === "Tab" || key === "Enter") {
-        const selectedItem = activeComposerMenuItemRef.current ?? currentItems[0];
-        if (selectedItem) {
-          onSelectComposerItem(selectedItem);
-          return true;
-        }
-      }
-    }
-
-    if (
-      shouldHandlePromptHistoryNavigationKey({
-        key,
-        metaKey: event.metaKey,
-        ctrlKey: event.ctrlKey,
-        altKey: event.altKey,
-        shiftKey: event.shiftKey,
-        menuIsActive,
-        hasActivePendingProgress: Boolean(activePendingProgress),
-        isComposerApprovalState,
-        pendingUserInputCount: pendingUserInputs.length,
-      })
-    ) {
-      const direction = key === "ArrowUp" ? "older" : "newer";
-      const previousNavigationState = promptHistoryNavigationRef.current;
-      const result = resolvePromptHistoryNavigation({
-        direction,
-        history: promptHistory,
-        currentPrompt: snapshot.value,
-        // Line-boundary math needs raw string offsets; the collapsed cursor
-        // undercounts inline token chips (mentions, links, slash commands).
-        currentExpandedCursor: snapshot.expandedCursor,
-        selectionCollapsed: snapshot.selectionCollapsed,
-        state: previousNavigationState,
-      });
-      if (result.handled) {
-        promptHistoryNavigationRef.current = result.state;
-        if (result.state === null) {
-          restoreComposerDraftPromptHistorySavedDraft(threadId);
-        } else if (previousNavigationState === null) {
-          setComposerDraftPromptHistorySavedDraft(
-            threadId,
-            captureComposerPromptHistorySavedDraft({
-              threadId,
-              draft: composerDraft,
-              prompt: result.state.draft,
-            }),
-          );
-        }
-        applyingPromptHistoryNavigationRef.current = true;
-        expectedPromptHistoryPromptRef.current = result.prompt;
-        promptHistoryAppliedPromptRef.current = result.prompt;
-        promptRef.current = result.prompt;
-        setPrompt(result.prompt);
-        setComposerCursor(collapseExpandedComposerCursor(result.prompt, result.expandedCursor));
-        // Recalled text replaces the whole prompt; suppress trigger detection
-        // so an entry ending in a mention/slash token cannot pop a menu that
-        // would capture the next arrow keypress.
-        setComposerTrigger(null);
-        window.requestAnimationFrame(() => {
-          applyingPromptHistoryNavigationRef.current = false;
-        });
-        return true;
-      }
-    }
-
-    if (key === "Enter" && !event.shiftKey) {
-      if (promptHistoryNavigationRef.current !== null) {
-        // Sending commits the recalled text as the prompt; drop the saved
-        // draft here (not just in the send path) so it cannot linger and
-        // resurrect a stale draft if the send is rejected.
-        promptHistoryNavigationRef.current = null;
-        setComposerDraftPromptHistorySavedDraft(threadId, null);
-      }
-      expectedPromptHistoryPromptRef.current = null;
-      void onSend(
-        undefined,
-        resolveFollowUpDispatchMode({
-          behavior: settings.followUpBehavior,
-          hasLiveTurn,
-          useOppositeBehavior: event.metaKey || event.ctrlKey,
-        }),
-      );
-      return true;
-    }
-    return false;
-  };
-  const onExpandTimelineImage = useCallback((preview: ExpandedImagePreview) => {
-    setExpandedImage(preview);
-  }, []);
-  const onScrollToBottom = useCallback(() => {
-    cancelPendingScrollGesture();
-    tailAnchorScrollInFlightRef.current = false;
-    setTranscriptScrollDetached(false);
-    isAtEndRef.current = true;
-    showScrollDebouncer.current.cancel();
-    setShowScrollToBottom(false);
-    const target = legendListRef.current;
-    if (!target) {
-      return;
-    }
-
-    const requestId = settledScrollRequestRef.current + 1;
-    settledScrollRequestRef.current = requestId;
-    settledScrollInFlightRef.current = true;
-    programmaticScrollUntilRef.current = performance.now() + 200;
-    void scrollTranscriptToSettledEnd({
-      target,
-      isCurrent: () =>
-        settledScrollRequestRef.current === requestId && legendListRef.current === target,
-      beforeFinalScroll: () => {
-        programmaticScrollUntilRef.current = performance.now() + 200;
-      },
-    })
-      .then((settled) => {
-        if (settledScrollRequestRef.current !== requestId) {
-          return;
-        }
-        settledScrollInFlightRef.current = false;
-        if (!settled) {
-          return;
-        }
-        isAtEndRef.current = true;
-        showScrollDebouncer.current.cancel();
-        setShowScrollToBottom(false);
-      })
-      .catch(() => {
-        if (settledScrollRequestRef.current === requestId) {
-          settledScrollInFlightRef.current = false;
-        }
-      });
-  }, [cancelPendingScrollGesture, setTranscriptScrollDetached]);
   const onOpenTurnDiff = useCallback(
     (turnId: TurnId, filePath?: string) => {
       if (diffEnvironmentPending) {
@@ -11371,7 +4501,7 @@ export default function ChatView({
   const dismissActiveRateLimitBanner = useCallback(() => {
     if (!activeRateLimitBannerDismissalKey) return;
     setDismissedRateLimitBannerKey(activeRateLimitBannerDismissalKey);
-  }, [activeRateLimitBannerDismissalKey]);
+  }, [setDismissedRateLimitBannerKey, activeRateLimitBannerDismissalKey]);
 
   // Empty state: no active thread
   if (!activeThread) {
@@ -11797,7 +4927,6 @@ export default function ChatView({
               {workflowRunState ? (
                 <WorkflowRunCard
                   workflowRun={workflowRunState}
-                  nowMs={workflowNowMs}
                   compact={workflowRunCardCompact}
                   onCompactChange={setWorkflowRunCardCompact}
                   onOpenThread={onNavigateToThread}
@@ -12076,81 +5205,16 @@ export default function ChatView({
                     since the approve/decline actions live in the detached approval card
                     floating above (see ComposerPendingApprovalPanel). */}
                 {activePendingApproval ? null : (
-                  <div
-                    data-chat-composer-footer="true"
-                    className={cn(
-                      "@container",
-                      COMPOSER_FOOTER_ROW_CLASS_NAME,
-                      isComposerFooterCompact
-                        ? "gap-1.5"
-                        : "flex-wrap gap-1.5 sm:flex-nowrap sm:gap-0",
-                    )}
-                  >
-                    <div
-                      data-chat-composer-leading="true"
-                      className={cn(
-                        "flex items-center",
-                        isVoiceRecording || isVoiceTranscribing
-                          ? "min-w-0 shrink-0 gap-1"
-                          : isComposerFooterCompact
-                            ? "min-w-0 flex-1 gap-1 overflow-hidden"
-                            : "min-w-0 flex-1 gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden sm:min-w-max sm:overflow-visible",
-                      )}
-                    >
-                      {relocateComposerLeadingControls
+                  <ChatComposerFooter
+                    isComposerFooterCompact={isComposerFooterCompact}
+                    leadingControls={
+                      relocateComposerLeadingControls
                         ? null
-                        : renderComposerLeadingControls({ iconOnly: false })}
-
-                      {!isVoiceRecording && !isVoiceTranscribing ? (
-                        <>
-                          {interactionMode !== "default" ? (
-                            <Button
-                              variant="ghost"
-                              className="shrink-0 whitespace-nowrap px-2 text-[length:var(--app-font-size-ui-sm,11px)] sm:text-[length:var(--app-font-size-ui-sm,11px)] font-normal text-[var(--color-text-foreground-secondary)] hover:bg-[var(--color-background-button-secondary-hover)] hover:text-[var(--color-text-foreground)] sm:px-3"
-                              size="sm"
-                              type="button"
-                              onClick={resetInteractionMode}
-                              title={`${interactionMode === "plan" ? "Plan" : "Debug"} mode — click to return to normal build mode`}
-                            >
-                              {interactionMode === "plan" ? (
-                                <GoTasklist className="size-3.5" />
-                              ) : (
-                                <BugIcon className="size-3.5" />
-                              )}
-                              <span className="sr-only sm:not-sr-only">
-                                {interactionMode === "plan" ? "Plan" : "Debug"}
-                              </span>
-                            </Button>
-                          ) : null}
-
-                          {activeTaskList || sidebarProposedPlan || planSidebarOpen ? (
-                            <Button
-                              variant="ghost"
-                              className="shrink-0 whitespace-nowrap px-2 text-[length:var(--app-font-size-ui-sm,11px)] sm:text-[length:var(--app-font-size-ui-sm,11px)] font-normal sm:px-3"
-                              size="sm"
-                              type="button"
-                              onClick={togglePlanSidebar}
-                              title={planSidebarToggleTitle}
-                              aria-label={planSidebarToggleTitle}
-                            >
-                              <LayoutSidebarIcon className="size-3.5" />
-                              <span className="sr-only sm:not-sr-only">
-                                {planSidebarToggleLabel}
-                              </span>
-                            </Button>
-                          ) : null}
-                        </>
-                      ) : null}
-                    </div>
-
-                    <div
-                      data-chat-composer-actions="right"
-                      className={cn(
-                        "flex items-center gap-2",
-                        isVoiceRecording || isVoiceTranscribing ? "min-w-0 flex-1" : "shrink-0",
-                      )}
-                    >
-                      {!isVoiceRecording &&
+                        : renderComposerLeadingControls({ iconOnly: false })
+                    }
+                    composerPickerControls={composerPickerControls}
+                    contextMeter={
+                      !isVoiceRecording &&
                       !isVoiceTranscribing &&
                       runtimeUsageContextWindow &&
                       composerFooterControlsPlan.showContextMeter ? (
@@ -12171,181 +5235,53 @@ export default function ChatView({
                               }
                             : {})}
                         />
-                      ) : null}
-                      {!isVoiceRecording && !isVoiceTranscribing ? composerPickerControls : null}
-                      {showVoiceNotesControl && (isVoiceRecording || isVoiceTranscribing) ? (
-                        <ComposerVoiceRecorderBar
-                          disabled={
-                            isComposerApprovalState ||
-                            isConnecting ||
-                            isSendBusy ||
-                            isSidechatExpired
+                      ) : null
+                    }
+                    interactionMode={interactionMode}
+                    resetInteractionMode={resetInteractionMode}
+                    sidebarAction={
+                      activeTaskList || sidebarProposedPlan || planSidebarOpen
+                        ? {
+                            title: planSidebarToggleTitle,
+                            label: planSidebarToggleLabel,
+                            onClick: togglePlanSidebar,
                           }
-                          isRecording={isVoiceRecording}
-                          isTranscribing={isVoiceTranscribing}
-                          durationLabel={voiceRecordingDurationLabel}
-                          waveformLevels={voiceWaveformLevels}
-                          onDiscard={cancelComposerVoiceRecording}
-                          onStop={() => {
-                            void submitComposerVoiceRecording();
-                          }}
-                        />
-                      ) : null}
-                      {activePendingProgress ? (
-                        <Button
-                          type="submit"
-                          size="sm"
-                          className="rounded-full px-4"
-                          disabled={
-                            activePendingIsResponding ||
-                            (activePendingProgress.isLastQuestion
-                              ? !activePendingResolvedAnswers
-                              : !activePendingProgress.canAdvance)
+                        : null
+                    }
+                    voice={{
+                      enabled: showVoiceNotesControl,
+                      recording: isVoiceRecording,
+                      transcribing: isVoiceTranscribing,
+                      durationLabel: voiceRecordingDurationLabel,
+                      waveformLevels: voiceWaveformLevels,
+                      onCancel: cancelComposerVoiceRecording,
+                      onSubmit: submitComposerVoiceRecording,
+                      onToggle: toggleComposerVoiceRecording,
+                    }}
+                    pendingInput={
+                      activePendingProgress
+                        ? {
+                            progress: activePendingProgress,
+                            responding: activePendingIsResponding,
+                            answersComplete: Boolean(activePendingResolvedAnswers),
                           }
-                        >
-                          {activePendingIsResponding
-                            ? "Submitting..."
-                            : activePendingProgress.isLastQuestion
-                              ? "Submit answers"
-                              : "Next question"}
-                        </Button>
-                      ) : phase === "running" ? (
-                        <Button
-                          type="button"
-                          variant="prominent"
-                          size="icon-xs"
-                          className="sm:size-[26px]"
-                          onClick={onInterruptFromStopControl}
-                          aria-label="Stop generation"
-                          title="Stop the current response. On Mac, press Ctrl+C to interrupt."
-                        >
-                          <span
-                            aria-hidden="true"
-                            className="block size-2 rounded-[1px] bg-current"
-                          />
-                        </Button>
-                      ) : pendingUserInputs.length === 0 &&
-                        !isVoiceRecording &&
-                        !isVoiceTranscribing ? (
-                        showPlanFollowUpPrompt ? (
-                          prompt.trim().length > 0 ? (
-                            <Button
-                              type="submit"
-                              size="sm"
-                              className="h-9 rounded-full px-4 sm:h-8"
-                              disabled={isSendBusy || isConnecting || isSidechatExpired}
-                            >
-                              {isConnecting || isSendBusy ? "Sending..." : "Refine"}
-                            </Button>
-                          ) : (
-                            <div className="flex items-center">
-                              <Button
-                                type="submit"
-                                size="sm"
-                                className="h-9 rounded-l-full rounded-r-none px-4 sm:h-8"
-                                disabled={isSendBusy || isConnecting || isSidechatExpired}
-                              >
-                                {isConnecting || isSendBusy ? "Sending..." : "Implement"}
-                              </Button>
-                              <Menu>
-                                <MenuTrigger
-                                  render={
-                                    <Button
-                                      size="sm"
-                                      variant="default"
-                                      className="h-9 rounded-l-none rounded-r-full border-l-white/12 px-2 sm:h-8"
-                                      aria-label="Implementation actions"
-                                      disabled={isSendBusy || isConnecting || isSidechatExpired}
-                                    />
-                                  }
-                                >
-                                  <ChevronDownIcon className="size-3.5" />
-                                </MenuTrigger>
-                                <ComposerPickerMenuPopup align="end" side="top">
-                                  <MenuItem
-                                    disabled={isSendBusy || isConnecting || isSidechatExpired}
-                                    onClick={() => void onImplementPlanInNewThread()}
-                                  >
-                                    Implement in a new thread
-                                  </MenuItem>
-                                </ComposerPickerMenuPopup>
-                              </Menu>
-                            </div>
-                          )
-                        ) : (
-                          <>
-                            {showVoiceNotesControl ? (
-                              <ComposerVoiceButton
-                                disabled={
-                                  isComposerApprovalState ||
-                                  isConnecting ||
-                                  isSendBusy ||
-                                  isSidechatExpired
-                                }
-                                isRecording={isVoiceRecording}
-                                isTranscribing={isVoiceTranscribing}
-                                durationLabel={voiceRecordingDurationLabel}
-                                onClick={toggleComposerVoiceRecording}
-                              />
-                            ) : null}
-                            <Button
-                              type="submit"
-                              variant="prominent"
-                              size="icon-xs"
-                              className="size-7 rounded-full sm:size-7"
-                              disabled={
-                                isSendBusy ||
-                                isConnecting ||
-                                isSidechatExpired ||
-                                isVoiceTranscribing ||
-                                isPreparingComposerImages ||
-                                !composerSendState.hasSendableContent
-                              }
-                              aria-label={
-                                isConnecting
-                                  ? "Connecting"
-                                  : isVoiceTranscribing
-                                    ? "Transcribing voice note"
-                                    : isPreparingComposerImages
-                                      ? "Optimizing image"
-                                      : isPreparingWorktree
-                                        ? "Preparing worktree"
-                                        : isSendBusy
-                                          ? "Sending"
-                                          : "Send message"
-                              }
-                            >
-                              {isConnecting || isSendBusy || isPreparingComposerImages ? (
-                                <svg
-                                  width="12"
-                                  height="12"
-                                  viewBox="0 0 14 14"
-                                  fill="none"
-                                  className="animate-spin"
-                                  aria-hidden="true"
-                                >
-                                  <circle
-                                    cx="7"
-                                    cy="7"
-                                    r="5.5"
-                                    stroke="currentColor"
-                                    strokeWidth="1.5"
-                                    strokeLinecap="round"
-                                    strokeDasharray="20 12"
-                                  />
-                                </svg>
-                              ) : (
-                                <ComposerSendArrowIcon
-                                  aria-hidden="true"
-                                  className="size-5 shrink-0 translate-y-px"
-                                />
-                              )}
-                            </Button>
-                          </>
-                        )
-                      ) : null}
-                    </div>
-                  </div>
+                        : null
+                    }
+                    submission={{
+                      phase,
+                      busy: isSendBusy,
+                      connecting: isConnecting,
+                      expired: isSidechatExpired,
+                      preparingImages: isPreparingComposerImages,
+                      preparingWorktree: isPreparingWorktree,
+                      hasContent: composerSendState.hasSendableContent,
+                      hasPendingUserInputs: pendingUserInputs.length > 0,
+                      showPlanFollowUp: showPlanFollowUpPrompt,
+                      hasPrompt: prompt.trim().length > 0,
+                      onInterrupt: onInterruptFromStopControl,
+                      onImplementInNewThread: onImplementPlanInNewThread,
+                    }}
+                  />
                 )}
               </div>
             </div>

--- a/apps/web/src/components/chat/ChatComposerFooter.tsx
+++ b/apps/web/src/components/chat/ChatComposerFooter.tsx
@@ -1,0 +1,295 @@
+import { ProviderInteractionMode } from "@synara/contracts";
+import { type ReactNode } from "react";
+import { GoTasklist } from "react-icons/go";
+import { BugIcon, ChevronDownIcon, ComposerSendArrowIcon, LayoutSidebarIcon } from "~/lib/icons";
+import { cn } from "~/lib/utils";
+import type { derivePendingUserInputProgress } from "../../pendingUserInput";
+import type { SessionPhase } from "../../types";
+import { Button } from "../ui/button";
+import { Menu, MenuItem, MenuTrigger } from "../ui/menu";
+import { ComposerPickerMenuPopup } from "./ComposerPickerMenuPopup";
+import { ComposerVoiceButton } from "./ComposerVoiceButton";
+import { ComposerVoiceRecorderBar } from "./ComposerVoiceRecorderBar";
+import { COMPOSER_FOOTER_ROW_CLASS_NAME } from "./composerPickerStyles";
+interface ChatComposerFooterProps {
+  isComposerFooterCompact: boolean;
+  leadingControls: ReactNode;
+  composerPickerControls: ReactNode;
+  contextMeter: ReactNode;
+  interactionMode: ProviderInteractionMode;
+  resetInteractionMode: () => void;
+  sidebarAction: { title: string; label: string; onClick: () => void } | null;
+  voice: {
+    enabled: boolean;
+    recording: boolean;
+    transcribing: boolean;
+    durationLabel: string;
+    waveformLevels: readonly number[];
+    onCancel: () => void;
+    onSubmit: () => void;
+    onToggle: () => void;
+  };
+  pendingInput: {
+    progress: NonNullable<ReturnType<typeof derivePendingUserInputProgress>>;
+    responding: boolean;
+    answersComplete: boolean;
+  } | null;
+  submission: {
+    phase: SessionPhase;
+    busy: boolean;
+    connecting: boolean;
+    expired: boolean;
+    preparingImages: boolean;
+    preparingWorktree: boolean;
+    hasContent: boolean;
+    hasPendingUserInputs: boolean;
+    showPlanFollowUp: boolean;
+    hasPrompt: boolean;
+    onInterrupt: () => void;
+    onImplementInNewThread: () => void;
+  };
+}
+
+export function ChatComposerFooter({
+  isComposerFooterCompact,
+  leadingControls,
+  composerPickerControls,
+  contextMeter,
+  interactionMode,
+  resetInteractionMode,
+  sidebarAction,
+  voice,
+  pendingInput,
+  submission,
+}: ChatComposerFooterProps) {
+  return (
+    <div
+      data-chat-composer-footer="true"
+      className={cn(
+        "@container",
+        COMPOSER_FOOTER_ROW_CLASS_NAME,
+        isComposerFooterCompact ? "gap-1.5" : "flex-wrap gap-1.5 sm:flex-nowrap sm:gap-0",
+      )}
+    >
+      <div
+        data-chat-composer-leading="true"
+        className={cn(
+          "flex items-center",
+          voice.recording || voice.transcribing
+            ? "min-w-0 shrink-0 gap-1"
+            : isComposerFooterCompact
+              ? "min-w-0 flex-1 gap-1 overflow-hidden"
+              : "min-w-0 flex-1 gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden sm:min-w-max sm:overflow-visible",
+        )}
+      >
+        {leadingControls}
+
+        {!voice.recording && !voice.transcribing ? (
+          <>
+            {interactionMode !== "default" ? (
+              <Button
+                variant="ghost"
+                className="shrink-0 whitespace-nowrap px-2 text-[length:var(--app-font-size-ui-sm,11px)] sm:text-[length:var(--app-font-size-ui-sm,11px)] font-normal text-[var(--color-text-foreground-secondary)] hover:bg-[var(--color-background-button-secondary-hover)] hover:text-[var(--color-text-foreground)] sm:px-3"
+                size="sm"
+                type="button"
+                onClick={resetInteractionMode}
+                title={`${interactionMode === "plan" ? "Plan" : "Debug"} mode — click to return to normal build mode`}
+              >
+                {interactionMode === "plan" ? (
+                  <GoTasklist className="size-3.5" />
+                ) : (
+                  <BugIcon className="size-3.5" />
+                )}
+                <span className="sr-only sm:not-sr-only">
+                  {interactionMode === "plan" ? "Plan" : "Debug"}
+                </span>
+              </Button>
+            ) : null}
+
+            {sidebarAction ? (
+              <Button
+                variant="ghost"
+                className="shrink-0 whitespace-nowrap px-2 text-[length:var(--app-font-size-ui-sm,11px)] sm:text-[length:var(--app-font-size-ui-sm,11px)] font-normal sm:px-3"
+                size="sm"
+                type="button"
+                onClick={sidebarAction.onClick}
+                title={sidebarAction.title}
+                aria-label={sidebarAction.title}
+              >
+                <LayoutSidebarIcon className="size-3.5" />
+                <span className="sr-only sm:not-sr-only">{sidebarAction.label}</span>
+              </Button>
+            ) : null}
+          </>
+        ) : null}
+      </div>
+
+      <div
+        data-chat-composer-actions="right"
+        className={cn(
+          "flex items-center gap-2",
+          voice.recording || voice.transcribing ? "min-w-0 flex-1" : "shrink-0",
+        )}
+      >
+        {contextMeter}
+        {!voice.recording && !voice.transcribing ? composerPickerControls : null}
+        {voice.enabled && (voice.recording || voice.transcribing) ? (
+          <ComposerVoiceRecorderBar
+            disabled={submission.connecting || submission.busy || submission.expired}
+            isRecording={voice.recording}
+            isTranscribing={voice.transcribing}
+            durationLabel={voice.durationLabel}
+            waveformLevels={voice.waveformLevels}
+            onDiscard={voice.onCancel}
+            onStop={() => {
+              void voice.onSubmit();
+            }}
+          />
+        ) : null}
+        {pendingInput?.progress ? (
+          <Button
+            type="submit"
+            size="sm"
+            className="rounded-full px-4"
+            disabled={
+              pendingInput.responding ||
+              (pendingInput.progress.isLastQuestion
+                ? !pendingInput.answersComplete
+                : !pendingInput.progress.canAdvance)
+            }
+          >
+            {pendingInput.responding
+              ? "Submitting..."
+              : pendingInput.progress.isLastQuestion
+                ? "Submit answers"
+                : "Next question"}
+          </Button>
+        ) : submission.phase === "running" ? (
+          <Button
+            type="button"
+            variant="prominent"
+            size="icon-xs"
+            className="sm:size-[26px]"
+            onClick={submission.onInterrupt}
+            aria-label="Stop generation"
+            title="Stop the current response. On Mac, press Ctrl+C to interrupt."
+          >
+            <span aria-hidden="true" className="block size-2 rounded-[1px] bg-current" />
+          </Button>
+        ) : !submission.hasPendingUserInputs && !voice.recording && !voice.transcribing ? (
+          submission.showPlanFollowUp ? (
+            submission.hasPrompt ? (
+              <Button
+                type="submit"
+                size="sm"
+                className="h-9 rounded-full px-4 sm:h-8"
+                disabled={submission.busy || submission.connecting || submission.expired}
+              >
+                {submission.connecting || submission.busy ? "Sending..." : "Refine"}
+              </Button>
+            ) : (
+              <div className="flex items-center">
+                <Button
+                  type="submit"
+                  size="sm"
+                  className="h-9 rounded-l-full rounded-r-none px-4 sm:h-8"
+                  disabled={submission.busy || submission.connecting || submission.expired}
+                >
+                  {submission.connecting || submission.busy ? "Sending..." : "Implement"}
+                </Button>
+                <Menu>
+                  <MenuTrigger
+                    render={
+                      <Button
+                        size="sm"
+                        variant="default"
+                        className="h-9 rounded-l-none rounded-r-full border-l-white/12 px-2 sm:h-8"
+                        aria-label="Implementation actions"
+                        disabled={submission.busy || submission.connecting || submission.expired}
+                      />
+                    }
+                  >
+                    <ChevronDownIcon className="size-3.5" />
+                  </MenuTrigger>
+                  <ComposerPickerMenuPopup align="end" side="top">
+                    <MenuItem
+                      disabled={submission.busy || submission.connecting || submission.expired}
+                      onClick={() => void submission.onImplementInNewThread()}
+                    >
+                      Implement in a new thread
+                    </MenuItem>
+                  </ComposerPickerMenuPopup>
+                </Menu>
+              </div>
+            )
+          ) : (
+            <>
+              {voice.enabled ? (
+                <ComposerVoiceButton
+                  disabled={submission.connecting || submission.busy || submission.expired}
+                  isRecording={voice.recording}
+                  isTranscribing={voice.transcribing}
+                  durationLabel={voice.durationLabel}
+                  onClick={voice.onToggle}
+                />
+              ) : null}
+              <Button
+                type="submit"
+                variant="prominent"
+                size="icon-xs"
+                className="size-7 rounded-full sm:size-7"
+                disabled={
+                  submission.busy ||
+                  submission.connecting ||
+                  submission.expired ||
+                  voice.transcribing ||
+                  submission.preparingImages ||
+                  !submission.hasContent
+                }
+                aria-label={
+                  submission.connecting
+                    ? "Connecting"
+                    : voice.transcribing
+                      ? "Transcribing voice note"
+                      : submission.preparingImages
+                        ? "Optimizing image"
+                        : submission.preparingWorktree
+                          ? "Preparing worktree"
+                          : submission.busy
+                            ? "Sending"
+                            : "Send message"
+                }
+              >
+                {submission.connecting || submission.busy || submission.preparingImages ? (
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 14 14"
+                    fill="none"
+                    className="animate-spin"
+                    aria-hidden="true"
+                  >
+                    <circle
+                      cx="7"
+                      cy="7"
+                      r="5.5"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeDasharray="20 12"
+                    />
+                  </svg>
+                ) : (
+                  <ComposerSendArrowIcon
+                    aria-hidden="true"
+                    className="size-5 shrink-0 translate-y-px"
+                  />
+                )}
+              </Button>
+            </>
+          )
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/WorkflowRunCard.browser.tsx
+++ b/apps/web/src/components/chat/WorkflowRunCard.browser.tsx
@@ -1,0 +1,68 @@
+import { flushSync } from "react-dom";
+import { afterEach, expect, it, vi } from "vitest";
+import { cleanup, render } from "vitest-browser-react";
+
+import { ComposerColumnFrame } from "./ComposerColumnFrame";
+import { WorkflowRunCard } from "./WorkflowRunCard";
+import type { WorkflowRunState } from "./WorkflowRunCard.logic";
+
+afterEach(async () => {
+  await cleanup();
+  vi.useRealTimers();
+});
+
+it("updates live elapsed time locally and stops ticking when the workflow settles", async () => {
+  vi.useFakeTimers({ toFake: ["Date", "setInterval", "clearInterval"] });
+  vi.setSystemTime(new Date("2026-09-11T10:00:00.000Z"));
+  const workflowRun: WorkflowRunState = {
+    workflowTaskId: "workflow-clock",
+    name: "Review changes",
+    description: null,
+    startedAt: new Date().toISOString(),
+    status: "running",
+    settled: false,
+    pausedByUser: false,
+    runId: null,
+    scriptPath: null,
+    phases: null,
+    runningCount: 0,
+    agents: [],
+    taskIds: ["workflow-clock"],
+  };
+  const onParentRender = vi.fn();
+  const onAction = vi.fn();
+  function Parent({ run }: { run: WorkflowRunState }) {
+    onParentRender();
+    return (
+      <ComposerColumnFrame>
+        <WorkflowRunCard
+          workflowRun={run}
+          compact={false}
+          onCompactChange={onAction}
+          onOpenThread={onAction}
+          onStop={onAction}
+          onPause={onAction}
+          onResume={onAction}
+          onDismiss={onAction}
+        />
+      </ComposerColumnFrame>
+    );
+  }
+  const screen = await render(<Parent run={workflowRun} />);
+  await expect.element(screen.getByText("0s", { exact: true })).toBeVisible();
+  const parentRenderCount = onParentRender.mock.calls.length;
+
+  flushSync(() => vi.advanceTimersByTime(2_000));
+  await expect.element(screen.getByText("2s", { exact: true })).toBeVisible();
+  expect(onParentRender).toHaveBeenCalledTimes(parentRenderCount);
+
+  await screen.rerender(<Parent run={{ ...workflowRun, status: "completed", settled: true }} />);
+  await expect.element(screen.getByText("Completed", { exact: true })).toBeVisible();
+  await expect.element(screen.getByText("2s", { exact: true })).not.toBeInTheDocument();
+  expect(vi.getTimerCount()).toBe(0);
+
+  await screen.rerender(<Parent run={workflowRun} />);
+  expect(vi.getTimerCount()).toBe(1);
+  await screen.unmount();
+  expect(vi.getTimerCount()).toBe(0);
+});

--- a/apps/web/src/components/chat/WorkflowRunCard.tsx
+++ b/apps/web/src/components/chat/WorkflowRunCard.tsx
@@ -34,6 +34,7 @@ import {
 } from "~/lib/icons";
 import { cn } from "~/lib/utils";
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
+import { useNowMs } from "~/hooks/useNowMs";
 import { formatClockDuration } from "../../session-logic";
 import { Button } from "../ui/button";
 import { DisclosureChevron } from "../ui/DisclosureChevron";
@@ -58,7 +59,6 @@ import {
 
 interface WorkflowRunCardProps {
   workflowRun: WorkflowRunState;
-  nowMs: number;
   compact: boolean;
   onCompactChange: (compact: boolean) => void;
   onOpenThread: (threadId: ThreadId) => void;
@@ -278,7 +278,6 @@ function WorkflowAgentRowView({
 
 export function WorkflowRunCard({
   workflowRun,
-  nowMs,
   compact,
   onCompactChange,
   onOpenThread,
@@ -288,6 +287,8 @@ export function WorkflowRunCard({
   onDismiss,
   attachedToPrevious: attachedToPreviousProp,
 }: WorkflowRunCardProps) {
+  // Keep elapsed-time ticks local to the card instead of rerendering ChatView.
+  const nowMs = useNowMs(!workflowRun.settled);
   const attachedToPrevious = attachedToPreviousProp ?? false;
   const { copyToClipboard, isCopied } = useCopyToClipboard();
   // Default view lists every phase's agents (grouped); a pill click narrows to

--- a/apps/web/src/components/chat/automationSetupBubble.ts
+++ b/apps/web/src/components/chat/automationSetupBubble.ts
@@ -1,0 +1,13 @@
+import { newMessageId } from "~/lib/utils";
+import { type ChatMessage } from "../../types";
+
+export function makeAutomationSetupBubble(role: "user" | "assistant", text: string): ChatMessage {
+  return {
+    id: newMessageId(),
+    role,
+    text,
+    createdAt: new Date().toISOString(),
+    streaming: false,
+    source: "native",
+  };
+}

--- a/apps/web/src/components/chat/chatSendTypes.ts
+++ b/apps/web/src/components/chat/chatSendTypes.ts
@@ -1,0 +1,296 @@
+import type {
+  MessageId,
+  ModelSelection,
+  ProviderInteractionMode,
+  ProviderKind,
+  ProviderStartOptions,
+  RuntimeMode,
+  ThreadId,
+} from "@synara/contracts";
+import type { QueryClient, UseMutationResult } from "@tanstack/react-query";
+import type { Dispatch, RefObject, SetStateAction } from "react";
+import type { useRefreshProviderStatusesNow } from "~/hooks/useProviderStatusRefresh";
+import type { gitCreateDetachedWorktreeMutationOptions } from "~/lib/gitReactQuery";
+import type { AppSettings } from "../../appSettings";
+import type {
+  DraftThreadEnvMode,
+  QueuedComposerChatTurn,
+  QueuedComposerPlanFollowUp,
+} from "../../composerDraftStore";
+import type { useComposerImageIntake } from "../../hooks/useComposerImageIntake";
+import type { PendingUserInputDraftAnswer } from "../../pendingUserInput";
+import type { LatestProposedPlanState } from "../../session-logic";
+import type { useStore } from "../../store";
+import type { Project, Thread } from "../../types";
+import type { QueuedSteerGate } from "../ChatView.logic";
+import type { useChatAutomationCreation } from "./useChatAutomationCreation";
+import type { useChatAutomationSetup } from "./useChatAutomationSetup";
+import type { useChatComposerDraft } from "./useChatComposerDraft";
+import type { useChatLocalDispatch } from "./useChatLocalDispatch";
+import type { useChatPendingInteractions } from "./useChatPendingInteractions";
+import type { useChatProjectScripts } from "./useChatProjectScripts";
+import type { useChatProviderModels } from "./useChatProviderModels";
+import type { useChatProviderStatus } from "./useChatProviderStatus";
+import type { useChatRuntimeModes } from "./useChatRuntimeModes";
+import type { useChatTimelineMessages } from "./useChatTimelineMessages";
+import type { useChatTranscriptScroll } from "./useChatTranscriptScroll";
+import type { useComposerReferences } from "./useComposerReferences";
+import type { useComposerVoiceController } from "./useComposerVoiceController";
+
+export interface PlanFollowUpSubmission {
+  text: string;
+  interactionMode: "default" | "plan";
+  dispatchMode: "queue" | "steer";
+  queuedTurn?: QueuedComposerPlanFollowUp;
+}
+
+/**
+ * Send-path handlers that are declared *after* `onSend` in the component body (they depend on
+ * state and callbacks that are set up later) yet have to be reachable from it — and, for
+ * `send` itself, from the queued-turn dispatcher that is declared before it.
+ *
+ * Reading a later-declared binding from an earlier one makes React Compiler bail out on the
+ * whole component ("Cannot access variable before it is declared") — silently, since
+ * `panicThreshold` is unset — which would drop memoization for the single hottest component in
+ * the app. Routing those calls through one latest-value ref keeps every reference well-ordered.
+ * The ref is only ever read from user-driven send flows, never during render, and it is
+ * refreshed in a layout effect so no passive-effect window can serve a stale handler.
+ */
+
+export interface LateComposerSendHandlers {
+  readonly send: (
+    event?: { preventDefault: () => void },
+    dispatchMode?: "queue" | "steer",
+    queuedTurn?: QueuedComposerChatTurn,
+  ) => Promise<boolean>;
+  readonly submitPlanFollowUp: (submission: PlanFollowUpSubmission) => Promise<boolean>;
+  readonly advanceActivePendingUserInput: (
+    answerOverrides?: Record<string, PendingUserInputDraftAnswer>,
+  ) => boolean;
+  readonly handleStandaloneSlashCommand: (trimmedPrompt: string) => Promise<boolean>;
+}
+
+export interface ChatTurnSubmissionInput {
+  threadId: ThreadId;
+  hasLiveTurn: boolean;
+  lateComposerSendHandlersRef: RefObject<LateComposerSendHandlers | null>;
+  activeThread: Thread | undefined;
+  isConnecting: boolean;
+  sendPreflightInFlightRef: RefObject<boolean>;
+  sendInFlightRef: RefObject<boolean>;
+  runtimeMode: RuntimeMode;
+  interactionMode: ProviderInteractionMode;
+  envMode: DraftThreadEnvMode;
+  showPlanFollowUpPrompt: boolean;
+  activeProposedPlan: LatestProposedPlanState | null;
+  hasQueueableLiveTurn: boolean;
+  clearComposerInput: (threadId: ThreadId) => void;
+  scheduleComposerFocus: () => void;
+  activeProject: Project | undefined;
+  threadWorkspaceCwd: string | null;
+  refreshProviderStatuses: ReturnType<typeof useRefreshProviderStatusesNow>;
+  isServerThread: boolean;
+  hasNativeUserMessages: boolean;
+  chatWorkspaceRoot: string | null;
+  isHomeChatContainer: boolean;
+  isStudioContainer: boolean;
+  resolvedThreadWorktreePath: string | null;
+  resolvedThreadWorkingDirectory: string | null;
+  currentActiveGitBranch: string | null;
+  isContainerLandingProject: boolean;
+  syncServerShellSnapshot: ReturnType<typeof useStore.getState>["syncServerShellSnapshot"];
+  activeRootBranch: string | null;
+  gitBranchSourceCwd: string | null;
+  setStoreThreadError: (threadId: ThreadId, error: string | null) => void;
+  queryClient: QueryClient;
+  isCenteredEmptyLanding: boolean;
+  setEnvironmentPanelPreferenceOpen: Dispatch<SetStateAction<boolean | null>>;
+  environmentPanelPreferenceOpen: boolean | null;
+  setTailAnchor: Dispatch<SetStateAction<{ threadId: ThreadId; messageId: MessageId } | null>>;
+  setThreadError: (targetThreadId: ThreadId | null, error: string | null) => void;
+  setComposerHighlightedItemId: Dispatch<SetStateAction<string | null>>;
+  setStoreThreadWorkspace: ReturnType<typeof useStore.getState>["setThreadWorkspace"];
+  createWorktreeMutation: UseMutationResult<
+    Awaited<
+      ReturnType<
+        NonNullable<ReturnType<typeof gitCreateDetachedWorktreeMutationOptions>["mutationFn"]>
+      >
+    >,
+    Error,
+    Parameters<
+      NonNullable<ReturnType<typeof gitCreateDetachedWorktreeMutationOptions>["mutationFn"]>
+    >[0]
+  >;
+  isLocalDraftThread: boolean;
+  threadNotes: string;
+  assistantDeliveryMode: "streaming" | "buffered";
+  setSettledThreadBranchWarningDismissedThreadId: Dispatch<SetStateAction<ThreadId | null>>;
+  setQueuedSteerGate: Dispatch<SetStateAction<QueuedSteerGate | null>>;
+  planSidebarDismissedForTurnRef: RefObject<string | null>;
+  setPlanSidebarOpen: Dispatch<SetStateAction<boolean>>;
+  settings: AppSettings;
+  isSendBusy: ReturnType<typeof useChatLocalDispatch>["isSendBusy"];
+  worktreeSetupResolutionRef: ReturnType<typeof useChatLocalDispatch>["worktreeSetupResolutionRef"];
+  setWorktreeSetupPendingAction: ReturnType<
+    typeof useChatLocalDispatch
+  >["setWorktreeSetupPendingAction"];
+  beginLocalDispatch: ReturnType<typeof useChatLocalDispatch>["beginLocalDispatch"];
+  clearLocalDispatchWorktreeSetup: ReturnType<
+    typeof useChatLocalDispatch
+  >["clearLocalDispatchWorktreeSetup"];
+  armLocalDispatchAckFallback: ReturnType<
+    typeof useChatLocalDispatch
+  >["armLocalDispatchAckFallback"];
+  failLocalDispatchWorktreeSetup: ReturnType<
+    typeof useChatLocalDispatch
+  >["failLocalDispatchWorktreeSetup"];
+  scheduleFailedWorktreeSetupDispatchReset: ReturnType<
+    typeof useChatLocalDispatch
+  >["scheduleFailedWorktreeSetupDispatchReset"];
+  resetLocalDispatch: ReturnType<typeof useChatLocalDispatch>["resetLocalDispatch"];
+  isVoiceTranscribing: ReturnType<typeof useComposerVoiceController>["isVoiceTranscribing"];
+  waitForPendingComposerImages: ReturnType<typeof useComposerImageIntake>["waitForPending"];
+  activePendingProgress: ReturnType<typeof useChatPendingInteractions>["activePendingProgress"];
+  activePendingUserInputKey: ReturnType<
+    typeof useChatPendingInteractions
+  >["activePendingUserInputKey"];
+  pendingUserInputAnswersByRequestIdRef: ReturnType<
+    typeof useChatPendingInteractions
+  >["pendingUserInputAnswersByRequestIdRef"];
+  setPendingUserInputAnswersByRequestId: ReturnType<
+    typeof useChatPendingInteractions
+  >["setPendingUserInputAnswersByRequestId"];
+  composerEditorRef: ReturnType<typeof useChatComposerDraft>["composerEditorRef"];
+  promptRef: ReturnType<typeof useChatComposerDraft>["promptRef"];
+  composerImages: ReturnType<typeof useChatComposerDraft>["composerImages"];
+  composerFiles: ReturnType<typeof useChatComposerDraft>["composerFiles"];
+  composerAssistantSelections: ReturnType<
+    typeof useChatComposerDraft
+  >["composerAssistantSelections"];
+  composerBrowserAnnotations: ReturnType<typeof useChatComposerDraft>["composerBrowserAnnotations"];
+  composerFileComments: ReturnType<typeof useChatComposerDraft>["composerFileComments"];
+  composerTerminalContexts: ReturnType<typeof useChatComposerDraft>["composerTerminalContexts"];
+  composerPastedTexts: ReturnType<typeof useChatComposerDraft>["composerPastedTexts"];
+  composerPullRequestContexts: ReturnType<
+    typeof useChatComposerDraft
+  >["composerPullRequestContexts"];
+  restoredQueuedSourceProposedPlanRef: ReturnType<
+    typeof useChatComposerDraft
+  >["restoredQueuedSourceProposedPlanRef"];
+  enqueueQueuedComposerTurn: ReturnType<typeof useChatComposerDraft>["enqueueQueuedComposerTurn"];
+  setComposerDraftPrompt: ReturnType<typeof useChatComposerDraft>["setComposerDraftPrompt"];
+  setComposerTrigger: ReturnType<typeof useChatComposerDraft>["setComposerTrigger"];
+  clearProjectDraftThreadId: ReturnType<typeof useChatComposerDraft>["clearProjectDraftThreadId"];
+  setDraftThreadContext: ReturnType<typeof useChatComposerDraft>["setDraftThreadContext"];
+  promptHistoryNavigationRef: ReturnType<typeof useChatComposerDraft>["promptHistoryNavigationRef"];
+  applyingPromptHistoryNavigationRef: ReturnType<
+    typeof useChatComposerDraft
+  >["applyingPromptHistoryNavigationRef"];
+  expectedPromptHistoryPromptRef: ReturnType<
+    typeof useChatComposerDraft
+  >["expectedPromptHistoryPromptRef"];
+  clearComposerDraftContent: ReturnType<typeof useChatComposerDraft>["clearComposerDraftContent"];
+  setComposerDraftInteractionMode: ReturnType<
+    typeof useChatComposerDraft
+  >["setComposerDraftInteractionMode"];
+  setComposerCursor: ReturnType<typeof useChatComposerDraft>["setComposerCursor"];
+  setRestoredQueuedSourceProposedPlan: ReturnType<
+    typeof useChatComposerDraft
+  >["setRestoredQueuedSourceProposedPlan"];
+  composerImagesRef: ReturnType<typeof useChatComposerDraft>["composerImagesRef"];
+  composerFilesRef: ReturnType<typeof useChatComposerDraft>["composerFilesRef"];
+  composerAssistantSelectionsRef: ReturnType<
+    typeof useChatComposerDraft
+  >["composerAssistantSelectionsRef"];
+  composerBrowserAnnotationsRef: ReturnType<
+    typeof useChatComposerDraft
+  >["composerBrowserAnnotationsRef"];
+  composerFileCommentsRef: ReturnType<typeof useChatComposerDraft>["composerFileCommentsRef"];
+  composerTerminalContextsRef: ReturnType<
+    typeof useChatComposerDraft
+  >["composerTerminalContextsRef"];
+  composerPastedTextsRef: ReturnType<typeof useChatComposerDraft>["composerPastedTextsRef"];
+  composerPullRequestContextsRef: ReturnType<
+    typeof useChatComposerDraft
+  >["composerPullRequestContextsRef"];
+  setPrompt: ReturnType<typeof useChatComposerDraft>["setPrompt"];
+  addComposerImagesToDraft: ReturnType<typeof useChatComposerDraft>["addComposerImagesToDraft"];
+  addComposerFilesToDraft: ReturnType<typeof useChatComposerDraft>["addComposerFilesToDraft"];
+  addComposerAssistantSelectionToDraft: ReturnType<
+    typeof useChatComposerDraft
+  >["addComposerAssistantSelectionToDraft"];
+  addComposerDraftBrowserAnnotations: ReturnType<
+    typeof useChatComposerDraft
+  >["addComposerDraftBrowserAnnotations"];
+  addComposerFileCommentToDraft: ReturnType<
+    typeof useChatComposerDraft
+  >["addComposerFileCommentToDraft"];
+  addComposerTerminalContextsToDraft: ReturnType<
+    typeof useChatComposerDraft
+  >["addComposerTerminalContextsToDraft"];
+  addComposerPastedTextsToDraft: ReturnType<
+    typeof useChatComposerDraft
+  >["addComposerPastedTextsToDraft"];
+  addComposerPullRequestContextsToDraft: ReturnType<
+    typeof useChatComposerDraft
+  >["addComposerPullRequestContextsToDraft"];
+  selectedComposerSkillsRef: ReturnType<typeof useComposerReferences>["selectedComposerSkillsRef"];
+  selectedComposerMentionsRef: ReturnType<
+    typeof useComposerReferences
+  >["selectedComposerMentionsRef"];
+  updateSelectedComposerSkills: ReturnType<
+    typeof useComposerReferences
+  >["updateSelectedComposerSkills"];
+  updateSelectedComposerMentions: ReturnType<
+    typeof useComposerReferences
+  >["updateSelectedComposerMentions"];
+  selectedProvider: ProviderKind;
+  selectedModel: string;
+  selectedPromptEffort: ReturnType<typeof useChatProviderModels>["selectedPromptEffort"];
+  selectedModelSelection: ModelSelection;
+  providerOptionsForDispatch: ProviderStartOptions | undefined;
+  pendingAutomationConversationRef: ReturnType<
+    typeof useChatAutomationSetup
+  >["pendingAutomationConversationRef"];
+  setPendingAutomationConversation: ReturnType<
+    typeof useChatAutomationSetup
+  >["setPendingAutomationConversation"];
+  pendingAutomationConversation: ReturnType<
+    typeof useChatAutomationSetup
+  >["pendingAutomationConversation"];
+  activeThreadIdRef: ReturnType<typeof useChatAutomationSetup>["activeThreadIdRef"];
+  hasLiveTurnRef: ReturnType<typeof useChatAutomationSetup>["hasLiveTurnRef"];
+  automationProjects: ReturnType<typeof useChatAutomationSetup>["automationProjects"];
+  setAutomationDraftWarningContext: ReturnType<
+    typeof useChatAutomationSetup
+  >["setAutomationDraftWarningContext"];
+  setAutomationDraftForm: ReturnType<typeof useChatAutomationSetup>["setAutomationDraftForm"];
+  setAutomationDraftWarnings: ReturnType<
+    typeof useChatAutomationSetup
+  >["setAutomationDraftWarnings"];
+  setAcknowledgedAutomationWarnings: ReturnType<
+    typeof useChatAutomationSetup
+  >["setAcknowledgedAutomationWarnings"];
+  setAutomationDraftOpen: ReturnType<typeof useChatAutomationSetup>["setAutomationDraftOpen"];
+  armTranscriptAutoFollow: ReturnType<typeof useChatTranscriptScroll>["armTranscriptAutoFollow"];
+  tailAnchorScrollInFlightRef: ReturnType<
+    typeof useChatTranscriptScroll
+  >["tailAnchorScrollInFlightRef"];
+  prepareAutomationFormForCreate: ReturnType<
+    typeof useChatAutomationCreation
+  >["prepareAutomationFormForCreate"];
+  createAutomationFromForm: ReturnType<
+    typeof useChatAutomationCreation
+  >["createAutomationFromForm"];
+  providerStatuses: ReturnType<typeof useChatProviderStatus>["providerStatuses"];
+  rememberCustomBinaryPathForDispatch: ReturnType<
+    typeof useChatProviderStatus
+  >["rememberCustomBinaryPathForDispatch"];
+  setOptimisticUserMessages: ReturnType<
+    typeof useChatTimelineMessages
+  >["setOptimisticUserMessages"];
+  runProjectScript: ReturnType<typeof useChatProjectScripts>["runProjectScript"];
+  persistThreadSettingsForNextTurn: ReturnType<
+    typeof useChatRuntimeModes
+  >["persistThreadSettingsForNextTurn"];
+}

--- a/apps/web/src/components/chat/handleChatAutomationSend.ts
+++ b/apps/web/src/components/chat/handleChatAutomationSend.ts
@@ -1,0 +1,218 @@
+import { ThreadId, type ModelSelection, type ProviderStartOptions } from "@synara/contracts";
+import { readNativeApi } from "~/nativeApi";
+import {
+  automationClarificationPrompt,
+  buildComposerAutomationDraft,
+  resolveComposerAutomationRequest,
+} from "../../lib/composerAutomation";
+import { projectModelSelection as automationProjectModelSelection } from "../../routes/-automations.shared";
+import type { Project } from "../../types";
+import { type Thread } from "../../types";
+import { useChatAutomationCreation } from "./useChatAutomationCreation";
+import { useChatAutomationSetup } from "./useChatAutomationSetup";
+import { useChatComposerDraft } from "./useChatComposerDraft";
+import { useChatTranscriptScroll } from "./useChatTranscriptScroll";
+import { toastManager } from "../ui/toast";
+import { makeAutomationSetupBubble } from "./automationSetupBubble";
+interface ChatAutomationSendInput {
+  threadId: ThreadId;
+  pendingAutomationConversation: ReturnType<
+    typeof useChatAutomationSetup
+  >["pendingAutomationConversation"];
+  trimmedPromptForSend: string;
+  threadWorkspaceCwd: string | null;
+  activeProject: Project;
+  api: NonNullable<ReturnType<typeof readNativeApi>>;
+  activeThreadIdRef: ReturnType<typeof useChatAutomationSetup>["activeThreadIdRef"];
+  pendingAutomationConversationRef: ReturnType<
+    typeof useChatAutomationSetup
+  >["pendingAutomationConversationRef"];
+  hasLiveTurn: boolean;
+  hasLiveTurnRef: ReturnType<typeof useChatAutomationSetup>["hasLiveTurnRef"];
+  hasPromptOnlySendableContent: boolean;
+  promptRef: ReturnType<typeof useChatComposerDraft>["promptRef"];
+  setComposerDraftPrompt: ReturnType<typeof useChatComposerDraft>["setComposerDraftPrompt"];
+  activeThread: Thread;
+  setComposerTrigger: ReturnType<typeof useChatComposerDraft>["setComposerTrigger"];
+  armTranscriptAutoFollow: ReturnType<typeof useChatTranscriptScroll>["armTranscriptAutoFollow"];
+  setPendingAutomationConversation: ReturnType<
+    typeof useChatAutomationSetup
+  >["setPendingAutomationConversation"];
+  automationProjects: ReturnType<typeof useChatAutomationSetup>["automationProjects"];
+  selectedModelSelectionForSend: ModelSelection;
+  setAutomationDraftWarningContext: ReturnType<
+    typeof useChatAutomationSetup
+  >["setAutomationDraftWarningContext"];
+  setAutomationDraftForm: ReturnType<typeof useChatAutomationSetup>["setAutomationDraftForm"];
+  setAutomationDraftWarnings: ReturnType<
+    typeof useChatAutomationSetup
+  >["setAutomationDraftWarnings"];
+  setAcknowledgedAutomationWarnings: ReturnType<
+    typeof useChatAutomationSetup
+  >["setAcknowledgedAutomationWarnings"];
+  setAutomationDraftOpen: ReturnType<typeof useChatAutomationSetup>["setAutomationDraftOpen"];
+  prepareAutomationFormForCreate: ReturnType<
+    typeof useChatAutomationCreation
+  >["prepareAutomationFormForCreate"];
+  createAutomationFromForm: ReturnType<
+    typeof useChatAutomationCreation
+  >["createAutomationFromForm"];
+  providerOptionsForDispatchForSend: ProviderStartOptions | undefined;
+}
+
+export async function handleChatAutomationSend({
+  threadId,
+  pendingAutomationConversation,
+  trimmedPromptForSend,
+  threadWorkspaceCwd,
+  activeProject,
+  api,
+  activeThreadIdRef,
+  pendingAutomationConversationRef,
+  hasLiveTurn,
+  hasLiveTurnRef,
+  hasPromptOnlySendableContent,
+  promptRef,
+  setComposerDraftPrompt,
+  activeThread,
+  setComposerTrigger,
+  armTranscriptAutoFollow,
+  setPendingAutomationConversation,
+  automationProjects,
+  selectedModelSelectionForSend,
+  setAutomationDraftWarningContext,
+  setAutomationDraftForm,
+  setAutomationDraftWarnings,
+  setAcknowledgedAutomationWarnings,
+  setAutomationDraftOpen,
+  prepareAutomationFormForCreate,
+  createAutomationFromForm,
+  providerOptionsForDispatchForSend,
+}: ChatAutomationSendInput): Promise<boolean> {
+  const conversation = pendingAutomationConversation;
+  // While gathering missing details, fold the reply into the cleaned request so it
+  // re-resolves as a whole rather than parsing the bare answer (and never re-parses
+  // "could you create an automation" scaffolding as the task).
+  const messageForAutomation = conversation
+    ? `${conversation.accumulatedMessage}\n${trimmedPromptForSend}`
+    : trimmedPromptForSend;
+  const automationRequest = await resolveComposerAutomationRequest({
+    message: messageForAutomation,
+    cwd: threadWorkspaceCwd ?? activeProject.cwd,
+    generateIntent: (request) => api.server.generateAutomationIntent(request),
+  });
+  // Drop a stale resolve: bail if the user switched threads, or cancelled/changed the
+  // setup, while generateAutomationIntent was awaiting.
+  if (
+    activeThreadIdRef.current !== threadId ||
+    pendingAutomationConversationRef.current !== conversation ||
+    (!hasLiveTurn && hasLiveTurnRef.current)
+  ) {
+    return true;
+  }
+  if (automationRequest.type !== "normal-chat") {
+    if (automationRequest.type === "needs-clarification") {
+      // Conversational setup only runs for prompt-only sends while no turn is live:
+      // clearing the composer would drop attachments/mentions Cancel can't restore,
+      // and ephemeral setup bubbles must not anchor a running turn's work rows.
+      if (!hasPromptOnlySendableContent || hasLiveTurn) {
+        toastManager.add({
+          type: "warning",
+          title: "Automation needs a bit more detail",
+          description:
+            automationRequest.reason ??
+            'Add what it should do and how often, e.g. "every weekday at 9am, summarize my PRs".',
+        });
+        return true;
+      }
+      // Render the exchange in-thread: echo the user's words as a bubble and ask for
+      // what's missing as an assistant bubble. Nothing reaches a provider; the cleaned
+      // automationMessage accumulates for the next re-resolve and for Cancel's restore.
+      const question = automationClarificationPrompt(automationRequest.missingFields);
+      const priorBubbles = conversation?.bubbles ?? [];
+      // Drop the submitted request from the composer (it is captured in
+      // accumulatedMessage, so re-folding it would duplicate the scaffold) while
+      // preserving anything typed *after* it during the async resolve.
+      const liveDraft = promptRef.current.trimStart();
+      const leftover = liveDraft.startsWith(trimmedPromptForSend)
+        ? liveDraft.slice(trimmedPromptForSend.length).trimStart()
+        : liveDraft;
+      promptRef.current = leftover;
+      setComposerDraftPrompt(activeThread.id, leftover);
+      setComposerTrigger(null);
+      // Bring the new question into view even if the user had scrolled up.
+      armTranscriptAutoFollow(activeThread.id, true);
+      setPendingAutomationConversation({
+        threadId: activeThread.id,
+        accumulatedMessage: automationRequest.automationMessage,
+        bubbles: [
+          ...priorBubbles,
+          makeAutomationSetupBubble("user", trimmedPromptForSend),
+          makeAutomationSetupBubble("assistant", question),
+        ],
+      });
+      return true;
+    }
+
+    pendingAutomationConversationRef.current = null;
+    setPendingAutomationConversation(null);
+    const automationIntent = automationRequest.resolution.intent;
+    const automationTargetThreadId =
+      automationIntent.executionScope === "thread" ? activeThread.id : null;
+    const automationDraft = buildComposerAutomationDraft({
+      resolution: automationRequest.resolution,
+      projectId: activeProject.id,
+      projectModelSelection: automationProjectModelSelection(automationProjects, activeProject.id),
+      selectedModelSelection: selectedModelSelectionForSend,
+      targetThreadId: automationTargetThreadId,
+      hasEphemeralContext: !hasPromptOnlySendableContent,
+    });
+    // A multi-turn setup always confirms before creating, so the user reviews the
+    // parsed task/schedule (and any scaffolding the parser kept) rather than it
+    // silently auto-creating a recurring job.
+    if (automationDraft.needsDraftReview || conversation !== null) {
+      if (conversation !== null) {
+        // Keep the full multi-turn request in the composer so dismissing the review
+        // dialog doesn't lose it (the single-turn path likewise leaves its text).
+        // Restore only the text; any attachments/mentions on the final reply stay.
+        const liveDraft = promptRef.current.trimStart();
+        const leftover = liveDraft.startsWith(trimmedPromptForSend)
+          ? liveDraft.slice(trimmedPromptForSend.length).trimStart()
+          : liveDraft;
+        const restoredPrompt = leftover
+          ? `${messageForAutomation}\n${leftover}`
+          : messageForAutomation;
+        promptRef.current = restoredPrompt;
+        setComposerDraftPrompt(activeThread.id, restoredPrompt);
+      }
+      setAutomationDraftWarningContext(automationDraft.warningContext);
+      setAutomationDraftForm(automationDraft.form);
+      setAutomationDraftWarnings(automationDraft.warnings);
+      setAcknowledgedAutomationWarnings(automationDraft.acknowledgedWarningIds);
+      setAutomationDraftOpen(true);
+      return true;
+    }
+    const preparedAutomation = await prepareAutomationFormForCreate(automationDraft.form);
+    if (!preparedAutomation) {
+      return true;
+    }
+    await createAutomationFromForm({
+      form: preparedAutomation.form,
+      warnings: automationDraft.warnings,
+      acknowledgedWarningIds: automationDraft.acknowledgedWarningIds,
+      activityThreadId: preparedAutomation.activityThreadId,
+      ...(providerOptionsForDispatchForSend
+        ? { providerOptions: providerOptionsForDispatchForSend }
+        : {}),
+    });
+    return true;
+  }
+  if (conversation) {
+    // The combined text no longer reads as an automation; abandon setup and let
+    // this message send as a normal chat turn instead of looping on the question.
+    pendingAutomationConversationRef.current = null;
+    setPendingAutomationConversation(null);
+  }
+
+  return false;
+}

--- a/apps/web/src/components/chat/prepareChatSendWorkspace.ts
+++ b/apps/web/src/components/chat/prepareChatSendWorkspace.ts
@@ -1,0 +1,367 @@
+import {
+  DEFAULT_MODEL_BY_PROVIDER,
+  RuntimeMode,
+  ThreadId,
+  type ModelSelection,
+} from "@synara/contracts";
+import {
+  GENERIC_CHAT_THREAD_TITLE,
+  buildPromptThreadTitleFallback,
+} from "@synara/shared/chatThreads";
+import { getDefaultModel } from "@synara/shared/model";
+import type { QueryClient } from "@tanstack/react-query";
+import { gitStatusQueryOptions } from "~/lib/gitReactQuery";
+import { newCommandId, newProjectId } from "~/lib/utils";
+import { readNativeApi } from "~/nativeApi";
+import { setupProjectScript } from "~/projectScripts";
+import {
+  useComposerDraftStore,
+  type BrowserAnnotationDraft,
+  type ComposerAssistantSelectionAttachment,
+  type ComposerFileAttachment,
+  type ComposerImageAttachment,
+  type DraftThreadEnvMode,
+} from "../../composerDraftStore";
+import { formatAssistantSelectionTitleSeed } from "../../lib/assistantSelections";
+import { formatBrowserAnnotationLabel } from "../../lib/browserAnnotations";
+import { resolveFirstSendTarget } from "../../lib/chatFirstSend";
+import { type PastedTextDraft } from "../../lib/composerPastedText";
+import { formatFileCommentTitleSeed, type FileCommentDraft } from "../../lib/fileComments";
+import {
+  isDuplicateProjectCreateError,
+  waitForRecoverableProjectForDuplicateCreate,
+} from "../../lib/projectCreateRecovery";
+import { formatTerminalContextLabel, type TerminalContextDraft } from "../../lib/terminalContext";
+import { buildModelSelection } from "../../providerModelOptions";
+import { readActiveSpaceId } from "../../spacesUiStore";
+import { useStore } from "../../store";
+import type { Project } from "../../types";
+import { type Thread } from "../../types";
+import { formatPastedTextTitleSeed } from "./queuedComposerPreview";
+interface Input {
+  activeThread: Thread;
+  isServerThread: boolean;
+  hasNativeUserMessages: boolean;
+  composerImagesForSend: ComposerImageAttachment[];
+  trimmedPromptForSend: string;
+  composerFilesForSend: ComposerFileAttachment[];
+  composerAssistantSelectionsForSend: ComposerAssistantSelectionAttachment[];
+  composerBrowserAnnotationsForSend: BrowserAnnotationDraft[];
+  sendableComposerTerminalContexts: TerminalContextDraft[];
+  composerFileCommentsForSend: FileCommentDraft[];
+  sendableComposerPastedTexts: PastedTextDraft[];
+  selectedModelSelectionForSend: ModelSelection;
+  selectedModelForSend: string;
+  activeProject: Project;
+  chatWorkspaceRoot: string | null;
+  isHomeChatContainer: boolean;
+  isStudioContainer: boolean;
+  resolvedThreadWorktreePath: string | null;
+  runtimeModeForSend: RuntimeMode;
+  envModeForSend: DraftThreadEnvMode;
+  resolvedThreadWorkingDirectory: string | null;
+  currentActiveGitBranch: string | null;
+  isContainerLandingProject: boolean;
+  api: NonNullable<ReturnType<typeof readNativeApi>>;
+  syncServerShellSnapshot: ReturnType<typeof useStore.getState>["syncServerShellSnapshot"];
+  clearProjectDraftThreadId: ReturnType<
+    typeof useComposerDraftStore.getState
+  >["clearProjectDraftThreadId"];
+  setDraftThreadContext: ReturnType<typeof useComposerDraftStore.getState>["setDraftThreadContext"];
+  activeRootBranch: string | null;
+  gitBranchSourceCwd: string | null;
+  setStoreThreadError: (threadId: ThreadId, error: string | null) => void;
+  queryClient: QueryClient;
+}
+
+export async function prepareChatSendWorkspace({
+  activeThread,
+  isServerThread,
+  hasNativeUserMessages,
+  composerImagesForSend,
+  trimmedPromptForSend,
+  composerFilesForSend,
+  composerAssistantSelectionsForSend,
+  composerBrowserAnnotationsForSend,
+  sendableComposerTerminalContexts,
+  composerFileCommentsForSend,
+  sendableComposerPastedTexts,
+  selectedModelSelectionForSend,
+  selectedModelForSend,
+  activeProject,
+  chatWorkspaceRoot,
+  isHomeChatContainer,
+  isStudioContainer,
+  resolvedThreadWorktreePath,
+  runtimeModeForSend,
+  envModeForSend,
+  resolvedThreadWorkingDirectory,
+  currentActiveGitBranch,
+  isContainerLandingProject,
+  api,
+  syncServerShellSnapshot,
+  clearProjectDraftThreadId,
+  setDraftThreadContext,
+  activeRootBranch,
+  gitBranchSourceCwd,
+  setStoreThreadError,
+  queryClient,
+}: Input) {
+  const threadIdForSend = activeThread.id;
+  const isFirstMessage = !isServerThread || !hasNativeUserMessages;
+  const firstSendCreatedAt = new Date();
+  let firstComposerImageNameForTitle: string | null = null;
+  if (composerImagesForSend.length > 0) {
+    firstComposerImageNameForTitle = composerImagesForSend[0]?.name ?? null;
+  }
+  let titleSeed = trimmedPromptForSend;
+  if (!titleSeed) {
+    if (firstComposerImageNameForTitle) {
+      titleSeed = `Image: ${firstComposerImageNameForTitle}`;
+    } else if (composerFilesForSend.length > 0) {
+      titleSeed = `File: ${composerFilesForSend[0]?.name ?? "attachment"}`;
+    } else if (composerAssistantSelectionsForSend.length > 0) {
+      titleSeed = formatAssistantSelectionTitleSeed(composerAssistantSelectionsForSend.length);
+    } else if (composerBrowserAnnotationsForSend.length > 0) {
+      titleSeed = formatBrowserAnnotationLabel(composerBrowserAnnotationsForSend[0]!);
+    } else if (sendableComposerTerminalContexts.length > 0) {
+      titleSeed = formatTerminalContextLabel(sendableComposerTerminalContexts[0]!);
+    } else if (composerFileCommentsForSend.length > 0) {
+      titleSeed = formatFileCommentTitleSeed(composerFileCommentsForSend.length);
+    } else if (sendableComposerPastedTexts.length > 0) {
+      titleSeed =
+        formatPastedTextTitleSeed(sendableComposerPastedTexts) ?? GENERIC_CHAT_THREAD_TITLE;
+    } else {
+      titleSeed = GENERIC_CHAT_THREAD_TITLE;
+    }
+  }
+  // Keep the optimistic label short while the server asks Codex for a better summary.
+  const title = buildPromptThreadTitleFallback(titleSeed);
+  const currentStoreState = useStore.getState();
+  // Keep an optimistically selected Space across the command/snapshot race. The server
+  // validates this best-effort target and degrades genuinely stale/deleted ids to Void.
+  const activeSpaceIdForSend = readActiveSpaceId();
+  const firstSendDefaultModelSelection = buildModelSelection(
+    selectedModelSelectionForSend.provider,
+    selectedModelSelectionForSend.model ||
+      selectedModelForSend ||
+      getDefaultModel(selectedModelSelectionForSend.provider) ||
+      DEFAULT_MODEL_BY_PROVIDER.codex,
+    selectedModelSelectionForSend.options,
+  );
+  const firstSendTarget = resolveFirstSendTarget({
+    activeProject,
+    chatWorkspaceRoot,
+    createdAt: firstSendCreatedAt,
+    defaultModelSelection: firstSendDefaultModelSelection,
+    isFirstMessage,
+    isHomeChatContainer,
+    isStudioContainer,
+    projects: currentStoreState.projects,
+    // Studio reference folders change the thread cwd without moving the chat out of
+    // the managed Studio project. Home-chat folder selection keeps its project routing.
+    selectedWorkspaceRoot: isHomeChatContainer ? (resolvedThreadWorktreePath ?? null) : null,
+    title,
+    titleSeed,
+  });
+  let {
+    targetProjectId: targetProjectIdForSend,
+    targetProjectKind: targetProjectKindForSend,
+    targetProjectCwd: targetProjectCwdForSend,
+    targetProjectScripts: targetProjectScriptsForSend,
+    targetProjectDefaultModelSelection: targetProjectDefaultModelSelectionForSend,
+  } = firstSendTarget.kind === "create-project"
+    ? {
+        targetProjectId: activeProject.id,
+        targetProjectKind: activeProject.kind,
+        targetProjectCwd: activeProject.cwd,
+        targetProjectScripts: activeProject.kind === "project" ? activeProject.scripts : [],
+        targetProjectDefaultModelSelection: activeProject.defaultModelSelection ?? null,
+      }
+    : firstSendTarget.target;
+  let nextRuntimeModeForSend = runtimeModeForSend;
+  let nextThreadEnvMode = envModeForSend;
+  let nextThreadBranch = isStudioContainer ? null : activeThread.branch;
+  let nextThreadWorktreePath = isStudioContainer ? null : activeThread.worktreePath;
+  let nextThreadWorkingDirectory = isStudioContainer
+    ? resolvedThreadWorkingDirectory
+    : (activeThread.workingDirectory ?? null);
+  let nextAssociatedWorktreePath = isStudioContainer
+    ? null
+    : (activeThread.associatedWorktreePath ?? null);
+  let nextAssociatedWorktreeBranch = isStudioContainer
+    ? null
+    : (activeThread.associatedWorktreeBranch ?? null);
+  let nextAssociatedWorktreeRef = isStudioContainer
+    ? null
+    : (activeThread.associatedWorktreeRef ?? null);
+  const shouldResumeSettledLocalThread =
+    isServerThread &&
+    activeThread.settledAt != null &&
+    nextThreadEnvMode === "local" &&
+    nextThreadWorktreePath === null;
+  let currentActiveGitBranchForSend = currentActiveGitBranch;
+
+  if (isFirstMessage && isContainerLandingProject && firstSendTarget.kind !== "current") {
+    if (firstSendTarget.kind === "create-project") {
+      const projectId = newProjectId();
+      const createdAt = firstSendCreatedAt.toISOString();
+      // Managed chat rows stay global; a folder mention creates an ordinary project and
+      // should inherit the Space where the first send originated. Resolved before the
+      // `try`: a value block inside a try body makes React Compiler bail out on the whole
+      // component.
+      const createProjectSpaceFields =
+        firstSendTarget.creation.kind === "project" ? { spaceId: activeSpaceIdForSend } : {};
+      try {
+        await api.orchestration.dispatchCommand({
+          type: "project.create",
+          commandId: newCommandId(),
+          projectId,
+          kind: firstSendTarget.creation.kind,
+          title: firstSendTarget.creation.title,
+          workspaceRoot: firstSendTarget.creation.workspaceRoot,
+          createWorkspaceRootIfMissing: firstSendTarget.creation.createWorkspaceRootIfMissing,
+          defaultModelSelection: firstSendTarget.creation.defaultModelSelection,
+          ...createProjectSpaceFields,
+          createdAt,
+        });
+        targetProjectIdForSend = projectId;
+        targetProjectKindForSend = firstSendTarget.creation.kind;
+        targetProjectCwdForSend = firstSendTarget.creation.workspaceRoot;
+        targetProjectScriptsForSend = [];
+        targetProjectDefaultModelSelectionForSend = firstSendTarget.creation.defaultModelSelection;
+      } catch (error) {
+        const description =
+          error instanceof Error ? error.message : "Failed to create the selected project.";
+        if (!isDuplicateProjectCreateError(description)) {
+          throw error;
+        }
+
+        // If the server already knows this workspace root, reuse that project and continue.
+        const { snapshot, project: recoveredProject } =
+          await waitForRecoverableProjectForDuplicateCreate({
+            message: description,
+            workspaceRoot: firstSendTarget.creation.workspaceRoot,
+            loadSnapshot: () => api.orchestration.getShellSnapshot().catch(() => null),
+          });
+        if (!snapshot || !recoveredProject) {
+          throw error;
+        }
+
+        syncServerShellSnapshot(snapshot);
+        targetProjectIdForSend = recoveredProject.id;
+        targetProjectKindForSend = recoveredProject.kind ?? firstSendTarget.creation.kind;
+        targetProjectCwdForSend = recoveredProject.workspaceRoot;
+        targetProjectScriptsForSend =
+          (recoveredProject.kind ?? firstSendTarget.creation.kind) === "project"
+            ? [...recoveredProject.scripts]
+            : [];
+        targetProjectDefaultModelSelectionForSend =
+          recoveredProject.defaultModelSelection ?? firstSendTarget.creation.defaultModelSelection;
+      }
+    }
+
+    clearProjectDraftThreadId(targetProjectIdForSend);
+    setDraftThreadContext(threadIdForSend, {
+      projectId: targetProjectIdForSend,
+      envMode: "local",
+      worktreePath: null,
+      workingDirectory: null,
+      branch: null,
+    });
+    nextThreadEnvMode = "local";
+    nextThreadBranch = null;
+    nextThreadWorktreePath = null;
+    nextThreadWorkingDirectory = null;
+    nextAssociatedWorktreePath = null;
+    nextAssociatedWorktreeBranch = null;
+    nextAssociatedWorktreeRef = null;
+  }
+
+  // The branch query can finish just after the user chooses New worktree. Use the
+  // resolved active branch at send time instead of rejecting an otherwise valid fast send.
+  if (
+    isFirstMessage &&
+    nextThreadEnvMode === "worktree" &&
+    !nextThreadWorktreePath &&
+    !nextThreadBranch
+  ) {
+    nextThreadBranch = activeRootBranch ?? null;
+  }
+
+  // A settled local thread keeps its historical branch until the user resumes it, so the
+  // composer can explain the branch change. Refresh Git status before sending because the
+  // cached branch query may still be loading or may lag behind an out-of-band checkout.
+  if (shouldResumeSettledLocalThread) {
+    if (!gitBranchSourceCwd) {
+      setStoreThreadError(threadIdForSend, "Unable to determine the current branch.");
+      return false;
+    }
+
+    try {
+      const gitStatus = await queryClient.fetchQuery({
+        ...gitStatusQueryOptions(gitBranchSourceCwd),
+        staleTime: 0,
+      });
+      currentActiveGitBranchForSend = gitStatus.branch;
+    } catch {
+      setStoreThreadError(
+        threadIdForSend,
+        "Unable to determine the current branch. Try again before sending.",
+      );
+      return false;
+    }
+
+    if (currentActiveGitBranchForSend !== null) {
+      nextThreadBranch = currentActiveGitBranchForSend;
+    }
+  }
+
+  const baseBranchForWorktree =
+    isFirstMessage && nextThreadEnvMode === "worktree" && !nextThreadWorktreePath
+      ? nextThreadBranch
+      : null;
+
+  // In worktree mode, require an explicit base branch so we don't silently
+  // fall back to local execution when branch selection is missing.
+  const shouldCreateWorktree =
+    isFirstMessage && nextThreadEnvMode === "worktree" && !nextThreadWorktreePath;
+  if (shouldCreateWorktree && !nextThreadBranch) {
+    setStoreThreadError(
+      threadIdForSend,
+      "Select a base branch before sending in New worktree mode.",
+    );
+    return false;
+  }
+
+  const setupScriptForWorktree = baseBranchForWorktree
+    ? setupProjectScript(targetProjectScriptsForSend)
+    : null;
+  const worktreeSetupScriptName = setupScriptForWorktree?.name ?? null;
+  // Branching off the checkout's current branch also carries its uncommitted
+  // changes into the worktree, which the setup card surfaces as its own step.
+  const worktreeCopiesLocalChanges =
+    Boolean(baseBranchForWorktree) && baseBranchForWorktree === activeRootBranch;
+  return {
+    threadIdForSend,
+    title,
+    targetProjectIdForSend,
+    targetProjectKindForSend,
+    targetProjectCwdForSend,
+    targetProjectDefaultModelSelectionForSend,
+    nextRuntimeModeForSend,
+    nextThreadEnvMode,
+    nextThreadBranch,
+    nextThreadWorktreePath,
+    nextThreadWorkingDirectory,
+    nextAssociatedWorktreePath,
+    nextAssociatedWorktreeBranch,
+    nextAssociatedWorktreeRef,
+    shouldResumeSettledLocalThread,
+    currentActiveGitBranchForSend,
+    baseBranchForWorktree,
+    setupScriptForWorktree,
+    worktreeSetupScriptName,
+    worktreeCopiesLocalChanges,
+  };
+}

--- a/apps/web/src/components/chat/projectScriptRuntime.ts
+++ b/apps/web/src/components/chat/projectScriptRuntime.ts
@@ -1,0 +1,91 @@
+import { ThreadId } from "@synara/contracts";
+import { selectThreadTerminalState, useTerminalStateStore } from "../../terminalStateStore";
+
+const SETUP_SCRIPT_TERMINAL_ACTIVITY_START_TIMEOUT_MS = 1_000;
+const SETUP_SCRIPT_TERMINAL_MAX_RUNTIME_MS = 10 * 60 * 1000;
+
+function terminalHasRunningSubprocess(threadId: ThreadId, terminalId: string): boolean {
+  const terminalState = selectThreadTerminalState(
+    useTerminalStateStore.getState().terminalStateByThreadId,
+    threadId,
+  );
+  return terminalState.runningTerminalIds.includes(terminalId);
+}
+
+export function waitForSetupScriptTerminalActivity(input: {
+  threadId: ThreadId;
+  terminalId: string;
+  observeStartTimeoutMs?: number;
+  maxRuntimeMs?: number;
+  signal?: AbortSignal;
+}): Promise<void> {
+  if (typeof window === "undefined") {
+    return Promise.resolve();
+  }
+
+  const observeStartTimeoutMs =
+    input.observeStartTimeoutMs ?? SETUP_SCRIPT_TERMINAL_ACTIVITY_START_TIMEOUT_MS;
+  const maxRuntimeMs = input.maxRuntimeMs ?? SETUP_SCRIPT_TERMINAL_MAX_RUNTIME_MS;
+
+  return new Promise((resolve) => {
+    let resolved = false;
+    let observedRunning = terminalHasRunningSubprocess(input.threadId, input.terminalId);
+    let observeStartTimer: number | null = null;
+    let maxRuntimeTimer: number | null = null;
+
+    const unsubscribe = useTerminalStateStore.subscribe(() => {
+      checkRunningState();
+    });
+
+    const clearTimers = () => {
+      if (observeStartTimer !== null) {
+        window.clearTimeout(observeStartTimer);
+        observeStartTimer = null;
+      }
+      if (maxRuntimeTimer !== null) {
+        window.clearTimeout(maxRuntimeTimer);
+        maxRuntimeTimer = null;
+      }
+    };
+
+    const finish = () => {
+      if (resolved) return;
+      resolved = true;
+      clearTimers();
+      unsubscribe();
+      input.signal?.removeEventListener("abort", finish);
+      resolve();
+    };
+
+    const ensureMaxRuntimeTimer = () => {
+      if (maxRuntimeTimer !== null) return;
+      maxRuntimeTimer = window.setTimeout(finish, maxRuntimeMs);
+    };
+
+    function checkRunningState() {
+      const running = terminalHasRunningSubprocess(input.threadId, input.terminalId);
+      if (running) {
+        observedRunning = true;
+        if (observeStartTimer !== null) {
+          window.clearTimeout(observeStartTimer);
+          observeStartTimer = null;
+        }
+        ensureMaxRuntimeTimer();
+        return;
+      }
+      if (observedRunning) {
+        finish();
+      }
+    }
+
+    if (input.signal?.aborted) {
+      finish();
+      return;
+    }
+    input.signal?.addEventListener("abort", finish, { once: true });
+    checkRunningState();
+    if (!observedRunning) {
+      observeStartTimer = window.setTimeout(finish, observeStartTimeoutMs);
+    }
+  });
+}

--- a/apps/web/src/components/chat/queuedComposerPreview.ts
+++ b/apps/web/src/components/chat/queuedComposerPreview.ts
@@ -1,0 +1,100 @@
+import {
+  type BrowserAnnotationDraft,
+  type ComposerFileAttachment,
+  type ComposerImageAttachment,
+} from "../../composerDraftStore";
+import { formatAssistantSelectionQueuePreview } from "../../lib/assistantSelections";
+import { formatBrowserAnnotationLabel } from "../../lib/browserAnnotations";
+import { pastedTextTitle, type PastedTextDraft } from "../../lib/composerPastedText";
+import { formatFileCommentLabel, type FileCommentDraft } from "../../lib/fileComments";
+import {
+  formatPullRequestContextTitleSeed,
+  type PullRequestContextDraft,
+} from "../../lib/pullRequestContext";
+import { formatTerminalContextLabel, type TerminalContextDraft } from "../../lib/terminalContext";
+
+export function buildQueuedComposerPreviewText(input: {
+  trimmedPrompt: string;
+  images: ReadonlyArray<ComposerImageAttachment>;
+  files: ReadonlyArray<ComposerFileAttachment>;
+  assistantSelections: ReadonlyArray<{ id: string }>;
+  browserAnnotations: ReadonlyArray<BrowserAnnotationDraft>;
+  terminalContexts: ReadonlyArray<TerminalContextDraft>;
+  fileComments: ReadonlyArray<FileCommentDraft>;
+  pastedTexts: ReadonlyArray<PastedTextDraft>;
+  pullRequestContexts: ReadonlyArray<PullRequestContextDraft>;
+}): string {
+  if (input.trimmedPrompt.length > 0) {
+    return input.trimmedPrompt;
+  }
+  const firstImage = input.images[0];
+  if (firstImage) {
+    return `Image: ${firstImage.name}`;
+  }
+  const firstFile = input.files[0];
+  if (firstFile) {
+    return `File: ${firstFile.name}`;
+  }
+  if (input.assistantSelections.length > 0) {
+    return formatAssistantSelectionQueuePreview(input.assistantSelections.length);
+  }
+  const firstBrowserAnnotation = input.browserAnnotations[0];
+  if (firstBrowserAnnotation) {
+    return `#${firstBrowserAnnotation.ordinal} ${formatBrowserAnnotationLabel(firstBrowserAnnotation)}`;
+  }
+  const firstTerminalContext = input.terminalContexts[0];
+  if (firstTerminalContext) {
+    return formatTerminalContextLabel(firstTerminalContext);
+  }
+  const firstFileComment = input.fileComments[0];
+  if (firstFileComment) {
+    return formatFileCommentLabel(firstFileComment);
+  }
+  const pastedTitle = formatPastedTextTitleSeed(input.pastedTexts);
+  if (pastedTitle) {
+    return pastedTitle;
+  }
+  const pullRequestTitle = formatPullRequestContextTitleSeed(input.pullRequestContexts);
+  if (pullRequestTitle) {
+    return pullRequestTitle;
+  }
+  return "Queued follow-up";
+}
+
+export function formatPastedTextTitleSeed(
+  pastedTexts: ReadonlyArray<PastedTextDraft>,
+): string | null {
+  const firstPastedText = pastedTexts[0];
+  if (!firstPastedText) {
+    return null;
+  }
+  return pastedTexts.length === 1
+    ? pastedTextTitle(firstPastedText.text)
+    : `${pastedTexts.length} pasted texts`;
+}
+
+function normalizeRestoredQueuedPrompt(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+export function composerPromptStillMatchesRestoredQueuedDraft(
+  restoredPrompt: string,
+  nextPrompt: string,
+): boolean {
+  const restored = normalizeRestoredQueuedPrompt(restoredPrompt);
+  const next = normalizeRestoredQueuedPrompt(nextPrompt);
+  if (next.length === 0) {
+    return false;
+  }
+  if (restored.length === 0) {
+    return true;
+  }
+  if (next.includes(restored)) {
+    return true;
+  }
+  if (next.length >= Math.min(16, restored.length) && restored.includes(next)) {
+    return true;
+  }
+  const probe = restored.slice(0, Math.min(48, restored.length));
+  return probe.length >= 16 && next.includes(probe);
+}

--- a/apps/web/src/components/chat/resolveChatPromptCaptures.ts
+++ b/apps/web/src/components/chat/resolveChatPromptCaptures.ts
@@ -1,0 +1,121 @@
+import { PROVIDER_SEND_TURN_MAX_ATTACHMENTS } from "@synara/contracts";
+import { readNativeApi } from "~/nativeApi";
+import {
+  type ComposerAssistantSelectionAttachment,
+  type ComposerFileAttachment,
+  type ComposerImageAttachment,
+} from "../../composerDraftStore";
+import {
+  maybeResolveBrowserPromptAttachment,
+  type BrowserPromptAttachmentResolution,
+} from "../../lib/browserPromptContext";
+import {
+  maybeResolveDevicePromptAttachment,
+  type DevicePromptAttachmentResolution,
+} from "../../lib/devicePromptContext";
+import { type Thread } from "../../types";
+import { toastManager } from "../ui/toast";
+interface Input {
+  api: NonNullable<ReturnType<typeof readNativeApi>>;
+  activeThread: Thread;
+  promptForSend: string;
+  composerImagesForSend: ComposerImageAttachment[];
+  composerFilesForSend: ComposerFileAttachment[];
+  composerAssistantSelectionsForSend: ComposerAssistantSelectionAttachment[];
+}
+
+export async function resolveChatPromptCaptures({
+  api,
+  activeThread,
+  promptForSend,
+  composerImagesForSend,
+  composerFilesForSend,
+  composerAssistantSelectionsForSend,
+}: Input) {
+  const browserPromptAttachment: BrowserPromptAttachmentResolution =
+    await maybeResolveBrowserPromptAttachment({
+      api,
+      threadId: activeThread.id,
+      prompt: promptForSend,
+    }).catch(
+      (): BrowserPromptAttachmentResolution => ({
+        requested: false,
+        image: null,
+      }),
+    );
+  if (browserPromptAttachment.image) {
+    const nextAttachmentCount =
+      composerImagesForSend.length +
+      composerFilesForSend.length +
+      composerAssistantSelectionsForSend.length +
+      (browserPromptAttachment.image ? 1 : 0);
+    if (nextAttachmentCount <= PROVIDER_SEND_TURN_MAX_ATTACHMENTS) {
+      composerImagesForSend = [...composerImagesForSend, browserPromptAttachment.image];
+    } else {
+      toastManager.add({
+        type: "warning",
+        title: `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} references per message.`,
+        description:
+          "The current browser screenshot was skipped because this message is already at the attachment limit.",
+      });
+    }
+  } else if (browserPromptAttachment.requested) {
+    const description =
+      browserPromptAttachment.reason === "no-open-browser"
+        ? "Open the in-app browser first, then try again."
+        : browserPromptAttachment.reason === "no-active-tab"
+          ? "The in-app browser has no active tab to capture yet."
+          : browserPromptAttachment.reason === "attachment-processing-failed"
+            ? "The browser screenshot could not be optimized for attachment."
+            : "The current browser context could not be attached.";
+    toastManager.add({
+      type: "warning",
+      title: "Couldn’t attach the in-app browser context",
+      description,
+    });
+  }
+
+  const devicePromptAttachment: DevicePromptAttachmentResolution =
+    await maybeResolveDevicePromptAttachment({
+      api,
+      threadId: activeThread.id,
+      prompt: promptForSend,
+    }).catch(
+      (): DevicePromptAttachmentResolution => ({
+        requested: false,
+        image: null,
+      }),
+    );
+  if (devicePromptAttachment.image) {
+    const nextAttachmentCount =
+      composerImagesForSend.length +
+      composerFilesForSend.length +
+      composerAssistantSelectionsForSend.length +
+      1;
+    if (nextAttachmentCount <= PROVIDER_SEND_TURN_MAX_ATTACHMENTS) {
+      composerImagesForSend = [...composerImagesForSend, devicePromptAttachment.image];
+    } else {
+      toastManager.add({
+        type: "warning",
+        title: `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} references per message.`,
+        description:
+          "The simulator screenshot was skipped because this message is already at the attachment limit.",
+      });
+    }
+  } else if (devicePromptAttachment.requested) {
+    const description =
+      devicePromptAttachment.reason === "no-attached-device"
+        ? "Open the iOS Simulator panel and choose a device first, then try again."
+        : devicePromptAttachment.reason === "device-not-booted"
+          ? "The selected simulator is still starting up."
+          : devicePromptAttachment.reason === "attachment-processing-failed"
+            ? "The simulator screenshot could not be optimized for attachment."
+            : "The current simulator context could not be attached.";
+    toastManager.add({
+      type: "warning",
+      title: "Couldn’t attach the simulator screen",
+      description,
+    });
+  }
+  return { composerImagesForSend };
+}

--- a/apps/web/src/components/chat/useChatAutomationCreation.ts
+++ b/apps/web/src/components/chat/useChatAutomationCreation.ts
@@ -1,0 +1,393 @@
+import {
+  EventId,
+  ProviderInteractionMode,
+  RuntimeMode,
+  ThreadId,
+  type AutomationSchedule,
+  type ModelSelection,
+  type ProviderStartOptions,
+} from "@synara/contracts";
+import { automationRequiresTargetThread } from "@synara/shared/automationMode";
+import {
+  GENERIC_CHAT_THREAD_TITLE,
+  buildPromptThreadTitleFallback,
+} from "@synara/shared/chatThreads";
+import { deriveAssociatedWorktreeMetadata } from "@synara/shared/threadWorkspace";
+import type { QueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { promoteThreadCreate } from "~/lib/threadCreatePromotion";
+import { newCommandId, randomUUID } from "~/lib/utils";
+import { readNativeApi } from "~/nativeApi";
+import { dispatchThreadNotes } from "~/pinnedMessages";
+import {
+  mergeProjectInstructionsIntoThreadNotes,
+  useProjectInstructionsStore,
+} from "~/projectInstructionsStore";
+import {
+  acknowledgedRiskIdsForDraft,
+  hasBlockingAutomationDraftWarnings,
+  type AutomationDraftWarning,
+  type AutomationDraftWarningId,
+} from "../../lib/automationDraft";
+import {
+  automationQueryKey,
+  createInputFromForm,
+  formatCadence,
+  isFormSubmittable,
+  type AutomationFormState,
+} from "../../routes/-automations.shared";
+import type { Project } from "../../types";
+import { type Thread } from "../../types";
+import { useChatAutomationSetup } from "./useChatAutomationSetup";
+import { toastManager } from "../ui/toast";
+function automationScheduleActivityPayload(schedule: AutomationSchedule) {
+  switch (schedule.type) {
+    case "manual":
+      return { type: "manual" } as const;
+    case "once":
+      return { type: "once", runAt: schedule.runAt } as const;
+    case "interval":
+      return { type: "interval", everySeconds: schedule.everySeconds } as const;
+    case "daily":
+      return schedule.timezone
+        ? { type: "daily", timeOfDay: schedule.timeOfDay, timezone: schedule.timezone }
+        : { type: "daily", timeOfDay: schedule.timeOfDay };
+    case "weekdays":
+      return schedule.timezone
+        ? { type: "weekdays", timeOfDay: schedule.timeOfDay, timezone: schedule.timezone }
+        : { type: "weekdays", timeOfDay: schedule.timeOfDay };
+    case "weekly":
+      return schedule.timezone
+        ? {
+            type: "weekly",
+            dayOfWeek: schedule.dayOfWeek,
+            timeOfDay: schedule.timeOfDay,
+            timezone: schedule.timezone,
+          }
+        : {
+            type: "weekly",
+            dayOfWeek: schedule.dayOfWeek,
+            timeOfDay: schedule.timeOfDay,
+          };
+    case "cron":
+      return {
+        type: "cron",
+        expression: schedule.expression,
+        timezone: schedule.timezone,
+      } as const;
+  }
+}
+interface ChatAutomationCreationInput {
+  threadId: ThreadId;
+  activeProject: Project | undefined;
+  automationDraftSubmittingRef: ReturnType<
+    typeof useChatAutomationSetup
+  >["automationDraftSubmittingRef"];
+  isServerThread: boolean;
+  activeThread: Thread | undefined;
+  providerOptionsForDispatch: ProviderStartOptions | undefined;
+  setIsAutomationDraftSubmitting: ReturnType<
+    typeof useChatAutomationSetup
+  >["setIsAutomationDraftSubmitting"];
+  queryClient: QueryClient;
+  clearComposerInput: (threadId: ThreadId) => void;
+  resetAutomationDraftState: ReturnType<typeof useChatAutomationSetup>["resetAutomationDraftState"];
+  activeThreadAssociatedWorktree: ReturnType<typeof deriveAssociatedWorktreeMetadata>;
+  threadNotes: string;
+  selectedModelSelection: ModelSelection;
+  runtimeMode: RuntimeMode;
+  interactionMode: ProviderInteractionMode;
+  automationDraftForm: ReturnType<typeof useChatAutomationSetup>["automationDraftForm"];
+  automationDraftWarnings: ReturnType<typeof useChatAutomationSetup>["automationDraftWarnings"];
+  acknowledgedAutomationWarnings: ReturnType<
+    typeof useChatAutomationSetup
+  >["acknowledgedAutomationWarnings"];
+}
+
+export function useChatAutomationCreation({
+  threadId,
+  activeProject,
+  automationDraftSubmittingRef,
+  isServerThread,
+  activeThread,
+  providerOptionsForDispatch,
+  setIsAutomationDraftSubmitting,
+  queryClient,
+  clearComposerInput,
+  resetAutomationDraftState,
+  activeThreadAssociatedWorktree,
+  threadNotes,
+  selectedModelSelection,
+  runtimeMode,
+  interactionMode,
+  automationDraftForm,
+  automationDraftWarnings,
+  acknowledgedAutomationWarnings,
+}: ChatAutomationCreationInput) {
+  const createAutomationFromForm = useCallback(
+    async (input: {
+      readonly form: AutomationFormState;
+      readonly warnings: readonly AutomationDraftWarning[];
+      readonly acknowledgedWarningIds: ReadonlySet<AutomationDraftWarningId>;
+      readonly providerOptions?: ProviderStartOptions;
+      readonly activityThreadId?: ThreadId | null;
+    }): Promise<boolean> => {
+      const api = readNativeApi();
+      if (!api || !activeProject) {
+        return false;
+      }
+      if (automationDraftSubmittingRef.current) {
+        return false;
+      }
+      if (!isFormSubmittable(input.form)) {
+        return false;
+      }
+      if (hasBlockingAutomationDraftWarnings(input.warnings, input.acknowledgedWarningIds)) {
+        return false;
+      }
+      const acknowledgedRisks = acknowledgedRiskIdsForDraft(
+        input.warnings,
+        input.acknowledgedWarningIds,
+      );
+      const activityThreadId =
+        input.activityThreadId ?? (isServerThread ? (activeThread?.id ?? null) : null);
+      const createdAt = new Date().toISOString();
+      const automationInput = createInputFromForm(
+        input.form,
+        input.providerOptions ?? providerOptionsForDispatch,
+        acknowledgedRisks,
+        activityThreadId,
+      );
+      automationDraftSubmittingRef.current = true;
+      setIsAutomationDraftSubmitting(true);
+      return await (async () => {
+        const definition = await api.automation.create(automationInput);
+        if (activityThreadId) {
+          void (async () => {
+            try {
+              await api.orchestration.dispatchCommand({
+                type: "thread.activity.append",
+                commandId: newCommandId(),
+                threadId: activityThreadId,
+                activity: {
+                  id: EventId.makeUnsafe(randomUUID()),
+                  tone: "info",
+                  kind: "automation.created",
+                  summary: `Created automation: ${definition.name} - ${formatCadence(definition.schedule)}`,
+                  payload: {
+                    source: "chat-composer",
+                    automationId: definition.id,
+                    automationName: definition.name,
+                    mode: definition.mode,
+                    cadenceLabel: formatCadence(definition.schedule),
+                    schedule: automationScheduleActivityPayload(definition.schedule),
+                  },
+                  turnId: null,
+                  createdAt,
+                },
+                createdAt,
+              });
+            } catch {
+              toastManager.add({
+                type: "warning",
+                title: "Thread note not added",
+                description:
+                  "The automation was created, but Synara could not add the activity note.",
+              });
+            }
+          })();
+        }
+        void queryClient.invalidateQueries({ queryKey: automationQueryKey });
+        clearComposerInput(activeThread?.id ?? threadId);
+        resetAutomationDraftState();
+        toastManager.add({
+          type: "success",
+          title: "Automation created",
+          description: `${definition.name} - ${formatCadence(definition.schedule)}`,
+        });
+        return true;
+      })()
+        .catch((error: unknown) => {
+          toastManager.add({
+            type: "error",
+            title: "Could not create automation",
+            description:
+              error instanceof Error ? error.message : "Synara could not save the automation.",
+          });
+          return false;
+        })
+        .finally(() => {
+          automationDraftSubmittingRef.current = false;
+          setIsAutomationDraftSubmitting(false);
+        });
+    },
+    [
+      activeProject,
+      activeThread,
+      automationDraftSubmittingRef,
+      clearComposerInput,
+      isServerThread,
+      providerOptionsForDispatch,
+      queryClient,
+      resetAutomationDraftState,
+      setIsAutomationDraftSubmitting,
+      threadId,
+    ],
+  );
+
+  const ensureAutomationTargetThread = useCallback(
+    async (input: {
+      readonly titleSeed: string;
+      readonly threadModelSelection: ModelSelection;
+      readonly threadRuntimeMode: RuntimeMode;
+      readonly threadInteractionMode: ProviderInteractionMode;
+    }): Promise<ThreadId | null> => {
+      const api = readNativeApi();
+      if (!api || !activeProject || !activeThread) {
+        toastManager.add({
+          type: "warning",
+          title: "Chat required",
+          description: "Open a chat before creating a chat-bound automation.",
+        });
+        return null;
+      }
+      if (isServerThread) {
+        return activeThread.id;
+      }
+
+      const title = buildPromptThreadTitleFallback(input.titleSeed || GENERIC_CHAT_THREAD_TITLE);
+      // Nested function so the `try` body holds no value blocks — see the comment on
+      // `deleteEmptyTerminalThread` above for why React Compiler requires this shape.
+      const promoteDraftForAutomation = async (): Promise<ThreadId | null> => {
+        const result = await promoteThreadCreate(
+          {
+            type: "thread.create",
+            commandId: newCommandId(),
+            threadId: activeThread.id,
+            projectId: activeProject.id,
+            title,
+            modelSelection: input.threadModelSelection,
+            runtimeMode: input.threadRuntimeMode,
+            interactionMode: input.threadInteractionMode,
+            envMode: activeThread.envMode ?? (activeThread.worktreePath ? "worktree" : "local"),
+            branch: activeThread.branch ?? null,
+            worktreePath: activeThread.worktreePath ?? null,
+            workingDirectory: activeThread.workingDirectory ?? null,
+            associatedWorktreePath: activeThreadAssociatedWorktree.associatedWorktreePath,
+            associatedWorktreeBranch: activeThreadAssociatedWorktree.associatedWorktreeBranch,
+            associatedWorktreeRef: activeThreadAssociatedWorktree.associatedWorktreeRef,
+            lastKnownPr: activeThread.lastKnownPr ?? null,
+            createdAt: activeThread.createdAt,
+          },
+          api,
+          { force: true },
+        );
+        if (result === "unavailable") {
+          toastManager.add({
+            type: "error",
+            title: "Could not create chat",
+            description: "Synara could not promote this draft before saving the automation.",
+          });
+          return null;
+        }
+
+        const inheritedProjectInstructions =
+          useProjectInstructionsStore.getState().instructionsByProjectId[activeProject.id] ?? "";
+        const inheritedThreadNotes = mergeProjectInstructionsIntoThreadNotes({
+          threadNotes,
+          projectInstructions: inheritedProjectInstructions,
+        });
+        if (inheritedThreadNotes !== threadNotes && inheritedThreadNotes.trim().length > 0) {
+          void dispatchThreadNotes(activeThread.id, inheritedThreadNotes).catch(() => undefined);
+        }
+
+        return activeThread.id;
+      };
+
+      try {
+        return await promoteDraftForAutomation();
+      } catch (error) {
+        toastManager.add({
+          type: "error",
+          title: "Could not create chat",
+          description:
+            error instanceof Error
+              ? error.message
+              : "Synara could not promote this draft before saving the automation.",
+        });
+        return null;
+      }
+    },
+    [activeProject, activeThread, activeThreadAssociatedWorktree, isServerThread, threadNotes],
+  );
+
+  const prepareAutomationFormForCreate = useCallback(
+    async (
+      form: AutomationFormState,
+    ): Promise<{
+      readonly form: AutomationFormState;
+      readonly activityThreadId: ThreadId | null;
+    } | null> => {
+      const activityThreadId = isServerThread ? (activeThread?.id ?? null) : null;
+      if (!automationRequiresTargetThread(form.mode) || !activeThread) {
+        return { form, activityThreadId };
+      }
+      if (isServerThread || form.targetThreadId !== activeThread.id) {
+        return { form, activityThreadId };
+      }
+
+      // Draft review can keep the local draft ID in the form; promote it only when
+      // the automation is actually submitted so cancelling review leaves no empty thread.
+      const targetThreadId = await ensureAutomationTargetThread({
+        titleSeed: form.prompt || form.name,
+        threadModelSelection: selectedModelSelection,
+        threadRuntimeMode: runtimeMode,
+        threadInteractionMode: interactionMode,
+      });
+      if (!targetThreadId) {
+        return null;
+      }
+      return {
+        form: { ...form, targetThreadId },
+        activityThreadId: targetThreadId,
+      };
+    },
+    [
+      activeThread,
+      ensureAutomationTargetThread,
+      interactionMode,
+      isServerThread,
+      runtimeMode,
+      selectedModelSelection,
+    ],
+  );
+
+  const submitAutomationDraft = useCallback(async () => {
+    if (!automationDraftForm) {
+      return;
+    }
+    if (
+      !isFormSubmittable(automationDraftForm) ||
+      hasBlockingAutomationDraftWarnings(automationDraftWarnings, acknowledgedAutomationWarnings)
+    ) {
+      return;
+    }
+    const preparedCreate = await prepareAutomationFormForCreate(automationDraftForm);
+    if (!preparedCreate) {
+      return;
+    }
+    await createAutomationFromForm({
+      form: preparedCreate.form,
+      warnings: automationDraftWarnings,
+      acknowledgedWarningIds: acknowledgedAutomationWarnings,
+      activityThreadId: preparedCreate.activityThreadId,
+    });
+  }, [
+    acknowledgedAutomationWarnings,
+    automationDraftForm,
+    automationDraftWarnings,
+    createAutomationFromForm,
+    prepareAutomationFormForCreate,
+  ]);
+  return { createAutomationFromForm, prepareAutomationFormForCreate, submitAutomationDraft };
+}

--- a/apps/web/src/components/chat/useChatComposerCommands.ts
+++ b/apps/web/src/components/chat/useChatComposerCommands.ts
@@ -1,0 +1,595 @@
+import {
+  ThreadId,
+  type ModelSlug,
+  type ProviderKind,
+  type ProviderSkillReference,
+} from "@synara/contracts";
+import type { Dispatch, RefObject, SetStateAction } from "react";
+import { useCallback } from "react";
+import { formatComposerMentionToken, skillMentionPrefix } from "~/lib/composerMentions";
+import type { AppSettings } from "../../appSettings";
+import { resolveFollowUpDispatchMode } from "../../appSettings";
+import { collapseExpandedComposerCursor, detectComposerTrigger } from "../../composer-logic";
+import {
+  captureComposerPromptHistorySavedDraft,
+  type QueuedComposerChatTurn,
+} from "../../composerDraftStore";
+import { useComposerSlashCommands } from "../../hooks/useComposerSlashCommands";
+import { extractChatAutomationInvocation } from "../../lib/automationIntent";
+import { syncTerminalContextsByIds, terminalContextIdListsEqual } from "../../lib/terminalContext";
+import {
+  promptStillMatchesActiveHistoryBrowse,
+  resolvePromptHistoryNavigation,
+  shouldHandlePromptHistoryNavigationKey,
+} from "../ChatView.logic";
+import { ComposerCommandItem } from "./ComposerCommandMenu";
+import { type ComposerLocalDirectoryMenuHandle } from "./ComposerLocalDirectoryMenu";
+import { composerPromptStillMatchesRestoredQueuedDraft } from "./queuedComposerPreview";
+import { useChatComposerDraft } from "./useChatComposerDraft";
+import { useChatComposerEditing } from "./useChatComposerEditing";
+import { useChatPendingInteractions } from "./useChatPendingInteractions";
+import { useChatRuntimeModes } from "./useChatRuntimeModes";
+import { useComposerDiscovery } from "./useComposerDiscovery";
+import { useComposerReferences } from "./useComposerReferences";
+
+interface ChatComposerCommandsInput {
+  threadId: ThreadId;
+  composerSelectLockRef: RefObject<boolean>;
+  setComposerCommandPicker: Dispatch<SetStateAction<"fork-target" | "review-target" | null>>;
+  setComposerHighlightedItemId: Dispatch<SetStateAction<string | null>>;
+  handleForkTargetSelection: ReturnType<
+    typeof useComposerSlashCommands
+  >["handleForkTargetSelection"];
+  handleReviewTargetSelection: ReturnType<
+    typeof useComposerSlashCommands
+  >["handleReviewTargetSelection"];
+  resolveActiveComposerTrigger: ReturnType<
+    typeof useChatComposerEditing
+  >["resolveActiveComposerTrigger"];
+  applyComposerTriggerReplacement: ReturnType<
+    typeof useChatComposerEditing
+  >["applyComposerTriggerReplacement"];
+  handleNavigateLocalFolder: ReturnType<typeof useChatComposerEditing>["handleNavigateLocalFolder"];
+  localFolderBrowseRootPath: string | null;
+  handleSlashCommandSelection: ReturnType<
+    typeof useComposerSlashCommands
+  >["handleSlashCommandSelection"];
+  selectedProvider: ProviderKind;
+  scheduleComposerFocus: () => void;
+  updateSelectedComposerSkills: ReturnType<
+    typeof useComposerReferences
+  >["updateSelectedComposerSkills"];
+  updateSelectedComposerMentions: ReturnType<
+    typeof useComposerReferences
+  >["updateSelectedComposerMentions"];
+  onProviderModelSelect: (provider: ProviderKind, model: ModelSlug) => Promise<void>;
+  composerMenuItems: ComposerCommandItem[];
+  composerHighlightedItemId: string | null;
+  activePendingQuestion: ReturnType<typeof useChatPendingInteractions>["activePendingQuestion"];
+  activePendingUserInput: ReturnType<typeof useChatPendingInteractions>["activePendingUserInput"];
+  promptHistoryNavigationRef: ReturnType<typeof useChatComposerDraft>["promptHistoryNavigationRef"];
+  restoreComposerDraftPromptHistorySavedDraft: ReturnType<
+    typeof useChatComposerDraft
+  >["restoreComposerDraftPromptHistorySavedDraft"];
+  promptRef: ReturnType<typeof useChatComposerDraft>["promptRef"];
+  setPrompt: ReturnType<typeof useChatComposerDraft>["setPrompt"];
+  expectedPromptHistoryPromptRef: ReturnType<
+    typeof useChatComposerDraft
+  >["expectedPromptHistoryPromptRef"];
+  onChangeActivePendingUserInputCustomAnswer: ReturnType<
+    typeof useChatPendingInteractions
+  >["onChangeActivePendingUserInputCustomAnswer"];
+  setComposerDraftPromptHistorySavedDraft: ReturnType<
+    typeof useChatComposerDraft
+  >["setComposerDraftPromptHistorySavedDraft"];
+  applyingPromptHistoryNavigationRef: ReturnType<
+    typeof useChatComposerDraft
+  >["applyingPromptHistoryNavigationRef"];
+  promptHistory: string[];
+  promptHistoryAppliedPromptRef: ReturnType<
+    typeof useChatComposerDraft
+  >["promptHistoryAppliedPromptRef"];
+  restoredQueuedSourceProposedPlanRef: ReturnType<
+    typeof useChatComposerDraft
+  >["restoredQueuedSourceProposedPlanRef"];
+  setRestoredQueuedSourceProposedPlan: ReturnType<
+    typeof useChatComposerDraft
+  >["setRestoredQueuedSourceProposedPlan"];
+  composerCommandPicker: "fork-target" | "review-target" | null;
+  composerTerminalContexts: ReturnType<typeof useChatComposerDraft>["composerTerminalContexts"];
+  setComposerDraftTerminalContexts: ReturnType<
+    typeof useChatComposerDraft
+  >["setComposerDraftTerminalContexts"];
+  setComposerCursor: ReturnType<typeof useChatComposerDraft>["setComposerCursor"];
+  setComposerTrigger: ReturnType<typeof useChatComposerDraft>["setComposerTrigger"];
+  clearComposerSlashDraft: ReturnType<typeof useChatComposerEditing>["clearComposerSlashDraft"];
+  toggleInteractionMode: ReturnType<typeof useChatRuntimeModes>["toggleInteractionMode"];
+  composerMenuOpenRef: RefObject<boolean>;
+  onSend: (
+    e?: { preventDefault: () => void },
+    requestedDispatchMode?: "queue" | "steer",
+    queuedTurn?: QueuedComposerChatTurn,
+  ) => Promise<boolean>;
+  settings: AppSettings;
+  hasLiveTurn: boolean;
+  isLocalFolderBrowserOpen: ReturnType<typeof useComposerDiscovery>["isLocalFolderBrowserOpen"];
+  localDirectoryMenuRef: RefObject<ComposerLocalDirectoryMenuHandle | null>;
+  composerMenuItemsRef: RefObject<ComposerCommandItem[]>;
+  activeComposerMenuItemRef: RefObject<ComposerCommandItem | null>;
+  activePendingProgress: ReturnType<typeof useChatPendingInteractions>["activePendingProgress"];
+  isComposerApprovalState: boolean;
+  pendingUserInputs: ReturnType<typeof useChatPendingInteractions>["pendingUserInputs"];
+  composerDraft: ReturnType<typeof useChatComposerDraft>["composerDraft"];
+}
+
+export function useChatComposerCommands({
+  threadId,
+  composerSelectLockRef,
+  setComposerCommandPicker,
+  setComposerHighlightedItemId,
+  handleForkTargetSelection,
+  handleReviewTargetSelection,
+  resolveActiveComposerTrigger,
+  applyComposerTriggerReplacement,
+  handleNavigateLocalFolder,
+  localFolderBrowseRootPath,
+  handleSlashCommandSelection,
+  selectedProvider,
+  scheduleComposerFocus,
+  updateSelectedComposerSkills,
+  updateSelectedComposerMentions,
+  onProviderModelSelect,
+  composerMenuItems,
+  composerHighlightedItemId,
+  activePendingQuestion,
+  activePendingUserInput,
+  promptHistoryNavigationRef,
+  restoreComposerDraftPromptHistorySavedDraft,
+  promptRef,
+  setPrompt,
+  expectedPromptHistoryPromptRef,
+  onChangeActivePendingUserInputCustomAnswer,
+  setComposerDraftPromptHistorySavedDraft,
+  applyingPromptHistoryNavigationRef,
+  promptHistory,
+  promptHistoryAppliedPromptRef,
+  restoredQueuedSourceProposedPlanRef,
+  setRestoredQueuedSourceProposedPlan,
+  composerCommandPicker,
+  composerTerminalContexts,
+  setComposerDraftTerminalContexts,
+  setComposerCursor,
+  setComposerTrigger,
+  clearComposerSlashDraft,
+  toggleInteractionMode,
+  composerMenuOpenRef,
+  onSend,
+  settings,
+  hasLiveTurn,
+  isLocalFolderBrowserOpen,
+  localDirectoryMenuRef,
+  composerMenuItemsRef,
+  activeComposerMenuItemRef,
+  activePendingProgress,
+  isComposerApprovalState,
+  pendingUserInputs,
+  composerDraft,
+}: ChatComposerCommandsInput) {
+  const onSelectComposerItem = useCallback(
+    (item: ComposerCommandItem) => {
+      if (composerSelectLockRef.current) return;
+      composerSelectLockRef.current = true;
+      window.requestAnimationFrame(() => {
+        composerSelectLockRef.current = false;
+      });
+      if (item.type === "fork-target") {
+        setComposerCommandPicker(null);
+        setComposerHighlightedItemId(null);
+        void handleForkTargetSelection(item.target);
+        return;
+      }
+      if (item.type === "review-target") {
+        setComposerCommandPicker(null);
+        setComposerHighlightedItemId(null);
+        void handleReviewTargetSelection(item.target);
+        return;
+      }
+      const { snapshot, trigger } = resolveActiveComposerTrigger();
+      if (!trigger) return;
+      if (item.type === "path") {
+        applyComposerTriggerReplacement({
+          snapshot,
+          trigger,
+          base: `${formatComposerMentionToken(item.path)} `,
+        });
+        return;
+      }
+      if (item.type === "local-root") {
+        handleNavigateLocalFolder(localFolderBrowseRootPath ?? "/");
+        return;
+      }
+      if (item.type === "slash-command") {
+        handleSlashCommandSelection(item);
+        return;
+      }
+      if (item.type === "provider-native-command") {
+        if (selectedProvider === "codex" && item.command.toLowerCase() === "review") {
+          setComposerCommandPicker("review-target");
+          setComposerHighlightedItemId("review-target:changes");
+          scheduleComposerFocus();
+          return;
+        }
+        applyComposerTriggerReplacement({
+          snapshot,
+          trigger,
+          base: `/${item.command} `,
+        });
+        return;
+      }
+      if (item.type === "skill") {
+        applyComposerTriggerReplacement({
+          snapshot,
+          trigger,
+          base: `${skillMentionPrefix(selectedProvider)}${item.skill.name} `,
+          onApplied: () => {
+            updateSelectedComposerSkills((existing) => {
+              const nextSkill = {
+                name: item.skill.name,
+                path: item.skill.path,
+              } satisfies ProviderSkillReference;
+              return existing.some(
+                (skill) => skill.name === nextSkill.name && skill.path === nextSkill.path,
+              )
+                ? existing
+                : [...existing, nextSkill];
+            });
+          },
+        });
+        return;
+      }
+      if (item.type === "plugin" || item.type === "thread") {
+        applyComposerTriggerReplacement({
+          snapshot,
+          trigger,
+          base: `${formatComposerMentionToken(item.mention.name)} `,
+          onApplied: () => {
+            updateSelectedComposerMentions((existing) => {
+              const nextMention = item.mention;
+              const nextWithoutSameName = existing.filter(
+                (mention) => mention.name !== nextMention.name,
+              );
+              return [...nextWithoutSameName, nextMention];
+            });
+          },
+        });
+        return;
+      }
+      if (item.type === "model") {
+        onProviderModelSelect(item.provider, item.model);
+        applyComposerTriggerReplacement({ snapshot, trigger, base: "" });
+        return;
+      }
+      if (item.type === "agent") {
+        // Insert @alias() and position cursor inside the parentheses.
+        applyComposerTriggerReplacement({
+          snapshot,
+          trigger,
+          base: `@${item.alias}()`,
+          cursorOffset: -1,
+        });
+      }
+    },
+    [
+      composerSelectLockRef,
+      setComposerHighlightedItemId,
+      applyComposerTriggerReplacement,
+      scheduleComposerFocus,
+      handleForkTargetSelection,
+      handleNavigateLocalFolder,
+      handleReviewTargetSelection,
+      handleSlashCommandSelection,
+      onProviderModelSelect,
+      setComposerCommandPicker,
+      localFolderBrowseRootPath,
+      selectedProvider,
+      updateSelectedComposerMentions,
+      updateSelectedComposerSkills,
+      resolveActiveComposerTrigger,
+    ],
+  );
+  const onComposerMenuItemHighlighted = useCallback(
+    (itemId: string | null) => {
+      setComposerHighlightedItemId(itemId);
+    },
+    [setComposerHighlightedItemId],
+  );
+  const nudgeComposerMenuHighlight = useCallback(
+    (key: "ArrowDown" | "ArrowUp") => {
+      if (composerMenuItems.length === 0) {
+        return;
+      }
+      const highlightedIndex = composerMenuItems.findIndex(
+        (item) => item.id === composerHighlightedItemId,
+      );
+      const normalizedIndex =
+        highlightedIndex >= 0 ? highlightedIndex : key === "ArrowDown" ? -1 : 0;
+      const offset = key === "ArrowDown" ? 1 : -1;
+      const nextIndex =
+        (normalizedIndex + offset + composerMenuItems.length) % composerMenuItems.length;
+      const nextItem = composerMenuItems[nextIndex];
+      setComposerHighlightedItemId(nextItem?.id ?? null);
+    },
+    [setComposerHighlightedItemId, composerHighlightedItemId, composerMenuItems],
+  );
+
+  const onPromptChange = useCallback(
+    (
+      nextPrompt: string,
+      nextCursor: number,
+      expandedCursor: number,
+      cursorAdjacentToMention: boolean,
+      terminalContextIds: string[],
+    ) => {
+      if (activePendingQuestion && activePendingUserInput) {
+        const interruptedNavigation = promptHistoryNavigationRef.current;
+        if (interruptedNavigation !== null) {
+          // An active question ended the history browse while the persisted
+          // prompt still held a recalled entry; put the real draft back.
+          promptHistoryNavigationRef.current = null;
+          restoreComposerDraftPromptHistorySavedDraft(threadId);
+          promptRef.current = interruptedNavigation.draft;
+          setPrompt(interruptedNavigation.draft);
+        }
+        expectedPromptHistoryPromptRef.current = null;
+        onChangeActivePendingUserInputCustomAnswer(
+          activePendingQuestion.id,
+          nextPrompt,
+          nextCursor,
+          expandedCursor,
+          cursorAdjacentToMention,
+        );
+        return;
+      }
+      const expectedPromptHistoryPrompt = expectedPromptHistoryPromptRef.current;
+      if (expectedPromptHistoryPrompt !== null) {
+        if (nextPrompt === expectedPromptHistoryPrompt) {
+          expectedPromptHistoryPromptRef.current = null;
+        } else {
+          // The user edited past the recalled entry: the edited text is the
+          // draft now, so the saved pre-browse draft must not be restored.
+          promptHistoryNavigationRef.current = null;
+          expectedPromptHistoryPromptRef.current = null;
+          setComposerDraftPromptHistorySavedDraft(threadId, null);
+        }
+      } else if (!applyingPromptHistoryNavigationRef.current) {
+        const activePromptHistoryNavigation = promptHistoryNavigationRef.current;
+        if (
+          activePromptHistoryNavigation !== null &&
+          !promptStillMatchesActiveHistoryBrowse({
+            state: activePromptHistoryNavigation,
+            history: promptHistory,
+            nextPrompt,
+            appliedPrompt: promptHistoryAppliedPromptRef.current,
+          })
+        ) {
+          promptHistoryNavigationRef.current = null;
+          setComposerDraftPromptHistorySavedDraft(threadId, null);
+        }
+      }
+      const restoredQueuedSource = restoredQueuedSourceProposedPlanRef.current;
+      if (
+        restoredQueuedSource?.threadId === threadId &&
+        !composerPromptStillMatchesRestoredQueuedDraft(
+          restoredQueuedSource.restoredPrompt,
+          nextPrompt,
+        )
+      ) {
+        setRestoredQueuedSourceProposedPlan(threadId, null);
+      }
+      promptRef.current = nextPrompt;
+      setPrompt(nextPrompt);
+      if (composerCommandPicker !== null && nextPrompt.trim().length > 0) {
+        setComposerCommandPicker(null);
+      }
+      if (!terminalContextIdListsEqual(composerTerminalContexts, terminalContextIds)) {
+        setComposerDraftTerminalContexts(
+          threadId,
+          syncTerminalContextsByIds(composerTerminalContexts, terminalContextIds),
+        );
+      }
+      setComposerCursor(nextCursor);
+      setComposerTrigger(
+        cursorAdjacentToMention ? null : detectComposerTrigger(nextPrompt, expandedCursor),
+      );
+    },
+    [
+      promptHistoryNavigationRef,
+      promptRef,
+      expectedPromptHistoryPromptRef,
+      applyingPromptHistoryNavigationRef,
+      promptHistoryAppliedPromptRef,
+      restoredQueuedSourceProposedPlanRef,
+      setComposerCursor,
+      setComposerTrigger,
+      activePendingQuestion,
+      activePendingUserInput,
+      composerTerminalContexts,
+      composerCommandPicker,
+      onChangeActivePendingUserInputCustomAnswer,
+      promptHistory,
+      restoreComposerDraftPromptHistorySavedDraft,
+      setPrompt,
+      setComposerDraftPromptHistorySavedDraft,
+      setComposerDraftTerminalContexts,
+      setComposerCommandPicker,
+      setRestoredQueuedSourceProposedPlan,
+      threadId,
+    ],
+  );
+
+  const onComposerCommandKey = (
+    key: "ArrowDown" | "ArrowUp" | "Enter" | "Tab" | "Slash",
+    event: KeyboardEvent,
+  ) => {
+    if (key === "Slash" && !event.metaKey && !event.ctrlKey && !event.altKey) {
+      const { snapshot, trigger } = resolveActiveComposerTrigger();
+      const slashTriggerText =
+        trigger && (trigger.kind === "slash-command" || trigger.kind === "slash-model")
+          ? snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd)
+          : null;
+
+      if (slashTriggerText === "/" && snapshot.expandedCursor === trigger?.rangeEnd) {
+        // Pressing `/` again on a lone `/` dismisses the picker. Only wipe the
+        // draft when the slash IS the whole prompt; a mid-line slash (e.g. after
+        // an existing chip) must keep surrounding content, so let it type through.
+        if (trigger.rangeStart === 0 && trigger.rangeEnd === snapshot.value.length) {
+          clearComposerSlashDraft();
+          return true;
+        }
+        return false;
+      }
+      return false;
+    }
+
+    if (key === "Tab" && event.shiftKey) {
+      toggleInteractionMode();
+      return true;
+    }
+
+    const { snapshot, trigger } = resolveActiveComposerTrigger();
+    const menuIsActive = composerMenuOpenRef.current || trigger !== null;
+    if (
+      key === "Enter" &&
+      !event.shiftKey &&
+      !menuIsActive &&
+      extractChatAutomationInvocation(snapshot.value) !== null
+    ) {
+      void onSend(
+        undefined,
+        resolveFollowUpDispatchMode({
+          behavior: settings.followUpBehavior,
+          hasLiveTurn,
+          useOppositeBehavior: event.metaKey || event.ctrlKey,
+        }),
+      );
+      return true;
+    }
+
+    if (menuIsActive && isLocalFolderBrowserOpen) {
+      if (key === "ArrowDown") {
+        localDirectoryMenuRef.current?.moveHighlight("down");
+        return true;
+      }
+      if (key === "ArrowUp") {
+        localDirectoryMenuRef.current?.moveHighlight("up");
+        return true;
+      }
+      if (key === "Enter" || key === "Tab") {
+        localDirectoryMenuRef.current?.activateHighlighted();
+        return true;
+      }
+    }
+
+    if (menuIsActive) {
+      const currentItems = composerMenuItemsRef.current;
+      if (key === "ArrowDown" && currentItems.length > 0) {
+        nudgeComposerMenuHighlight("ArrowDown");
+        return true;
+      }
+      if (key === "ArrowUp" && currentItems.length > 0) {
+        nudgeComposerMenuHighlight("ArrowUp");
+        return true;
+      }
+      if (key === "Tab" || key === "Enter") {
+        const selectedItem = activeComposerMenuItemRef.current ?? currentItems[0];
+        if (selectedItem) {
+          onSelectComposerItem(selectedItem);
+          return true;
+        }
+      }
+    }
+
+    if (
+      shouldHandlePromptHistoryNavigationKey({
+        key,
+        metaKey: event.metaKey,
+        ctrlKey: event.ctrlKey,
+        altKey: event.altKey,
+        shiftKey: event.shiftKey,
+        menuIsActive,
+        hasActivePendingProgress: Boolean(activePendingProgress),
+        isComposerApprovalState,
+        pendingUserInputCount: pendingUserInputs.length,
+      })
+    ) {
+      const direction = key === "ArrowUp" ? "older" : "newer";
+      const previousNavigationState = promptHistoryNavigationRef.current;
+      const result = resolvePromptHistoryNavigation({
+        direction,
+        history: promptHistory,
+        currentPrompt: snapshot.value,
+        // Line-boundary math needs raw string offsets; the collapsed cursor
+        // undercounts inline token chips (mentions, links, slash commands).
+        currentExpandedCursor: snapshot.expandedCursor,
+        selectionCollapsed: snapshot.selectionCollapsed,
+        state: previousNavigationState,
+      });
+      if (result.handled) {
+        promptHistoryNavigationRef.current = result.state;
+        if (result.state === null) {
+          restoreComposerDraftPromptHistorySavedDraft(threadId);
+        } else if (previousNavigationState === null) {
+          setComposerDraftPromptHistorySavedDraft(
+            threadId,
+            captureComposerPromptHistorySavedDraft({
+              threadId,
+              draft: composerDraft,
+              prompt: result.state.draft,
+            }),
+          );
+        }
+        applyingPromptHistoryNavigationRef.current = true;
+        expectedPromptHistoryPromptRef.current = result.prompt;
+        promptHistoryAppliedPromptRef.current = result.prompt;
+        promptRef.current = result.prompt;
+        setPrompt(result.prompt);
+        setComposerCursor(collapseExpandedComposerCursor(result.prompt, result.expandedCursor));
+        // Recalled text replaces the whole prompt; suppress trigger detection
+        // so an entry ending in a mention/slash token cannot pop a menu that
+        // would capture the next arrow keypress.
+        setComposerTrigger(null);
+        window.requestAnimationFrame(() => {
+          applyingPromptHistoryNavigationRef.current = false;
+        });
+        return true;
+      }
+    }
+
+    if (key === "Enter" && !event.shiftKey) {
+      if (promptHistoryNavigationRef.current !== null) {
+        // Sending commits the recalled text as the prompt; drop the saved
+        // draft here (not just in the send path) so it cannot linger and
+        // resurrect a stale draft if the send is rejected.
+        promptHistoryNavigationRef.current = null;
+        setComposerDraftPromptHistorySavedDraft(threadId, null);
+      }
+      expectedPromptHistoryPromptRef.current = null;
+      void onSend(
+        undefined,
+        resolveFollowUpDispatchMode({
+          behavior: settings.followUpBehavior,
+          hasLiveTurn,
+          useOppositeBehavior: event.metaKey || event.ctrlKey,
+        }),
+      );
+      return true;
+    }
+    return false;
+  };
+  return {
+    onSelectComposerItem,
+    onComposerMenuItemHighlighted,
+    onPromptChange,
+    onComposerCommandKey,
+  };
+}

--- a/apps/web/src/components/chat/useChatComposerDraft.ts
+++ b/apps/web/src/components/chat/useChatComposerDraft.ts
@@ -1,0 +1,536 @@
+import { ThreadId } from "@synara/contracts";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  clampCollapsedComposerCursor,
+  collapseExpandedComposerCursor,
+  detectComposerTrigger,
+  expandCollapsedComposerCursor,
+  type ComposerTrigger,
+} from "../../composer-logic";
+import {
+  useComposerDraftStore,
+  useComposerThreadDraft,
+  type BrowserAnnotationDraft,
+  type ComposerAssistantSelectionAttachment,
+  type ComposerFileAttachment,
+  type ComposerImageAttachment,
+  type RestoredComposerSourceProposedPlan,
+} from "../../composerDraftStore";
+import { type PastedTextDraft } from "../../lib/composerPastedText";
+import { type FileCommentDraft } from "../../lib/fileComments";
+import { type PullRequestContextDraft } from "../../lib/pullRequestContext";
+import {
+  removeInlineTerminalContextPlaceholder,
+  type TerminalContextDraft,
+} from "../../lib/terminalContext";
+import { deriveComposerSendState, type PromptHistoryNavigationState } from "../ChatView.logic";
+import { type ComposerPromptEditorHandle } from "../ComposerPromptEditor";
+import { useComposerAttachmentPersistence } from "./useComposerAttachmentPersistence";
+
+export type ChatComposerDraftController = ReturnType<typeof useChatComposerDraft>;
+interface ChatComposerDraftInput {
+  threadId: ThreadId;
+}
+
+export function useChatComposerDraft({ threadId }: ChatComposerDraftInput) {
+  const composerDraft = useComposerThreadDraft(threadId);
+  const prompt = composerDraft.prompt;
+  const composerPromptHistorySavedDraft = composerDraft.promptHistorySavedDraft;
+  const composerPromptHistorySavedDraftImages = composerPromptHistorySavedDraft?.images ?? null;
+  const composerImages = composerDraft.images;
+  const composerFiles = composerDraft.files;
+  const composerAssistantSelections = composerDraft.assistantSelections;
+  const composerBrowserAnnotations = composerDraft.browserAnnotations;
+  const composerFileComments = composerDraft.fileComments;
+  const composerTerminalContexts = composerDraft.terminalContexts;
+  const composerPastedTexts = composerDraft.pastedTexts;
+  const composerPullRequestContexts = composerDraft.pullRequestContexts;
+  const composerSkills = composerDraft.skills;
+  const composerMentions = composerDraft.mentions;
+  const queuedComposerTurns = composerDraft.queuedTurns;
+  const restoredSourceProposedPlan = composerDraft.restoredSourceProposedPlan;
+  const composerSendState = useMemo(
+    () =>
+      deriveComposerSendState({
+        prompt,
+        imageCount: composerImages.length,
+        fileCount: composerFiles.length,
+        assistantSelectionCount: composerAssistantSelections.length,
+        browserAnnotationCount: composerBrowserAnnotations.length,
+        fileCommentCount: composerFileComments.length,
+        terminalContexts: composerTerminalContexts,
+        pastedTexts: composerPastedTexts,
+        pullRequestContexts: composerPullRequestContexts,
+      }),
+    [
+      composerAssistantSelections.length,
+      composerBrowserAnnotations.length,
+      composerFileComments.length,
+      composerFiles.length,
+      composerImages.length,
+      composerTerminalContexts,
+      composerPastedTexts,
+      composerPullRequestContexts,
+      prompt,
+    ],
+  );
+  const nonPersistedComposerImageIds = composerDraft.nonPersistedImageIds;
+  const durablyPersistedComposerImageIds = composerDraft.persistedAttachments;
+  const setComposerDraftPrompt = useComposerDraftStore((store) => store.setPrompt);
+  const setComposerDraftPromptHistorySavedDraft = useComposerDraftStore(
+    (store) => store.setPromptHistorySavedDraft,
+  );
+  const restoreComposerDraftPromptHistorySavedDraft = useComposerDraftStore(
+    (store) => store.restorePromptHistorySavedDraft,
+  );
+  const setComposerDraftModelSelection = useComposerDraftStore((store) => store.setModelSelection);
+  const setComposerDraftProviderModelOptions = useComposerDraftStore(
+    (store) => store.setProviderModelOptions,
+  );
+  const setComposerDraftRuntimeMode = useComposerDraftStore((store) => store.setRuntimeMode);
+  const setComposerDraftInteractionMode = useComposerDraftStore(
+    (store) => store.setInteractionMode,
+  );
+  const enqueueQueuedComposerTurn = useComposerDraftStore((store) => store.enqueueQueuedTurn);
+  const insertQueuedComposerTurn = useComposerDraftStore((store) => store.insertQueuedTurn);
+  const removeQueuedComposerTurnFromDraft = useComposerDraftStore(
+    (store) => store.removeQueuedTurn,
+  );
+  const addComposerDraftImages = useComposerDraftStore((store) => store.addImages);
+  const removeComposerDraftImage = useComposerDraftStore((store) => store.removeImage);
+  const addComposerDraftFiles = useComposerDraftStore((store) => store.addFiles);
+  const removeComposerDraftFile = useComposerDraftStore((store) => store.removeFile);
+  const addComposerDraftAssistantSelection = useComposerDraftStore(
+    (store) => store.addAssistantSelection,
+  );
+  const addComposerDraftBrowserAnnotations = useComposerDraftStore(
+    (store) => store.addBrowserAnnotations,
+  );
+  const removeComposerDraftBrowserAnnotation = useComposerDraftStore(
+    (store) => store.removeBrowserAnnotation,
+  );
+  const clearComposerDraftAssistantSelections = useComposerDraftStore(
+    (store) => store.clearAssistantSelections,
+  );
+  const addComposerDraftFileComment = useComposerDraftStore((store) => store.addFileComment);
+  const clearComposerDraftFileComments = useComposerDraftStore((store) => store.clearFileComments);
+  const insertComposerDraftTerminalContext = useComposerDraftStore(
+    (store) => store.insertTerminalContext,
+  );
+  const addComposerDraftTerminalContexts = useComposerDraftStore(
+    (store) => store.addTerminalContexts,
+  );
+  const removeComposerDraftTerminalContext = useComposerDraftStore(
+    (store) => store.removeTerminalContext,
+  );
+  const addComposerDraftPastedTexts = useComposerDraftStore((store) => store.addPastedTexts);
+  const removeComposerDraftPastedText = useComposerDraftStore((store) => store.removePastedText);
+  const addComposerDraftPullRequestContext = useComposerDraftStore(
+    (store) => store.addPullRequestContext,
+  );
+  const removeComposerDraftPullRequestContext = useComposerDraftStore(
+    (store) => store.removePullRequestContext,
+  );
+  const setComposerDraftTerminalContexts = useComposerDraftStore(
+    (store) => store.setTerminalContexts,
+  );
+  const setComposerDraftRestoredSourceProposedPlan = useComposerDraftStore(
+    (store) => store.setRestoredSourceProposedPlan,
+  );
+  const clearComposerDraftContent = useComposerDraftStore((store) => store.clearComposerContent);
+  const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
+  const getDraftThreadByProjectId = useComposerDraftStore(
+    (store) => store.getDraftThreadByProjectId,
+  );
+  const getDraftThread = useComposerDraftStore((store) => store.getDraftThread);
+  const setProjectDraftThreadId = useComposerDraftStore((store) => store.setProjectDraftThreadId);
+  const clearProjectDraftThreadId = useComposerDraftStore(
+    (store) => store.clearProjectDraftThreadId,
+  );
+
+  const promptRef = useRef(prompt);
+
+  const composerAssistantSelectionsRef = useRef<ComposerAssistantSelectionAttachment[]>(
+    composerAssistantSelections,
+  );
+  const composerBrowserAnnotationsRef = useRef<BrowserAnnotationDraft[]>(
+    composerBrowserAnnotations,
+  );
+  const composerTerminalContextsRef = useRef<TerminalContextDraft[]>(composerTerminalContexts);
+  const composerFileCommentsRef = useRef<FileCommentDraft[]>(composerFileComments);
+  const composerPastedTextsRef = useRef<PastedTextDraft[]>(composerPastedTexts);
+  const composerPullRequestContextsRef = useRef<PullRequestContextDraft[]>(
+    composerPullRequestContexts,
+  );
+
+  const [composerCursor, setComposerCursor] = useState(() =>
+    collapseExpandedComposerCursor(prompt, prompt.length),
+  );
+  const [composerTrigger, setComposerTrigger] = useState<ComposerTrigger | null>(() =>
+    detectComposerTrigger(prompt, prompt.length),
+  );
+
+  const composerEditorRef = useRef<ComposerPromptEditorHandle>(null);
+
+  const promptHistoryNavigationRef = useRef<PromptHistoryNavigationState | null>(null);
+  const applyingPromptHistoryNavigationRef = useRef(false);
+  const expectedPromptHistoryPromptRef = useRef<string | null>(null);
+  const promptHistoryAppliedPromptRef = useRef<string | null>(null);
+
+  const composerImagesRef = useRef<ComposerImageAttachment[]>([]);
+  const composerFilesRef = useRef<ComposerFileAttachment[]>([]);
+
+  const restoredQueuedSourceProposedPlanRef = useRef<RestoredComposerSourceProposedPlan | null>(
+    restoredSourceProposedPlan ?? null,
+  );
+
+  useEffect(() => {
+    promptHistoryNavigationRef.current = null;
+    applyingPromptHistoryNavigationRef.current = false;
+    expectedPromptHistoryPromptRef.current = null;
+    promptHistoryAppliedPromptRef.current = null;
+  }, [threadId]);
+  // While a history browse is active the persisted draft prompt holds a
+  // recalled entry and the user's real draft snapshot sits in promptHistorySavedDraft.
+  // A non-null saved draft with no live navigation state means the browse was
+  // interrupted (thread switch, reload, unmount) — put the real draft back.
+  useEffect(() => {
+    if (promptHistoryNavigationRef.current !== null || composerPromptHistorySavedDraft === null) {
+      return;
+    }
+    restoreComposerDraftPromptHistorySavedDraft(threadId);
+    setComposerCursor(
+      collapseExpandedComposerCursor(
+        composerPromptHistorySavedDraft.prompt,
+        composerPromptHistorySavedDraft.prompt.length,
+      ),
+    );
+  }, [composerPromptHistorySavedDraft, restoreComposerDraftPromptHistorySavedDraft, threadId]);
+  const setRestoredQueuedSourceProposedPlan = useCallback(
+    (targetThreadId: ThreadId, source: RestoredComposerSourceProposedPlan | null) => {
+      restoredQueuedSourceProposedPlanRef.current = source;
+      setComposerDraftRestoredSourceProposedPlan(targetThreadId, source);
+    },
+    [setComposerDraftRestoredSourceProposedPlan],
+  );
+  useEffect(() => {
+    restoredQueuedSourceProposedPlanRef.current = restoredSourceProposedPlan ?? null;
+  }, [restoredSourceProposedPlan]);
+
+  const setPrompt = useCallback(
+    (nextPrompt: string) => {
+      setComposerDraftPrompt(threadId, nextPrompt);
+    },
+    [setComposerDraftPrompt, threadId],
+  );
+  const discardPromptHistoryNavigationForComposerMutation = useCallback(() => {
+    if (promptHistoryNavigationRef.current === null) {
+      return;
+    }
+    // Attachment edits mean the recalled prompt is now the user's draft; do not restore the old one.
+    promptHistoryNavigationRef.current = null;
+    applyingPromptHistoryNavigationRef.current = false;
+    expectedPromptHistoryPromptRef.current = null;
+    promptHistoryAppliedPromptRef.current = null;
+    setComposerDraftPromptHistorySavedDraft(threadId, null);
+  }, [setComposerDraftPromptHistorySavedDraft, threadId]);
+  const addComposerImagesToDraft = useCallback(
+    (images: ComposerImageAttachment[]) => {
+      discardPromptHistoryNavigationForComposerMutation();
+      return addComposerDraftImages(threadId, images);
+    },
+    [addComposerDraftImages, discardPromptHistoryNavigationForComposerMutation, threadId],
+  );
+  const addComposerFilesToDraft = useCallback(
+    (files: ComposerFileAttachment[]) => {
+      discardPromptHistoryNavigationForComposerMutation();
+      return addComposerDraftFiles(threadId, files);
+    },
+    [addComposerDraftFiles, discardPromptHistoryNavigationForComposerMutation, threadId],
+  );
+  const addComposerAssistantSelectionToDraft = useCallback(
+    (selection: ComposerAssistantSelectionAttachment) => {
+      discardPromptHistoryNavigationForComposerMutation();
+      return addComposerDraftAssistantSelection(threadId, selection);
+    },
+    [
+      addComposerDraftAssistantSelection,
+      discardPromptHistoryNavigationForComposerMutation,
+      threadId,
+    ],
+  );
+  const addComposerTerminalContextsToDraft = useCallback(
+    (contexts: TerminalContextDraft[]) => {
+      discardPromptHistoryNavigationForComposerMutation();
+      addComposerDraftTerminalContexts(threadId, contexts);
+    },
+    [addComposerDraftTerminalContexts, discardPromptHistoryNavigationForComposerMutation, threadId],
+  );
+  const addComposerPastedTextsToDraft = useCallback(
+    (pastedTexts: PastedTextDraft[]) => {
+      discardPromptHistoryNavigationForComposerMutation();
+      addComposerDraftPastedTexts(threadId, pastedTexts);
+    },
+    [addComposerDraftPastedTexts, discardPromptHistoryNavigationForComposerMutation, threadId],
+  );
+  const addComposerFileCommentToDraft = useCallback(
+    (comment: FileCommentDraft) => {
+      discardPromptHistoryNavigationForComposerMutation();
+      addComposerDraftFileComment(threadId, comment);
+    },
+    [addComposerDraftFileComment, discardPromptHistoryNavigationForComposerMutation, threadId],
+  );
+  const removeComposerImageFromDraft = useCallback(
+    (imageId: string) => {
+      discardPromptHistoryNavigationForComposerMutation();
+      removeComposerDraftImage(threadId, imageId);
+    },
+    [discardPromptHistoryNavigationForComposerMutation, removeComposerDraftImage, threadId],
+  );
+  const clearComposerAssistantSelectionsFromDraft = useCallback(() => {
+    discardPromptHistoryNavigationForComposerMutation();
+    clearComposerDraftAssistantSelections(threadId);
+  }, [
+    clearComposerDraftAssistantSelections,
+    discardPromptHistoryNavigationForComposerMutation,
+    threadId,
+  ]);
+  const clearComposerFileCommentsFromDraft = useCallback(() => {
+    discardPromptHistoryNavigationForComposerMutation();
+    clearComposerDraftFileComments(threadId);
+  }, [clearComposerDraftFileComments, discardPromptHistoryNavigationForComposerMutation, threadId]);
+  const removeComposerTerminalContextFromDraft = useCallback(
+    (contextId: string) => {
+      discardPromptHistoryNavigationForComposerMutation();
+      const contextIndex = composerTerminalContexts.findIndex(
+        (context) => context.id === contextId,
+      );
+      if (contextIndex < 0) {
+        return;
+      }
+      const nextPrompt = removeInlineTerminalContextPlaceholder(promptRef.current, contextIndex);
+      promptRef.current = nextPrompt.prompt;
+      setPrompt(nextPrompt.prompt);
+      removeComposerDraftTerminalContext(threadId, contextId);
+      setComposerCursor(nextPrompt.cursor);
+      setComposerTrigger(
+        detectComposerTrigger(
+          nextPrompt.prompt,
+          expandCollapsedComposerCursor(nextPrompt.prompt, nextPrompt.cursor),
+        ),
+      );
+    },
+    [
+      composerTerminalContexts,
+      discardPromptHistoryNavigationForComposerMutation,
+      removeComposerDraftTerminalContext,
+      setPrompt,
+      threadId,
+    ],
+  );
+  const removeComposerPastedTextFromDraft = useCallback(
+    (pastedTextId: string) => {
+      discardPromptHistoryNavigationForComposerMutation();
+      removeComposerDraftPastedText(threadId, pastedTextId);
+    },
+    [discardPromptHistoryNavigationForComposerMutation, removeComposerDraftPastedText, threadId],
+  );
+  const addComposerPullRequestContextsToDraft = useCallback(
+    (contexts: ReadonlyArray<PullRequestContextDraft>) => {
+      if (contexts.length === 0) {
+        return;
+      }
+      discardPromptHistoryNavigationForComposerMutation();
+      for (const context of contexts) {
+        addComposerDraftPullRequestContext(threadId, context);
+      }
+    },
+    [
+      addComposerDraftPullRequestContext,
+      discardPromptHistoryNavigationForComposerMutation,
+      threadId,
+    ],
+  );
+  const removeComposerPullRequestContextFromDraft = useCallback(
+    (contextId: string) => {
+      discardPromptHistoryNavigationForComposerMutation();
+      removeComposerDraftPullRequestContext(threadId, contextId);
+    },
+    [
+      discardPromptHistoryNavigationForComposerMutation,
+      removeComposerDraftPullRequestContext,
+      threadId,
+    ],
+  );
+  const removeComposerBrowserAnnotationFromDraft = useCallback(
+    (annotationId: string) => {
+      discardPromptHistoryNavigationForComposerMutation();
+      removeComposerDraftBrowserAnnotation(threadId, annotationId);
+    },
+    [
+      discardPromptHistoryNavigationForComposerMutation,
+      removeComposerDraftBrowserAnnotation,
+      threadId,
+    ],
+  );
+  // "Show in text field": drop the full pasted text back into the editor (appended
+  // to the current prompt) and discard the card so it can be edited as normal text.
+  const showComposerPastedTextInField = useCallback(
+    (pastedTextId: string) => {
+      const pasted = composerPastedTexts.find((entry) => entry.id === pastedTextId);
+      if (!pasted) {
+        return;
+      }
+      discardPromptHistoryNavigationForComposerMutation();
+      const current = promptRef.current;
+      const separator = current.length > 0 && !current.endsWith("\n") ? "\n" : "";
+      const nextPrompt = `${current}${separator}${pasted.text}`;
+      promptRef.current = nextPrompt;
+      setPrompt(nextPrompt);
+      removeComposerDraftPastedText(threadId, pastedTextId);
+      setComposerCursor(collapseExpandedComposerCursor(nextPrompt, nextPrompt.length));
+      setComposerTrigger(detectComposerTrigger(nextPrompt, nextPrompt.length));
+      window.requestAnimationFrame(() => {
+        composerEditorRef.current?.focusAtEnd();
+      });
+    },
+    [
+      composerPastedTexts,
+      discardPromptHistoryNavigationForComposerMutation,
+      removeComposerDraftPastedText,
+      setPrompt,
+      threadId,
+    ],
+  );
+
+  useEffect(() => {
+    composerImagesRef.current = composerImages;
+  }, [composerImages]);
+
+  useEffect(() => {
+    composerFilesRef.current = composerFiles;
+  }, [composerFiles]);
+
+  useEffect(() => {
+    composerAssistantSelectionsRef.current = composerAssistantSelections;
+  }, [composerAssistantSelections]);
+
+  useEffect(() => {
+    composerBrowserAnnotationsRef.current = composerBrowserAnnotations;
+  }, [composerBrowserAnnotations]);
+
+  useEffect(() => {
+    composerTerminalContextsRef.current = composerTerminalContexts;
+  }, [composerTerminalContexts]);
+
+  useEffect(() => {
+    composerFileCommentsRef.current = composerFileComments;
+  }, [composerFileComments]);
+
+  useEffect(() => {
+    composerPastedTextsRef.current = composerPastedTexts;
+  }, [composerPastedTexts]);
+
+  useEffect(() => {
+    composerPullRequestContextsRef.current = composerPullRequestContexts;
+  }, [composerPullRequestContexts]);
+
+  useEffect(() => {
+    promptRef.current = prompt;
+    if (
+      promptHistoryNavigationRef.current !== null &&
+      prompt !== promptHistoryAppliedPromptRef.current
+    ) {
+      // Another writer (queued-turn restore, automation restore, insertion)
+      // replaced the prompt while a history browse was active. The new prompt
+      // is authoritative: end the browse and drop the saved pre-browse draft
+      // so it cannot clobber this prompt later.
+      promptHistoryNavigationRef.current = null;
+      expectedPromptHistoryPromptRef.current = null;
+      setComposerDraftPromptHistorySavedDraft(threadId, null);
+    }
+    setComposerCursor((existing) => clampCollapsedComposerCursor(prompt, existing));
+  }, [prompt, setComposerDraftPromptHistorySavedDraft, threadId]);
+
+  useComposerAttachmentPersistence({
+    threadId,
+    composerImages,
+    composerPromptHistorySavedDraftImages,
+  });
+  return {
+    composerDraft,
+    prompt,
+    composerImages,
+    composerFiles,
+    composerAssistantSelections,
+    composerBrowserAnnotations,
+    composerFileComments,
+    composerTerminalContexts,
+    composerPastedTexts,
+    composerPullRequestContexts,
+    composerSkills,
+    composerMentions,
+    queuedComposerTurns,
+    composerSendState,
+    nonPersistedComposerImageIds,
+    durablyPersistedComposerImageIds,
+    setComposerDraftPrompt,
+    setComposerDraftPromptHistorySavedDraft,
+    restoreComposerDraftPromptHistorySavedDraft,
+    setComposerDraftModelSelection,
+    setComposerDraftProviderModelOptions,
+    setComposerDraftRuntimeMode,
+    setComposerDraftInteractionMode,
+    enqueueQueuedComposerTurn,
+    insertQueuedComposerTurn,
+    removeQueuedComposerTurnFromDraft,
+    removeComposerDraftFile,
+    addComposerDraftBrowserAnnotations,
+    insertComposerDraftTerminalContext,
+    addComposerDraftPastedTexts,
+    setComposerDraftTerminalContexts,
+    clearComposerDraftContent,
+    setDraftThreadContext,
+    getDraftThreadByProjectId,
+    getDraftThread,
+    setProjectDraftThreadId,
+    clearProjectDraftThreadId,
+    promptRef,
+    composerAssistantSelectionsRef,
+    composerBrowserAnnotationsRef,
+    composerTerminalContextsRef,
+    composerFileCommentsRef,
+    composerPastedTextsRef,
+    composerPullRequestContextsRef,
+    composerCursor,
+    setComposerCursor,
+    composerTrigger,
+    setComposerTrigger,
+    composerEditorRef,
+    promptHistoryNavigationRef,
+    applyingPromptHistoryNavigationRef,
+    expectedPromptHistoryPromptRef,
+    promptHistoryAppliedPromptRef,
+    composerImagesRef,
+    composerFilesRef,
+    restoredQueuedSourceProposedPlanRef,
+    setRestoredQueuedSourceProposedPlan,
+    setPrompt,
+    discardPromptHistoryNavigationForComposerMutation,
+    addComposerImagesToDraft,
+    addComposerFilesToDraft,
+    addComposerAssistantSelectionToDraft,
+    addComposerTerminalContextsToDraft,
+    addComposerPastedTextsToDraft,
+    addComposerFileCommentToDraft,
+    removeComposerImageFromDraft,
+    clearComposerAssistantSelectionsFromDraft,
+    clearComposerFileCommentsFromDraft,
+    removeComposerTerminalContextFromDraft,
+    removeComposerPastedTextFromDraft,
+    addComposerPullRequestContextsToDraft,
+    removeComposerPullRequestContextFromDraft,
+    removeComposerBrowserAnnotationFromDraft,
+    showComposerPastedTextInField,
+  };
+}

--- a/apps/web/src/components/chat/useChatComposerEditing.ts
+++ b/apps/web/src/components/chat/useChatComposerEditing.ts
@@ -1,0 +1,302 @@
+import { ThreadId } from "@synara/contracts";
+import type { Dispatch, SetStateAction } from "react";
+import { useCallback } from "react";
+import {
+  composerMentionPathNeedsQuoting,
+  formatComposerMentionToken,
+} from "~/lib/composerMentions";
+import {
+  collapseExpandedComposerCursor,
+  detectComposerTrigger,
+  expandCollapsedComposerCursor,
+  replaceTextRange,
+  type ComposerTrigger,
+} from "../../composer-logic";
+import {
+  ensureLeadingSpaceForReplacement,
+  extendReplacementRangeForTrailingSpace,
+} from "../../composerTriggerInsertion";
+import { setPendingUserInputCustomAnswer } from "../../pendingUserInput";
+import { useChatComposerDraft } from "./useChatComposerDraft";
+import { useChatPendingInteractions } from "./useChatPendingInteractions";
+
+interface ChatComposerEditingInput {
+  threadId: ThreadId;
+  promptRef: ReturnType<typeof useChatComposerDraft>["promptRef"];
+  activePendingProgress: ReturnType<typeof useChatPendingInteractions>["activePendingProgress"];
+  activePendingUserInputKey: ReturnType<
+    typeof useChatPendingInteractions
+  >["activePendingUserInputKey"];
+  pendingUserInputAnswersByRequestIdRef: ReturnType<
+    typeof useChatPendingInteractions
+  >["pendingUserInputAnswersByRequestIdRef"];
+  setPendingUserInputAnswersByRequestId: ReturnType<
+    typeof useChatPendingInteractions
+  >["setPendingUserInputAnswersByRequestId"];
+  setPrompt: ReturnType<typeof useChatComposerDraft>["setPrompt"];
+  setComposerCursor: ReturnType<typeof useChatComposerDraft>["setComposerCursor"];
+  setComposerTrigger: ReturnType<typeof useChatComposerDraft>["setComposerTrigger"];
+  composerEditorRef: ReturnType<typeof useChatComposerDraft>["composerEditorRef"];
+  composerCursor: ReturnType<typeof useChatComposerDraft>["composerCursor"];
+  composerTerminalContexts: ReturnType<typeof useChatComposerDraft>["composerTerminalContexts"];
+  setComposerHighlightedItemId: Dispatch<SetStateAction<string | null>>;
+  setRestoredQueuedSourceProposedPlan: ReturnType<
+    typeof useChatComposerDraft
+  >["setRestoredQueuedSourceProposedPlan"];
+  clearComposerDraftContent: ReturnType<typeof useChatComposerDraft>["clearComposerDraftContent"];
+  scheduleComposerFocus: () => void;
+}
+
+export function useChatComposerEditing({
+  threadId,
+  promptRef,
+  activePendingProgress,
+  activePendingUserInputKey,
+  pendingUserInputAnswersByRequestIdRef,
+  setPendingUserInputAnswersByRequestId,
+  setPrompt,
+  setComposerCursor,
+  setComposerTrigger,
+  composerEditorRef,
+  composerCursor,
+  composerTerminalContexts,
+  setComposerHighlightedItemId,
+  setRestoredQueuedSourceProposedPlan,
+  clearComposerDraftContent,
+  scheduleComposerFocus,
+}: ChatComposerEditingInput) {
+  const applyPromptReplacement = useCallback(
+    (
+      rangeStart: number,
+      rangeEnd: number,
+      replacement: string,
+      options?: { expectedText?: string; cursorOffset?: number },
+    ): number | false => {
+      const currentText = promptRef.current;
+      const safeStart = Math.max(0, Math.min(currentText.length, rangeStart));
+      const safeEnd = Math.max(safeStart, Math.min(currentText.length, rangeEnd));
+      if (
+        options?.expectedText !== undefined &&
+        currentText.slice(safeStart, safeEnd) !== options.expectedText
+      ) {
+        return false;
+      }
+      const next = replaceTextRange(promptRef.current, rangeStart, rangeEnd, replacement);
+      let nextCursor = collapseExpandedComposerCursor(next.text, next.cursor);
+      // Apply cursor offset if specified (e.g., -1 to position inside parentheses)
+      if (options?.cursorOffset !== undefined) {
+        nextCursor = Math.max(0, nextCursor + options.cursorOffset);
+      }
+      promptRef.current = next.text;
+      const activePendingQuestion = activePendingProgress?.activeQuestion;
+      if (activePendingQuestion && activePendingUserInputKey) {
+        const nextDraftAnswer = setPendingUserInputCustomAnswer(
+          pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey]?.[
+            activePendingQuestion.id
+          ],
+          next.text,
+        );
+        const nextRequestAnswers = {
+          ...pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey],
+          [activePendingQuestion.id]: nextDraftAnswer,
+        };
+        pendingUserInputAnswersByRequestIdRef.current = {
+          ...pendingUserInputAnswersByRequestIdRef.current,
+          [activePendingUserInputKey]: nextRequestAnswers,
+        };
+        setPendingUserInputAnswersByRequestId((existing) => ({
+          ...existing,
+          [activePendingUserInputKey]: nextRequestAnswers,
+        }));
+      } else {
+        setPrompt(next.text);
+      }
+      setComposerCursor(nextCursor);
+      setComposerTrigger(
+        detectComposerTrigger(next.text, expandCollapsedComposerCursor(next.text, nextCursor)),
+      );
+      window.requestAnimationFrame(() => {
+        composerEditorRef.current?.focusAt(nextCursor);
+      });
+      return nextCursor;
+    },
+    [
+      promptRef,
+      setComposerCursor,
+      setComposerTrigger,
+      composerEditorRef,
+      activePendingProgress?.activeQuestion,
+      activePendingUserInputKey,
+      setPrompt,
+      setPendingUserInputAnswersByRequestId,
+      pendingUserInputAnswersByRequestIdRef,
+    ],
+  );
+
+  const readComposerSnapshot = useCallback((): {
+    value: string;
+    cursor: number;
+    expandedCursor: number;
+    selectionCollapsed: boolean;
+    terminalContextIds: string[];
+  } => {
+    const editorSnapshot = composerEditorRef.current?.readSnapshot();
+    if (editorSnapshot) {
+      return editorSnapshot;
+    }
+    return {
+      value: promptRef.current,
+      cursor: composerCursor,
+      expandedCursor: expandCollapsedComposerCursor(promptRef.current, composerCursor),
+      selectionCollapsed: true,
+      terminalContextIds: composerTerminalContexts.map((context) => context.id),
+    };
+  }, [promptRef, composerEditorRef, composerCursor, composerTerminalContexts]);
+
+  const resolveActiveComposerTrigger = useCallback((): {
+    snapshot: {
+      value: string;
+      cursor: number;
+      expandedCursor: number;
+      selectionCollapsed: boolean;
+    };
+    trigger: ComposerTrigger | null;
+  } => {
+    const snapshot = readComposerSnapshot();
+    return {
+      snapshot,
+      trigger: detectComposerTrigger(snapshot.value, snapshot.expandedCursor),
+    };
+  }, [readComposerSnapshot]);
+
+  // Shared insertion path for picker selections (mentions, plugins, skills,
+  // agents, provider-native commands, local folders). Guarantees the replacement
+  // is flanked by a leading space when landing next to a non-whitespace char and
+  // absorbs an existing trailing space so we don't end up with double spaces.
+  const applyComposerTriggerReplacement = useCallback(
+    (params: {
+      snapshot: { value: string };
+      trigger: ComposerTrigger;
+      base: string;
+      cursorOffset?: number;
+      onApplied?: () => void;
+    }): number | false => {
+      const { snapshot, trigger, base, cursorOffset, onApplied } = params;
+      const replacement = ensureLeadingSpaceForReplacement(
+        snapshot.value,
+        trigger.rangeStart,
+        base,
+      );
+      const replacementRangeEnd = extendReplacementRangeForTrailingSpace(
+        snapshot.value,
+        trigger.rangeEnd,
+        replacement,
+      );
+      const options: { expectedText: string; cursorOffset?: number } = {
+        expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd),
+      };
+      if (cursorOffset !== undefined) {
+        options.cursorOffset = cursorOffset;
+      }
+      const applied = applyPromptReplacement(
+        trigger.rangeStart,
+        replacementRangeEnd,
+        replacement,
+        options,
+      );
+      if (applied !== false) {
+        onApplied?.();
+        setComposerHighlightedItemId(null);
+      }
+      return applied;
+    },
+    [setComposerHighlightedItemId, applyPromptReplacement],
+  );
+
+  // Replaces the active `@...` token with a completed absolute folder mention.
+  const handleSelectLocalDirectoryMention = useCallback(
+    (absolutePath: string) => {
+      const { snapshot, trigger } = resolveActiveComposerTrigger();
+      if (!trigger) return;
+      applyComposerTriggerReplacement({
+        snapshot,
+        trigger,
+        base: `${formatComposerMentionToken(absolutePath)} `,
+      });
+    },
+    [applyComposerTriggerReplacement, resolveActiveComposerTrigger],
+  );
+
+  // Rewrites the active `@...` mention to an absolute folder path with a trailing separator
+  // so the local-folder picker stays open and the user can keep browsing by clicking or typing.
+  // Paths that need quoting (spaces, parentheses, …) are written as an unclosed
+  // `@"...` so detectComposerTrigger keeps matching while the user descends (#351).
+  const handleNavigateLocalFolder = useCallback(
+    (absolutePath: string) => {
+      const { snapshot, trigger } = resolveActiveComposerTrigger();
+      if (!trigger) return;
+      const separator = absolutePath.includes("\\") ? "\\" : "/";
+      const withTrailingSeparator = absolutePath.endsWith(separator)
+        ? absolutePath
+        : `${absolutePath}${separator}`;
+      const base = composerMentionPathNeedsQuoting(withTrailingSeparator)
+        ? `@"${withTrailingSeparator}`
+        : `@${withTrailingSeparator}`;
+      applyComposerTriggerReplacement({ snapshot, trigger, base });
+    },
+    [applyComposerTriggerReplacement, resolveActiveComposerTrigger],
+  );
+
+  const setComposerPromptValue = useCallback(
+    (nextPrompt: string) => {
+      setRestoredQueuedSourceProposedPlan(threadId, null);
+      promptRef.current = nextPrompt;
+      setPrompt(nextPrompt);
+      const nextCursor = collapseExpandedComposerCursor(nextPrompt, nextPrompt.length);
+      setComposerCursor(nextCursor);
+      setComposerTrigger(detectComposerTrigger(nextPrompt, nextPrompt.length));
+      setComposerHighlightedItemId(null);
+      window.requestAnimationFrame(() => {
+        composerEditorRef.current?.focusAt(nextCursor);
+      });
+    },
+    [
+      promptRef,
+      setComposerCursor,
+      setComposerTrigger,
+      composerEditorRef,
+      setComposerHighlightedItemId,
+      setPrompt,
+      setRestoredQueuedSourceProposedPlan,
+      threadId,
+    ],
+  );
+
+  const clearComposerSlashDraft = useCallback(() => {
+    promptRef.current = "";
+    setRestoredQueuedSourceProposedPlan(threadId, null);
+    clearComposerDraftContent(threadId);
+    setComposerHighlightedItemId(null);
+    setComposerCursor(0);
+    setComposerTrigger(null);
+    scheduleComposerFocus();
+  }, [
+    promptRef,
+    setComposerCursor,
+    setComposerTrigger,
+    setComposerHighlightedItemId,
+    clearComposerDraftContent,
+    scheduleComposerFocus,
+    setRestoredQueuedSourceProposedPlan,
+    threadId,
+  ]);
+  return {
+    applyPromptReplacement,
+    resolveActiveComposerTrigger,
+    applyComposerTriggerReplacement,
+    handleSelectLocalDirectoryMention,
+    handleNavigateLocalFolder,
+    setComposerPromptValue,
+    clearComposerSlashDraft,
+  };
+}

--- a/apps/web/src/components/chat/useChatKeyboardShortcuts.ts
+++ b/apps/web/src/components/chat/useChatKeyboardShortcuts.ts
@@ -1,0 +1,508 @@
+import {
+  ThreadId,
+  type ModelSlug,
+  type ProviderKind,
+  type ResolvedKeybindingsConfig,
+} from "@synara/contracts";
+import type { Dispatch, RefObject, SetStateAction } from "react";
+import { useEffect } from "react";
+import { readFavoriteModelSlugs } from "~/lib/modelFavorites";
+import { isMacNavigatorPlatform } from "~/lib/utils";
+import { projectScriptIdFromCommand } from "~/projectScripts";
+import { isElectron } from "../../env";
+import { resolveShortcutCommand } from "../../keybindings";
+import { isEditableEventTarget } from "../../lib/editableEventTarget";
+import { isTerminalFocused } from "../../lib/terminalFocus";
+import type { Project } from "../../types";
+import { type Thread } from "../../types";
+import { resolveCycledModelSlug } from "../ChatView.logic";
+import { collectForegroundRunningSubagentStripItems } from "./ComposerSubagentStrip.logic";
+import { eventTargetsInAppBrowser, shouldCaptureChatFindShortcut } from "./threadFind.logic";
+import { useChatProjectScripts } from "./useChatProjectScripts";
+import { useChatProviderModels } from "./useChatProviderModels";
+import { useChatTerminalController } from "./useChatTerminalController";
+import { useChatWorkLog } from "./useChatWorkLog";
+import { useComposerVoiceController } from "./useComposerVoiceController";
+import { toastManager } from "../ui/toast";
+function eventTargetsComposer(
+  event: globalThis.KeyboardEvent,
+  composerForm: HTMLFormElement | null,
+): boolean {
+  if (!composerForm) return false;
+  const target = event.target;
+  return target instanceof Node ? composerForm.contains(target) : false;
+}
+
+function canHandleComposerPickerShortcut(
+  event: globalThis.KeyboardEvent,
+  composerForm: HTMLFormElement | null,
+): boolean {
+  if (!composerForm) return false;
+  if (eventTargetsComposer(event, composerForm)) return true;
+  const target = event.target;
+  return (
+    target === document.body ||
+    target === document.documentElement ||
+    document.activeElement === document.body ||
+    document.activeElement === document.documentElement
+  );
+}
+interface ChatKeyboardShortcutsInput {
+  onToggleDevicePanel: (() => void) | undefined;
+  onSplitSurface: (() => void) | undefined;
+  surfaceMode: "single" | "split";
+  isFocusedPane: boolean;
+  activeThreadId: ThreadId | null;
+  hasLiveTurn: boolean;
+  composerFormRef: RefObject<HTMLFormElement | null>;
+  onInterruptFromStopControl: () => void;
+  composerSubagentStripItems: ReturnType<typeof useChatWorkLog>["composerSubagentStripItems"];
+  onBackgroundAllForegroundSubagentStripItems: () => Promise<void>;
+  isVoiceRecording: ReturnType<typeof useComposerVoiceController>["isVoiceRecording"];
+  isVoiceTranscribing: ReturnType<typeof useComposerVoiceController>["isVoiceTranscribing"];
+  isComposerApprovalState: boolean;
+  terminalState: ReturnType<typeof useChatTerminalController>["terminalState"];
+  terminalWorkspaceOpen: ReturnType<typeof useChatTerminalController>["terminalWorkspaceOpen"];
+  terminalWorkspaceTerminalTabActive: ReturnType<
+    typeof useChatTerminalController
+  >["terminalWorkspaceTerminalTabActive"];
+  terminalWorkspaceChatTabActive: ReturnType<
+    typeof useChatTerminalController
+  >["terminalWorkspaceChatTabActive"];
+  keybindings: ResolvedKeybindingsConfig;
+  toggleComposerFocus: () => void;
+  shouldRenderChatPaneContent: boolean;
+  setThreadFindOpen: Dispatch<SetStateAction<boolean>>;
+  setThreadFindFocusNonce: Dispatch<SetStateAction<number>>;
+  handleModelPickerOpenChange: (open: boolean) => void;
+  scheduleComposerFocus: () => void;
+  modelOptionsByProvider: ReturnType<typeof useChatProviderModels>["modelOptionsByProvider"];
+  selectedProvider: ProviderKind;
+  selectedModel: string;
+  onProviderModelSelect: (provider: ProviderKind, model: ModelSlug) => Promise<void>;
+  handleTraitsPickerOpenChange: (open: boolean) => void;
+  toggleTerminalVisibility: ReturnType<
+    typeof useChatTerminalController
+  >["toggleTerminalVisibility"];
+  setTerminalOpen: ReturnType<typeof useChatTerminalController>["setTerminalOpen"];
+  splitTerminalRight: ReturnType<typeof useChatTerminalController>["splitTerminalRight"];
+  splitTerminalLeft: ReturnType<typeof useChatTerminalController>["splitTerminalLeft"];
+  splitTerminalDown: ReturnType<typeof useChatTerminalController>["splitTerminalDown"];
+  splitTerminalUp: ReturnType<typeof useChatTerminalController>["splitTerminalUp"];
+  closeTerminal: ReturnType<typeof useChatTerminalController>["closeTerminal"];
+  createTerminalFromShortcut: ReturnType<
+    typeof useChatTerminalController
+  >["createTerminalFromShortcut"];
+  openNewFullWidthTerminal: ReturnType<
+    typeof useChatTerminalController
+  >["openNewFullWidthTerminal"];
+  closeActiveWorkspaceView: ReturnType<
+    typeof useChatTerminalController
+  >["closeActiveWorkspaceView"];
+  setTerminalWorkspaceTab: ReturnType<typeof useChatTerminalController>["setTerminalWorkspaceTab"];
+  onToggleDiff: () => void;
+  commitAndPushTriggerRef: RefObject<(() => void) | null>;
+  showGitActions: boolean;
+  isGitRepo: boolean;
+  onToggleBrowser: () => void;
+  copyThreadIdToClipboard: (threadId: string) => void;
+  activeProject: Project | undefined;
+  runProjectScript: ReturnType<typeof useChatProjectScripts>["runProjectScript"];
+  activeThread: Thread | undefined;
+}
+
+export function useChatKeyboardShortcuts({
+  onToggleDevicePanel,
+  onSplitSurface,
+  surfaceMode,
+  isFocusedPane,
+  activeThreadId,
+  hasLiveTurn,
+  composerFormRef,
+  onInterruptFromStopControl,
+  composerSubagentStripItems,
+  onBackgroundAllForegroundSubagentStripItems,
+  isVoiceRecording,
+  isVoiceTranscribing,
+  isComposerApprovalState,
+  terminalState,
+  terminalWorkspaceOpen,
+  terminalWorkspaceTerminalTabActive,
+  terminalWorkspaceChatTabActive,
+  keybindings,
+  toggleComposerFocus,
+  shouldRenderChatPaneContent,
+  setThreadFindOpen,
+  setThreadFindFocusNonce,
+  handleModelPickerOpenChange,
+  scheduleComposerFocus,
+  modelOptionsByProvider,
+  selectedProvider,
+  selectedModel,
+  onProviderModelSelect,
+  handleTraitsPickerOpenChange,
+  toggleTerminalVisibility,
+  setTerminalOpen,
+  splitTerminalRight,
+  splitTerminalLeft,
+  splitTerminalDown,
+  splitTerminalUp,
+  closeTerminal,
+  createTerminalFromShortcut,
+  openNewFullWidthTerminal,
+  closeActiveWorkspaceView,
+  setTerminalWorkspaceTab,
+  onToggleDiff,
+  commitAndPushTriggerRef,
+  showGitActions,
+  isGitRepo,
+  onToggleBrowser,
+  copyThreadIdToClipboard,
+  activeProject,
+  runProjectScript,
+  activeThread,
+}: ChatKeyboardShortcutsInput) {
+  useEffect(() => {
+    if (surfaceMode === "split" && !isFocusedPane) {
+      return;
+    }
+
+    const handler = (event: globalThis.KeyboardEvent) => {
+      if (!activeThreadId || event.defaultPrevented) return;
+      // Mirror terminal interrupt semantics without stealing regular copy shortcuts.
+      if (
+        hasLiveTurn &&
+        isMacNavigatorPlatform() &&
+        event.ctrlKey &&
+        !event.metaKey &&
+        !event.altKey &&
+        !event.shiftKey &&
+        event.key.toLowerCase() === "c" &&
+        eventTargetsComposer(event, composerFormRef.current)
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        onInterruptFromStopControl();
+        return;
+      }
+      // Ctrl+B mirrors the native CLI: background all foreground running
+      // subagents. Literal Ctrl on every platform, but stays out of the
+      // terminal, where Ctrl+B is real shell input (readline cursor-back,
+      // tmux prefix), and out of text-editing surfaces, where Ctrl+B is the
+      // native macOS "move cursor back" binding. Silent no-op (event
+      // untouched) when nothing qualifies.
+      if (
+        event.ctrlKey &&
+        !event.metaKey &&
+        !event.altKey &&
+        !event.shiftKey &&
+        event.key.toLowerCase() === "b" &&
+        !isTerminalFocused() &&
+        !isEditableEventTarget(event) &&
+        collectForegroundRunningSubagentStripItems(composerSubagentStripItems).length > 0
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        void onBackgroundAllForegroundSubagentStripItems();
+        return;
+      }
+      const composerPickerShortcutActive =
+        !isTerminalFocused() &&
+        !isVoiceRecording &&
+        !isVoiceTranscribing &&
+        !isComposerApprovalState &&
+        canHandleComposerPickerShortcut(event, composerFormRef.current);
+      const shortcutContext = {
+        terminalFocus: isTerminalFocused(),
+        terminalOpen: Boolean(terminalState.terminalOpen),
+        terminalWorkspaceOpen,
+        terminalWorkspaceTerminalOnly: terminalState.workspaceLayout === "terminal-only",
+        terminalWorkspaceTerminalTabActive,
+        terminalWorkspaceChatTabActive,
+      };
+
+      const command = resolveShortcutCommand(event, keybindings, {
+        context: shortcutContext,
+      });
+      if (!command) return;
+
+      if (command === "composer.focus.toggle") {
+        if (isComposerApprovalState || isVoiceRecording || isVoiceTranscribing) return;
+        event.preventDefault();
+        event.stopPropagation();
+        toggleComposerFocus();
+        return;
+      }
+
+      if (command === "chat.find") {
+        if (
+          !shouldCaptureChatFindShortcut({
+            shouldRenderChatPaneContent,
+            terminalWorkspaceTerminalTabActive,
+            inAppBrowserFocused: eventTargetsInAppBrowser(event.target),
+          })
+        ) {
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        setThreadFindOpen(true);
+        setThreadFindFocusNonce((current) => current + 1);
+        return;
+      }
+
+      if (command === "modelPicker.toggle") {
+        if (!composerPickerShortcutActive) return;
+        event.preventDefault();
+        event.stopPropagation();
+        handleModelPickerOpenChange(true);
+        scheduleComposerFocus();
+        return;
+      }
+
+      if (command === "model.next" || command === "model.previous") {
+        if (!composerPickerShortcutActive) return;
+        event.preventDefault();
+        event.stopPropagation();
+        const direction = command === "model.next" ? "next" : "previous";
+        const providerOptions = modelOptionsByProvider[selectedProvider] ?? [];
+        const nextSlug = resolveCycledModelSlug({
+          currentModel: selectedModel,
+          options: providerOptions,
+          favoriteSlugs: readFavoriteModelSlugs(selectedProvider),
+          direction,
+        });
+        if (!nextSlug) return;
+        onProviderModelSelect(selectedProvider, nextSlug as ModelSlug);
+        return;
+      }
+
+      if (command === "traitsPicker.toggle") {
+        if (!composerPickerShortcutActive) return;
+        event.preventDefault();
+        event.stopPropagation();
+        handleTraitsPickerOpenChange(true);
+        scheduleComposerFocus();
+        return;
+      }
+
+      if (command === "terminal.toggle") {
+        event.preventDefault();
+        event.stopPropagation();
+        toggleTerminalVisibility();
+        return;
+      }
+
+      if (command === "terminal.split" || command === "terminal.splitRight") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!terminalState.terminalOpen) {
+          setTerminalOpen(true);
+        }
+        splitTerminalRight();
+        return;
+      }
+
+      if (command === "terminal.splitLeft") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!terminalState.terminalOpen) {
+          setTerminalOpen(true);
+        }
+        splitTerminalLeft();
+        return;
+      }
+
+      if (command === "terminal.splitDown") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!terminalState.terminalOpen) {
+          setTerminalOpen(true);
+        }
+        splitTerminalDown();
+        return;
+      }
+
+      if (command === "terminal.splitUp") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!terminalState.terminalOpen) {
+          setTerminalOpen(true);
+        }
+        splitTerminalUp();
+        return;
+      }
+
+      if (command === "terminal.close") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!terminalState.terminalOpen) return;
+        closeTerminal(terminalState.activeTerminalId);
+        return;
+      }
+
+      if (command === "terminal.new") {
+        event.preventDefault();
+        event.stopPropagation();
+        createTerminalFromShortcut();
+        return;
+      }
+
+      if (command === "terminal.workspace.newFullWidth") {
+        event.preventDefault();
+        event.stopPropagation();
+        openNewFullWidthTerminal();
+        return;
+      }
+
+      if (command === "terminal.workspace.closeActive") {
+        event.preventDefault();
+        event.stopPropagation();
+        closeActiveWorkspaceView();
+        return;
+      }
+
+      if (command === "terminal.workspace.terminal") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!terminalWorkspaceOpen) return;
+        setTerminalWorkspaceTab("terminal");
+        return;
+      }
+
+      if (command === "terminal.workspace.chat") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!terminalWorkspaceOpen) return;
+        setTerminalWorkspaceTab("chat");
+        return;
+      }
+
+      if (command === "diff.toggle") {
+        event.preventDefault();
+        event.stopPropagation();
+        onToggleDiff();
+        return;
+      }
+
+      if (command === "git.commitAndPush") {
+        if (commitAndPushTriggerRef.current) {
+          event.preventDefault();
+          event.stopPropagation();
+          commitAndPushTriggerRef.current();
+          return;
+        }
+        // No registered trigger inside a git-enabled thread means the action just
+        // isn't runnable right now (clean tree, behind upstream, action in flight)
+        // — tell the user instead of eating the chord silently. Outside git threads
+        // the chord falls through untouched.
+        if (showGitActions && isGitRepo) {
+          event.preventDefault();
+          event.stopPropagation();
+          toastManager.add({
+            type: "info",
+            title: "Nothing to commit or push.",
+          });
+        }
+        return;
+      }
+
+      if (command === "browser.toggle") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!isElectron) return;
+        onToggleBrowser();
+        return;
+      }
+
+      if (command === "device.toggle") {
+        event.preventDefault();
+        event.stopPropagation();
+        // Unlike the browser this works in a plain tab, but only against a macOS
+        // server; the surface leaves the handler unwired when it cannot host one.
+        onToggleDevicePanel?.();
+        return;
+      }
+
+      if (command === "chat.split") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (surfaceMode === "single" && onSplitSurface) {
+          onSplitSurface();
+        }
+        return;
+      }
+
+      // The handler already bailed out when no thread is open, so the active thread id
+      // is always the one the user is looking at (the focused pane when split).
+      if (command === "thread.copyId") {
+        event.preventDefault();
+        event.stopPropagation();
+        copyThreadIdToClipboard(activeThreadId);
+        return;
+      }
+
+      const scriptId = projectScriptIdFromCommand(command);
+      if (!scriptId || !activeProject) return;
+      const script = activeProject.scripts.find((entry) => entry.id === scriptId);
+      if (!script) return;
+      event.preventDefault();
+      event.stopPropagation();
+      void runProjectScript(script);
+    };
+    window.addEventListener("keydown", handler, { capture: true });
+    return () => window.removeEventListener("keydown", handler, { capture: true });
+  }, [
+    composerFormRef,
+    setThreadFindOpen,
+    setThreadFindFocusNonce,
+    commitAndPushTriggerRef,
+    activeProject,
+    terminalState.terminalOpen,
+    terminalState.activeTerminalId,
+    terminalState.workspaceLayout,
+    activeThreadId,
+    closeTerminal,
+    closeActiveWorkspaceView,
+    createTerminalFromShortcut,
+    setTerminalOpen,
+    openNewFullWidthTerminal,
+    runProjectScript,
+    keybindings,
+    splitTerminalDown,
+    splitTerminalLeft,
+    splitTerminalRight,
+    splitTerminalUp,
+    terminalWorkspaceChatTabActive,
+    terminalWorkspaceOpen,
+    terminalWorkspaceTerminalTabActive,
+    onToggleBrowser,
+    onToggleDevicePanel,
+    onToggleDiff,
+    onInterruptFromStopControl,
+    onSplitSurface,
+    showGitActions,
+    isGitRepo,
+    composerSubagentStripItems,
+    onBackgroundAllForegroundSubagentStripItems,
+    isFocusedPane,
+    hasLiveTurn,
+    handleModelPickerOpenChange,
+    handleTraitsPickerOpenChange,
+    shouldRenderChatPaneContent,
+    isComposerApprovalState,
+    isVoiceRecording,
+    isVoiceTranscribing,
+    setTerminalWorkspaceTab,
+    surfaceMode,
+    scheduleComposerFocus,
+    toggleComposerFocus,
+    toggleTerminalVisibility,
+    activeThread,
+    selectedProvider,
+    selectedModel,
+    modelOptionsByProvider,
+    onProviderModelSelect,
+    copyThreadIdToClipboard,
+  ]);
+}

--- a/apps/web/src/components/chat/useChatLocalDispatch.ts
+++ b/apps/web/src/components/chat/useChatLocalDispatch.ts
@@ -1,0 +1,292 @@
+import { ThreadId } from "@synara/contracts";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { markPendingTurnDispatch } from "../../pendingTurnDispatch";
+import { derivePhase } from "../../session-logic";
+import { type ChatMessage, type Thread, type WorktreeSetupResolutionAction } from "../../types";
+import {
+  LOCAL_DISPATCH_ACK_TIMEOUT_MS,
+  LOCAL_DISPATCH_TURN_TAKEOVER_TIMEOUT_MS,
+  WORKTREE_SETUP_ERROR_HOLD_MS,
+  failWorktreeSetupSnapshot,
+  hasLiveTurnTakenOver,
+  hasServerAcknowledgedLocalDispatch,
+  resolveNextLocalDispatchSnapshot,
+  worktreeSetupHasError,
+  type LocalDispatchSnapshot,
+  type WorktreeSetupDispatchOptions,
+  type WorktreeSetupResolution,
+} from "../ChatView.logic";
+import { useChatPendingInteractions } from "./useChatPendingInteractions";
+const EMPTY_MESSAGES: ChatMessage[] = [];
+interface ChatLocalDispatchInput {
+  phase: ReturnType<typeof derivePhase>;
+  activeLatestTurn: Thread["latestTurn"];
+  activeThread: Thread | undefined;
+  activePendingApproval: ReturnType<typeof useChatPendingInteractions>["activePendingApproval"];
+  activePendingUserInput: ReturnType<typeof useChatPendingInteractions>["activePendingUserInput"];
+}
+
+export function useChatLocalDispatch({
+  phase,
+  activeLatestTurn,
+  activeThread,
+  activePendingApproval,
+  activePendingUserInput,
+}: ChatLocalDispatchInput) {
+  const [localDispatch, setLocalDispatch] = useState<LocalDispatchSnapshot | null>(null);
+  const failedWorktreeSetupDispatchStartedAtRef = useRef<string | null>(null);
+  // Live handle to the in-flight send's worktree preparation, resolved by the
+  // setup card's Cancel / Work locally buttons. One send at a time can prepare
+  // a worktree (the composer is send-busy while it runs), so a single ref is safe.
+  const worktreeSetupResolutionRef = useRef<WorktreeSetupResolution | null>(null);
+  const [worktreeSetupPendingAction, setWorktreeSetupPendingAction] =
+    useState<WorktreeSetupResolutionAction | null>(null);
+
+  const serverAcknowledgedLocalDispatch = useMemo(
+    () =>
+      hasServerAcknowledgedLocalDispatch({
+        localDispatch,
+        phase,
+        latestTurn: activeLatestTurn,
+        session: activeThread?.session ?? null,
+        messages: activeThread?.messages ?? EMPTY_MESSAGES,
+        hasPendingApproval: activePendingApproval !== null,
+        hasPendingUserInput: activePendingUserInput !== null,
+        threadError: activeThread?.error,
+      }),
+    [
+      activeLatestTurn,
+      activePendingApproval,
+      activePendingUserInput,
+      activeThread?.error,
+      activeThread?.messages,
+      activeThread?.session,
+      localDispatch,
+      phase,
+    ],
+  );
+  const turnTakenOver = useMemo(
+    () =>
+      hasLiveTurnTakenOver({
+        localDispatch,
+        phase,
+        latestTurn: activeLatestTurn,
+        session: activeThread?.session ?? null,
+        hasPendingApproval: activePendingApproval !== null,
+        hasPendingUserInput: activePendingUserInput !== null,
+        threadError: activeThread?.error,
+        now: Date.now(),
+      }),
+    [
+      activeLatestTurn,
+      activePendingApproval,
+      activePendingUserInput,
+      activeThread?.error,
+      activeThread?.session,
+      localDispatch,
+      phase,
+    ],
+  );
+  const isSendBusy = localDispatch !== null && !serverAcknowledgedLocalDispatch;
+  const isAwaitingTurnStart = localDispatch !== null && !turnTakenOver;
+  const activeWorktreeSetup = localDispatch?.worktreeSetup ?? null;
+  const isPreparingWorktree = activeWorktreeSetup !== null;
+
+  const beginLocalDispatch = useCallback(
+    (options?: WorktreeSetupDispatchOptions) => {
+      setLocalDispatch((current) => {
+        const next = resolveNextLocalDispatchSnapshot(
+          options ? { current, activeThread, options } : { current, activeThread },
+        );
+        if (next !== current) {
+          failedWorktreeSetupDispatchStartedAtRef.current = null;
+        }
+        return next;
+      });
+    },
+    [activeThread],
+  );
+
+  const failLocalDispatchWorktreeSetup = useCallback(() => {
+    setLocalDispatch((current) => {
+      if (!current?.worktreeSetup) {
+        return current;
+      }
+      const failed = failWorktreeSetupSnapshot(current.worktreeSetup);
+      failedWorktreeSetupDispatchStartedAtRef.current = current.startedAt;
+      return failed === current.worktreeSetup ? current : { ...current, worktreeSetup: failed };
+    });
+  }, []);
+
+  const resetLocalDispatch = useCallback(() => {
+    failedWorktreeSetupDispatchStartedAtRef.current = null;
+    setLocalDispatch(null);
+  }, []);
+
+  // Clears only the setup stepper from the dispatch marker: after "Work
+  // locally" the send continues (composer stays busy, Thinking shimmer takes
+  // over) but the worktree card animates out.
+  const clearLocalDispatchWorktreeSetup = useCallback(() => {
+    setLocalDispatch((current) =>
+      current?.worktreeSetup ? { ...current, worktreeSetup: null } : current,
+    );
+  }, []);
+
+  const onResolveWorktreeSetup = useCallback((action: WorktreeSetupResolutionAction) => {
+    const resolution = worktreeSetupResolutionRef.current;
+    if (!resolution || resolution.action !== null) {
+      return;
+    }
+    resolution.resolve(action);
+    setWorktreeSetupPendingAction(action);
+  }, []);
+
+  // The dispatch marker normally clears when the thread stream echoes the sent
+  // turn. Once the turn RPC has resolved the server owns the turn, so a stream
+  // that never echoes (dead subscription, lost event) must not lock the
+  // composer forever: this fallback force-clears the marker after a bound. The
+  // startedAt match keeps a stale timer from clearing a newer dispatch, and an
+  // already-acknowledged dispatch is left alone — the send spinner has
+  // released, and the awaiting-turn bridge legitimately keeps `localDispatch`
+  // alive until takeover or its own fail-open bound.
+  const localDispatchStartedAtRef = useRef<string | null>(null);
+  useEffect(() => {
+    localDispatchStartedAtRef.current = localDispatch?.startedAt ?? null;
+  }, [localDispatch]);
+  const serverAcknowledgedLocalDispatchRef = useRef(serverAcknowledgedLocalDispatch);
+  useEffect(() => {
+    serverAcknowledgedLocalDispatchRef.current = serverAcknowledgedLocalDispatch;
+  }, [serverAcknowledgedLocalDispatch]);
+  const localDispatchAckFallbackTimeoutRef = useRef<number | null>(null);
+  const armLocalDispatchAckFallback = useCallback((threadIdForSend: ThreadId) => {
+    // The turn RPC has resolved, so the server provably owns a turn. Re-arm
+    // the cross-component watchdog marker here: pre-dispatch work (worktree
+    // creation, attachment uploads) can outlive the marker's age cap, and this
+    // is the moment its clock should restart.
+    markPendingTurnDispatch(threadIdForSend);
+    const armedStartedAt = localDispatchStartedAtRef.current;
+    if (armedStartedAt === null) {
+      return;
+    }
+    if (localDispatchAckFallbackTimeoutRef.current !== null) {
+      window.clearTimeout(localDispatchAckFallbackTimeoutRef.current);
+    }
+    localDispatchAckFallbackTimeoutRef.current = window.setTimeout(() => {
+      localDispatchAckFallbackTimeoutRef.current = null;
+      if (serverAcknowledgedLocalDispatchRef.current) {
+        return;
+      }
+      setLocalDispatch((current) =>
+        current &&
+        current.startedAt === armedStartedAt &&
+        !worktreeSetupHasError(current.worktreeSetup)
+          ? null
+          : current,
+      );
+    }, LOCAL_DISPATCH_ACK_TIMEOUT_MS);
+  }, []);
+  useEffect(
+    () => () => {
+      if (localDispatchAckFallbackTimeoutRef.current !== null) {
+        window.clearTimeout(localDispatchAckFallbackTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  // Fallback cleanup for a failed worktree setup: clears the dispatch after the
+  // error hold unless a newer dispatch already replaced it.
+  const scheduleFailedWorktreeSetupDispatchReset = useCallback(() => {
+    const failedDispatchStartedAt = failedWorktreeSetupDispatchStartedAtRef.current;
+    window.setTimeout(() => {
+      setLocalDispatch((current) => {
+        if (
+          !failedDispatchStartedAt ||
+          !current ||
+          current.startedAt !== failedDispatchStartedAt ||
+          !worktreeSetupHasError(current.worktreeSetup)
+        ) {
+          return current;
+        }
+        failedWorktreeSetupDispatchStartedAtRef.current = null;
+        return null;
+      });
+    }, WORKTREE_SETUP_ERROR_HOLD_MS);
+  }, []);
+
+  const localDispatchWorktreeSetupFailed = worktreeSetupHasError(activeWorktreeSetup);
+  useEffect(() => {
+    if (!turnTakenOver) {
+      return;
+    }
+    // A failed worktree setup would otherwise reset in the same commit that
+    // painted the error (thread errors count as takeover), so hold the
+    // row briefly before letting it animate out.
+    if (localDispatchWorktreeSetupFailed) {
+      const failedDispatchStartedAt = localDispatch?.startedAt;
+      if (!failedDispatchStartedAt) {
+        return;
+      }
+      const holdTimeout = window.setTimeout(() => {
+        setLocalDispatch((current) => {
+          if (
+            !current ||
+            current.startedAt !== failedDispatchStartedAt ||
+            !worktreeSetupHasError(current.worktreeSetup)
+          ) {
+            return current;
+          }
+          failedWorktreeSetupDispatchStartedAtRef.current = null;
+          return null;
+        });
+      }, WORKTREE_SETUP_ERROR_HOLD_MS);
+      return () => window.clearTimeout(holdTimeout);
+    }
+    resetLocalDispatch();
+  }, [
+    localDispatch?.startedAt,
+    localDispatchWorktreeSetupFailed,
+    resetLocalDispatch,
+    turnTakenOver,
+  ]);
+
+  // Fail-open: if takeover never arrives, clear the awaiting-turn bridge so
+  // Thinking cannot stick forever. Skipped while worktree setup is active.
+  useEffect(() => {
+    if (!localDispatch || turnTakenOver || localDispatch.worktreeSetup) {
+      return;
+    }
+    const startedAtMs = Date.parse(localDispatch.startedAt);
+    if (!Number.isFinite(startedAtMs)) {
+      return;
+    }
+    const remainingMs = LOCAL_DISPATCH_TURN_TAKEOVER_TIMEOUT_MS - (Date.now() - startedAtMs);
+    if (remainingMs <= 0) {
+      resetLocalDispatch();
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      resetLocalDispatch();
+    }, remainingMs);
+    return () => window.clearTimeout(timer);
+  }, [localDispatch, resetLocalDispatch, turnTakenOver]);
+  return {
+    localDispatch,
+    setLocalDispatch,
+    worktreeSetupResolutionRef,
+    worktreeSetupPendingAction,
+    setWorktreeSetupPendingAction,
+    turnTakenOver,
+    isSendBusy,
+    isAwaitingTurnStart,
+    activeWorktreeSetup,
+    isPreparingWorktree,
+    beginLocalDispatch,
+    failLocalDispatchWorktreeSetup,
+    resetLocalDispatch,
+    clearLocalDispatchWorktreeSetup,
+    onResolveWorktreeSetup,
+    armLocalDispatchAckFallback,
+    scheduleFailedWorktreeSetupDispatchReset,
+  };
+}

--- a/apps/web/src/components/chat/useChatPendingInteractions.ts
+++ b/apps/web/src/components/chat/useChatPendingInteractions.ts
@@ -1,0 +1,574 @@
+import {
+  RuntimeMode,
+  ThreadId,
+  type ApprovalRequestId,
+  type ProviderApprovalDecision,
+  type ProviderRequestKind,
+  type ProviderUserInputAnswers,
+} from "@synara/contracts";
+import {
+  APPROVAL_ALREADY_ANSWERED_INVARIANT_MARKER,
+  collectErrorMessages,
+  describeErrorMessage,
+} from "@synara/shared/errorMessages";
+import { respondingInteractionReclaimAt } from "@synara/shared/pendingInteractions";
+import { pendingRequestInstanceKey } from "@synara/shared/threadSummary";
+import type { Dispatch, RefObject, SetStateAction } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { newCommandId } from "~/lib/utils";
+import { readNativeApi } from "~/nativeApi";
+import {
+  collapseExpandedComposerCursor,
+  detectComposerTrigger,
+  expandCollapsedComposerCursor,
+  type ComposerTrigger,
+} from "../../composer-logic";
+import { useComposerDraftStore } from "../../composerDraftStore";
+import {
+  buildPendingUserInputAnswers,
+  derivePendingUserInputProgress,
+  hasCompletePendingUserInputAnswers,
+  omitNullPendingUserInputAnswers,
+  setPendingUserInputCustomAnswer,
+  togglePendingUserInputOptionSelection,
+  type PendingUserInputDraftAnswer,
+} from "../../pendingUserInput";
+import { expiredUserInputDrafts } from "../../pendingUserInputRecovery";
+import { derivePendingApprovals, derivePendingUserInputs } from "../../session-logic";
+import { useStore } from "../../store";
+import {
+  buildThreadSubscribeInput,
+  clearThreadDetailResumeCursor,
+} from "../../threadDetailResumeCursors";
+import { type Thread } from "../../types";
+import { resolveRuntimeModeAfterApprovalDecision } from "../ChatView.logic";
+import { usePendingUserInputDrafts } from "./usePendingUserInputDrafts";
+const EMPTY_ACTIVITIES: Thread["activities"] = [];
+const EMPTY_PENDING_USER_INPUT_ANSWERS: Record<string, PendingUserInputDraftAnswer> = {};
+interface ChatPendingInteractionsInput {
+  threadId: ThreadId;
+  activeThread: Thread | undefined;
+  runtimeMode: RuntimeMode;
+  promptRef: RefObject<string>;
+  setPrompt: (prompt: string) => void;
+  setComposerCursor: Dispatch<SetStateAction<number>>;
+  setComposerTrigger: Dispatch<SetStateAction<ComposerTrigger | null>>;
+  setComposerHighlightedItemId: Dispatch<SetStateAction<string | null>>;
+}
+
+export function useChatPendingInteractions({
+  threadId,
+  activeThread,
+  runtimeMode,
+  promptRef,
+  setPrompt,
+  setComposerCursor,
+  setComposerTrigger,
+  setComposerHighlightedItemId,
+}: ChatPendingInteractionsInput) {
+  const activeThreadId = activeThread?.id ?? null;
+  const threadActivities = activeThread?.activities ?? EMPTY_ACTIVITIES;
+  const setStoreThreadError = useStore((store) => store.setError);
+  const setComposerDraftRuntimeMode = useComposerDraftStore((state) => state.setRuntimeMode);
+  const [respondingRequestKeys, setRespondingRequestKeys] = useState<string[]>([]);
+  const [respondingUserInputRequestKeys, setRespondingUserInputRequestKeys] = useState<string[]>(
+    [],
+  );
+  const [pendingUserInputQuestionIndexByRequestId, setPendingUserInputQuestionIndexByRequestId] =
+    useState<Record<string, number>>({});
+
+  const pendingApprovals = useMemo(
+    () =>
+      derivePendingApprovals(threadActivities, activeThread?.pendingInteractions, {
+        authoritativeHasPending: activeThread?.hasPendingApprovals,
+        latestTurnId: activeThread?.latestTurn?.turnId,
+      }),
+    [
+      activeThread?.hasPendingApprovals,
+      activeThread?.latestTurn?.turnId,
+      activeThread?.pendingInteractions,
+      threadActivities,
+    ],
+  );
+  const nextUserInputResponseReclaimAt = useMemo(() => {
+    let earliest: string | null = null;
+    for (const interaction of activeThread?.pendingInteractions ?? []) {
+      if (interaction.interactionKind !== "userInput" || interaction.status !== "responding") {
+        continue;
+      }
+      if (interaction.responseRequestedAt === null) {
+        return new Date(0).toISOString();
+      }
+      const reclaimAt = respondingInteractionReclaimAt(interaction.responseRequestedAt);
+      if (earliest === null || reclaimAt < earliest) {
+        earliest = reclaimAt;
+      }
+    }
+    return earliest;
+  }, [activeThread?.pendingInteractions]);
+  const [userInputResponseClaimReferenceAt, setUserInputResponseClaimReferenceAt] = useState(() =>
+    new Date().toISOString(),
+  );
+  useEffect(() => {
+    if (nextUserInputResponseReclaimAt === null) {
+      return;
+    }
+    const delayMs = Math.max(0, Date.parse(nextUserInputResponseReclaimAt) - Date.now());
+    const timeoutId = window.setTimeout(() => {
+      setUserInputResponseClaimReferenceAt(new Date().toISOString());
+    }, delayMs);
+    return () => window.clearTimeout(timeoutId);
+  }, [nextUserInputResponseReclaimAt]);
+  const pendingUserInputs = useMemo(
+    () =>
+      derivePendingUserInputs(threadActivities, activeThread?.pendingInteractions, {
+        authoritativeHasPending: activeThread?.hasPendingUserInput,
+        latestTurnId: activeThread?.latestTurn?.turnId,
+        responseClaimReferenceAt: userInputResponseClaimReferenceAt,
+      }),
+    [
+      activeThread?.hasPendingUserInput,
+      activeThread?.latestTurn?.turnId,
+      activeThread?.pendingInteractions,
+      threadActivities,
+      userInputResponseClaimReferenceAt,
+    ],
+  );
+  const {
+    answers: pendingUserInputAnswersByRequestId,
+    answersRef: pendingUserInputAnswersByRequestIdRef,
+    setAnswers: setPendingUserInputAnswersByRequestId,
+    drafts: pendingUserInputDrafts,
+  } = usePendingUserInputDrafts(threadId, pendingUserInputs, activeThread?.pendingInteractions);
+  const expiredQuestionDrafts = useMemo(
+    () => expiredUserInputDrafts(pendingUserInputDrafts, threadActivities),
+    [pendingUserInputDrafts, threadActivities],
+  );
+  const activePendingUserInput = pendingUserInputs[0] ?? null;
+  const activePendingUserInputKey = activePendingUserInput
+    ? pendingRequestInstanceKey(
+        activePendingUserInput.requestId,
+        activePendingUserInput.lifecycleGeneration,
+      )
+    : null;
+  const activePendingDraftAnswers = useMemo(
+    () =>
+      activePendingUserInputKey
+        ? (pendingUserInputAnswersByRequestId[activePendingUserInputKey] ??
+          EMPTY_PENDING_USER_INPUT_ANSWERS)
+        : EMPTY_PENDING_USER_INPUT_ANSWERS,
+    [activePendingUserInputKey, pendingUserInputAnswersByRequestId],
+  );
+  const activePendingQuestionIndex = activePendingUserInputKey
+    ? (pendingUserInputQuestionIndexByRequestId[activePendingUserInputKey] ?? 0)
+    : 0;
+  const activePendingProgress = useMemo(
+    () =>
+      activePendingUserInput
+        ? derivePendingUserInputProgress(
+            activePendingUserInput.questions,
+            activePendingDraftAnswers,
+            activePendingQuestionIndex,
+          )
+        : null,
+    [activePendingDraftAnswers, activePendingQuestionIndex, activePendingUserInput],
+  );
+  // Read once here for the same reason as `activeLatestTurnId`: an `activePendingProgress?.x`
+  // read inside a memo body makes React Compiler infer `activePendingProgress` as the
+  // dependency, which no longer matches the hand-written property-path dep.
+  const activePendingQuestion = activePendingProgress?.activeQuestion ?? null;
+  const activePendingResolvedAnswers = useMemo(
+    () =>
+      activePendingUserInput
+        ? buildPendingUserInputAnswers(activePendingUserInput.questions, activePendingDraftAnswers)
+        : null,
+    [activePendingDraftAnswers, activePendingUserInput],
+  );
+  const activePendingIsResponding = activePendingUserInputKey
+    ? respondingUserInputRequestKeys.includes(activePendingUserInputKey)
+    : false;
+
+  const activePendingApproval = pendingApprovals[0] ?? null;
+
+  const lastSyncedPendingInputRef = useRef<{
+    requestId: string | null;
+    questionId: string | null;
+  } | null>(null);
+
+  useEffect(() => {
+    const nextCustomAnswer = activePendingProgress?.customAnswer;
+    if (typeof nextCustomAnswer !== "string") {
+      lastSyncedPendingInputRef.current = null;
+      return;
+    }
+    const nextRequestId = activePendingUserInput?.requestId ?? null;
+    const nextQuestionId = activePendingProgress?.activeQuestion?.id ?? null;
+    const questionChanged =
+      lastSyncedPendingInputRef.current?.requestId !== nextRequestId ||
+      lastSyncedPendingInputRef.current?.questionId !== nextQuestionId;
+    const textChangedExternally = promptRef.current !== nextCustomAnswer;
+
+    lastSyncedPendingInputRef.current = {
+      requestId: nextRequestId,
+      questionId: nextQuestionId,
+    };
+
+    if (!questionChanged && !textChangedExternally) {
+      return;
+    }
+
+    promptRef.current = nextCustomAnswer;
+    const nextCursor = collapseExpandedComposerCursor(nextCustomAnswer, nextCustomAnswer.length);
+    setComposerCursor(nextCursor);
+    setComposerTrigger(
+      detectComposerTrigger(
+        nextCustomAnswer,
+        expandCollapsedComposerCursor(nextCustomAnswer, nextCursor),
+      ),
+    );
+    setComposerHighlightedItemId(null);
+  }, [
+    promptRef,
+    setComposerCursor,
+    setComposerTrigger,
+    setComposerHighlightedItemId,
+    activePendingProgress?.customAnswer,
+    activePendingUserInput?.requestId,
+    activePendingProgress?.activeQuestion?.id,
+  ]);
+
+  const onRespondToApproval = useCallback(
+    async (
+      requestId: ApprovalRequestId,
+      decision: ProviderApprovalDecision,
+      lifecycleGeneration?: string,
+      requestKind?: ProviderRequestKind,
+    ) => {
+      const api = readNativeApi();
+      if (!api || !activeThreadId) return;
+      const requestKey = pendingRequestInstanceKey(requestId, lifecycleGeneration);
+
+      setRespondingRequestKeys((existing) =>
+        existing.includes(requestKey) ? existing : [...existing, requestKey],
+      );
+      // Persist supervised "always allow" client-side so the next turn (after an
+      // idle-stop or runtime restart) uses full access. Auto remains the durable
+      // thread policy; its server-side override applies only to the live session.
+      const durableRuntimeMode = resolveRuntimeModeAfterApprovalDecision(
+        runtimeMode,
+        decision,
+        requestKind,
+      );
+      if (durableRuntimeMode) {
+        setComposerDraftRuntimeMode(activeThreadId, durableRuntimeMode);
+      }
+      await api.orchestration
+        .dispatchCommand({
+          type: "thread.approval.respond",
+          commandId: newCommandId(),
+          threadId: activeThreadId,
+          requestId,
+          decision,
+          ...(lifecycleGeneration !== undefined ? { lifecycleGeneration } : {}),
+          createdAt: new Date().toISOString(),
+        })
+        .catch(async (err: unknown) => {
+          if (
+            collectErrorMessages(err).some((message) =>
+              message.includes(APPROVAL_ALREADY_ANSWERED_INVARIANT_MARKER),
+            )
+          ) {
+            // The authoritative response won the race. Force a full detail
+            // snapshot so a stale local card cannot immediately submit again.
+            clearThreadDetailResumeCursor(activeThreadId);
+            await api.orchestration
+              .subscribeThread(buildThreadSubscribeInput(activeThreadId))
+              .catch(() => {
+                setStoreThreadError(
+                  activeThreadId,
+                  "Approval was already recorded, but the conversation could not be refreshed.",
+                );
+              });
+            return;
+          }
+          setStoreThreadError(
+            activeThreadId,
+            describeErrorMessage(err, "Failed to submit approval decision."),
+          );
+          setRespondingRequestKeys((existing) => existing.filter((key) => key !== requestKey));
+          throw err;
+        });
+      setRespondingRequestKeys((existing) => existing.filter((key) => key !== requestKey));
+    },
+    [activeThreadId, runtimeMode, setComposerDraftRuntimeMode, setStoreThreadError],
+  );
+
+  const userInputSubmissionsRef = useRef(new Set<string>());
+  const [userInputSubmissionVersion, setUserInputSubmissionVersion] = useState(0);
+  const onRespondToUserInput = useCallback(
+    async (
+      requestId: ApprovalRequestId,
+      answers: ProviderUserInputAnswers,
+      lifecycleGeneration?: string,
+    ) => {
+      const api = readNativeApi();
+      if (!api || !activeThreadId) return;
+      const requestKey = pendingRequestInstanceKey(requestId, lifecycleGeneration);
+      const submissionKey = `${activeThreadId}:${requestKey}`;
+      if (userInputSubmissionsRef.current.has(submissionKey)) return;
+      userInputSubmissionsRef.current.add(submissionKey);
+      setUserInputSubmissionVersion((version) => version + 1);
+      const dispatchAnswers = hasCompletePendingUserInputAnswers(answers)
+        ? answers
+        : omitNullPendingUserInputAnswers(answers);
+
+      setRespondingUserInputRequestKeys((existing) =>
+        existing.includes(requestKey) ? existing : [...existing, requestKey],
+      );
+      await Promise.resolve()
+        .then(async () => {
+          await api.orchestration.dispatchCommand({
+            type: "thread.user-input.respond",
+            commandId: newCommandId(),
+            threadId: activeThreadId,
+            requestId,
+            answers: dispatchAnswers,
+            ...(lifecycleGeneration !== undefined ? { lifecycleGeneration } : {}),
+            createdAt: new Date().toISOString(),
+          });
+          // Refresh identities and settlement after command acceptance; acceptance
+          // alone does not mean Claude received the answer.
+          clearThreadDetailResumeCursor(activeThreadId);
+          await api.orchestration.subscribeThread(buildThreadSubscribeInput(activeThreadId));
+        })
+        .catch((err: unknown) => {
+          setStoreThreadError(
+            activeThreadId,
+            describeErrorMessage(
+              err,
+              "Could not submit or refresh the answer. Your answers are saved.",
+            ),
+          );
+        })
+        .finally(() => {
+          userInputSubmissionsRef.current.delete(submissionKey);
+          setRespondingUserInputRequestKeys((existing) =>
+            existing.filter((key) => key !== requestKey),
+          );
+        });
+    },
+    [activeThreadId, setStoreThreadError],
+  );
+
+  const onCancelActivePendingUserInput = useCallback(() => {
+    if (!activePendingUserInput || activePendingIsResponding) {
+      return;
+    }
+    promptRef.current = "";
+    setPrompt("");
+    setComposerCursor(0);
+    setComposerTrigger(null);
+    void onRespondToUserInput(
+      activePendingUserInput.requestId,
+      {},
+      activePendingUserInput.lifecycleGeneration,
+    );
+  }, [
+    promptRef,
+    setComposerCursor,
+    setComposerTrigger,
+    activePendingIsResponding,
+    activePendingUserInput,
+    onRespondToUserInput,
+    setPrompt,
+  ]);
+
+  const setActivePendingUserInputQuestionIndex = useCallback(
+    (nextQuestionIndex: number) => {
+      if (!activePendingUserInputKey) {
+        return;
+      }
+      setPendingUserInputQuestionIndexByRequestId((existing) => ({
+        ...existing,
+        [activePendingUserInputKey]: nextQuestionIndex,
+      }));
+    },
+    [activePendingUserInputKey],
+  );
+
+  const onToggleActivePendingUserInputOption = useCallback(
+    (questionId: string, optionLabel: string) => {
+      if (!activePendingUserInput || !activePendingUserInputKey) {
+        return null;
+      }
+      const question = activePendingUserInput.questions.find((entry) => entry.id === questionId);
+      if (!question) {
+        return null;
+      }
+      const nextDraftAnswer = togglePendingUserInputOptionSelection(
+        question,
+        pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey]?.[questionId],
+        optionLabel,
+      );
+      const nextRequestAnswers = {
+        ...pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey],
+        [questionId]: nextDraftAnswer,
+      };
+      pendingUserInputAnswersByRequestIdRef.current = {
+        ...pendingUserInputAnswersByRequestIdRef.current,
+        [activePendingUserInputKey]: nextRequestAnswers,
+      };
+      setPendingUserInputAnswersByRequestId((existing) => ({
+        ...existing,
+        [activePendingUserInputKey]: nextRequestAnswers,
+      }));
+      promptRef.current = "";
+      setComposerCursor(0);
+      setComposerTrigger(null);
+      return nextDraftAnswer;
+    },
+    [
+      promptRef,
+      setComposerCursor,
+      setComposerTrigger,
+      activePendingUserInput,
+      activePendingUserInputKey,
+      pendingUserInputAnswersByRequestIdRef,
+      setPendingUserInputAnswersByRequestId,
+    ],
+  );
+
+  const onChangeActivePendingUserInputCustomAnswer = useCallback(
+    (
+      questionId: string,
+      value: string,
+      nextCursor: number,
+      expandedCursor: number,
+      cursorAdjacentToMention: boolean,
+    ) => {
+      if (!activePendingUserInputKey) {
+        return;
+      }
+      promptRef.current = value;
+      const nextDraftAnswer = setPendingUserInputCustomAnswer(
+        pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey]?.[questionId],
+        value,
+      );
+      const nextRequestAnswers = {
+        ...pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey],
+        [questionId]: nextDraftAnswer,
+      };
+      pendingUserInputAnswersByRequestIdRef.current = {
+        ...pendingUserInputAnswersByRequestIdRef.current,
+        [activePendingUserInputKey]: nextRequestAnswers,
+      };
+      setPendingUserInputAnswersByRequestId((existing) => ({
+        ...existing,
+        [activePendingUserInputKey]: nextRequestAnswers,
+      }));
+      setComposerCursor(nextCursor);
+      setComposerTrigger(
+        cursorAdjacentToMention ? null : detectComposerTrigger(value, expandedCursor),
+      );
+    },
+    [
+      promptRef,
+      setComposerCursor,
+      setComposerTrigger,
+      activePendingUserInputKey,
+      pendingUserInputAnswersByRequestIdRef,
+      setPendingUserInputAnswersByRequestId,
+    ],
+  );
+
+  const onAdvanceActivePendingUserInput = useCallback(
+    (answerOverrides?: Record<string, PendingUserInputDraftAnswer>): boolean => {
+      if (!activePendingUserInput || !activePendingUserInputKey || !activePendingProgress) {
+        return false;
+      }
+      const pendingDraftAnswers =
+        answerOverrides && Object.keys(answerOverrides).length > 0
+          ? {
+              ...pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey],
+              ...answerOverrides,
+            }
+          : (pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey] ??
+            activePendingDraftAnswers);
+      if (answerOverrides && Object.keys(answerOverrides).length > 0) {
+        pendingUserInputAnswersByRequestIdRef.current = {
+          ...pendingUserInputAnswersByRequestIdRef.current,
+          [activePendingUserInputKey]: pendingDraftAnswers,
+        };
+        setPendingUserInputAnswersByRequestId((existing) => ({
+          ...existing,
+          [activePendingUserInputKey]: pendingDraftAnswers,
+        }));
+      }
+      const resolvedAnswers = buildPendingUserInputAnswers(
+        activePendingUserInput.questions,
+        pendingDraftAnswers,
+      );
+      if (activePendingProgress.isLastQuestion) {
+        if (resolvedAnswers) {
+          void onRespondToUserInput(
+            activePendingUserInput.requestId,
+            resolvedAnswers,
+            activePendingUserInput.lifecycleGeneration,
+          );
+          return true;
+        }
+        return false;
+      }
+      const activeQuestionId = activePendingProgress.activeQuestion?.id ?? null;
+      const hasActiveOverride = activeQuestionId
+        ? answerOverrides?.[activeQuestionId] !== undefined
+        : false;
+      if (!activePendingProgress.canAdvance && !hasActiveOverride) {
+        return false;
+      }
+      setActivePendingUserInputQuestionIndex(activePendingProgress.questionIndex + 1);
+      return true;
+    },
+    [
+      activePendingDraftAnswers,
+      activePendingProgress,
+      activePendingUserInput,
+      activePendingUserInputKey,
+      onRespondToUserInput,
+      setActivePendingUserInputQuestionIndex,
+      setPendingUserInputAnswersByRequestId,
+      pendingUserInputAnswersByRequestIdRef,
+    ],
+  );
+
+  const onPreviousActivePendingUserInputQuestion = useCallback(() => {
+    if (!activePendingProgress) {
+      return;
+    }
+    setActivePendingUserInputQuestionIndex(Math.max(activePendingProgress.questionIndex - 1, 0));
+  }, [activePendingProgress, setActivePendingUserInputQuestionIndex]);
+  return {
+    respondingRequestKeys,
+    pendingApprovals,
+    pendingUserInputs,
+    pendingUserInputAnswersByRequestIdRef,
+    setPendingUserInputAnswersByRequestId,
+    expiredQuestionDrafts,
+    activePendingUserInput,
+    activePendingUserInputKey,
+    activePendingDraftAnswers,
+    activePendingQuestionIndex,
+    activePendingProgress,
+    activePendingQuestion,
+    activePendingResolvedAnswers,
+    activePendingIsResponding,
+    activePendingApproval,
+    onRespondToApproval,
+    userInputSubmissionVersion,
+    onCancelActivePendingUserInput,
+    onToggleActivePendingUserInputOption,
+    onChangeActivePendingUserInputCustomAnswer,
+    onAdvanceActivePendingUserInput,
+    onPreviousActivePendingUserInputQuestion,
+  };
+}

--- a/apps/web/src/components/chat/useChatProjectScripts.ts
+++ b/apps/web/src/components/chat/useChatProjectScripts.ts
@@ -1,0 +1,293 @@
+import {
+  ThreadId,
+  type KeybindingCommand,
+  type ProjectId,
+  type ProjectScript,
+} from "@synara/contracts";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { useLocalStorage } from "~/hooks/useLocalStorage";
+import { decodeProjectScriptKeybindingRule } from "~/lib/projectScriptKeybindings";
+import { serverQueryKeys } from "~/lib/serverReactQuery";
+import { newCommandId } from "~/lib/utils";
+import { readNativeApi } from "~/nativeApi";
+import {
+  commandForProjectScript,
+  nextProjectScriptId,
+  type ProjectScriptRunOptions,
+  type ProjectScriptRunResult,
+} from "~/projectScripts";
+import { runProjectCommandInTerminal } from "~/projectTerminalRunner";
+import { isElectron } from "../../env";
+import type { ThreadTerminalState } from "../../terminalStateStore";
+import { useTerminalStateStore } from "../../terminalStateStore";
+import type { Project, Thread } from "../../types";
+import { DEFAULT_THREAD_TERMINAL_ID } from "../../types";
+import {
+  LAST_INVOKED_SCRIPT_BY_PROJECT_KEY,
+  LastInvokedScriptByProjectSchema,
+  resolveProjectScriptTerminalTarget,
+} from "../ChatView.logic";
+import { type NewProjectScriptInput } from "../ProjectScriptsControl";
+import { randomTerminalId } from "../terminal/terminalIds";
+import { toastManager } from "../ui/toast";
+const EMPTY_LAST_INVOKED_SCRIPT_BY_PROJECT: Record<string, string> = {};
+interface ChatProjectScriptsInput {
+  activeThreadId: ThreadId | null;
+  activeThread: Thread | undefined;
+  activeProject: Project | undefined;
+  gitCwd: string | null;
+  isStudioContainer: boolean;
+  terminalState: ThreadTerminalState;
+  requestTerminalFocus: () => void;
+  setTerminalOpen: (open: boolean) => void;
+  setThreadError: (threadId: ThreadId, error: string | null) => void;
+}
+
+export function useChatProjectScripts({
+  activeThreadId,
+  activeThread,
+  activeProject,
+  gitCwd,
+  isStudioContainer,
+  terminalState,
+  requestTerminalFocus,
+  setTerminalOpen,
+  setThreadError,
+}: ChatProjectScriptsInput) {
+  const queryClient = useQueryClient();
+  const storeNewTerminal = useTerminalStateStore((state) => state.newTerminal);
+  const storeSetActiveTerminal = useTerminalStateStore((state) => state.setActiveTerminal);
+  const storeSetTerminalMetadata = useTerminalStateStore((state) => state.setTerminalMetadata);
+  const [lastInvokedScriptByProjectId, setLastInvokedScriptByProjectId] = useLocalStorage(
+    LAST_INVOKED_SCRIPT_BY_PROJECT_KEY,
+    EMPTY_LAST_INVOKED_SCRIPT_BY_PROJECT,
+    LastInvokedScriptByProjectSchema,
+  );
+
+  const runProjectScript = useCallback(
+    async (
+      script: ProjectScript,
+      options?: ProjectScriptRunOptions,
+    ): Promise<ProjectScriptRunResult | null> => {
+      const api = readNativeApi();
+      if (!api || !activeThreadId || !activeProject || !activeThread) return null;
+      if (options?.rememberAsLastInvoked !== false) {
+        setLastInvokedScriptByProjectId((current) => {
+          if (current[activeProject.id] === script.id) return current;
+          return { ...current, [activeProject.id]: script.id };
+        });
+      }
+      const targetCwd = options?.cwd ?? gitCwd ?? activeProject.cwd;
+      const baseTerminalId =
+        terminalState.activeTerminalId ||
+        terminalState.terminalIds[0] ||
+        DEFAULT_THREAD_TERMINAL_ID;
+      const { shouldCreateNewTerminal, terminalId: targetTerminalId } =
+        resolveProjectScriptTerminalTarget({
+          baseTerminalId,
+          createTerminalId: randomTerminalId,
+          hasRunningTerminal: terminalState.runningTerminalIds.length > 0,
+          preferNewTerminal: options?.preferNewTerminal,
+          terminalOpen: terminalState.terminalOpen,
+        });
+
+      setTerminalOpen(true);
+      if (shouldCreateNewTerminal) {
+        storeNewTerminal(activeThreadId, targetTerminalId);
+      } else {
+        storeSetActiveTerminal(activeThreadId, targetTerminalId);
+      }
+      requestTerminalFocus();
+
+      // React Compiler cannot lower value blocks directly inside `try`; keep
+      // those expressions in the nested function while retaining error handling.
+      const runScriptInTargetTerminal = async () => {
+        const { metadata } = await runProjectCommandInTerminal({
+          api,
+          threadId: activeThreadId,
+          terminalId: targetTerminalId,
+          project: {
+            cwd: isStudioContainer ? targetCwd : activeProject.cwd,
+          },
+          cwd: targetCwd,
+          command: script.command,
+          worktreePath: options?.worktreePath ?? activeThread.worktreePath ?? null,
+          ...(options?.env ? { env: options.env } : {}),
+        });
+        if (metadata) {
+          storeSetTerminalMetadata(activeThreadId, targetTerminalId, {
+            cliKind: metadata.cliKind,
+            label: metadata.label,
+          });
+        }
+      };
+
+      try {
+        await runScriptInTargetTerminal();
+        return { terminalId: targetTerminalId };
+      } catch (error) {
+        setThreadError(
+          activeThreadId,
+          error instanceof Error ? error.message : `Failed to run script "${script.name}".`,
+        );
+        if (options?.throwOnError) {
+          throw error instanceof Error
+            ? error
+            : new Error(`Failed to run script "${script.name}".`);
+        }
+        return null;
+      }
+    },
+    [
+      activeProject,
+      activeThread,
+      activeThreadId,
+      gitCwd,
+      isStudioContainer,
+      requestTerminalFocus,
+      setTerminalOpen,
+      setThreadError,
+      storeNewTerminal,
+      storeSetActiveTerminal,
+      storeSetTerminalMetadata,
+      setLastInvokedScriptByProjectId,
+      terminalState.activeTerminalId,
+      terminalState.terminalOpen,
+      terminalState.runningTerminalIds,
+      terminalState.terminalIds,
+    ],
+  );
+
+  const persistProjectScripts = useCallback(
+    async (input: {
+      projectId: ProjectId;
+      nextScripts: ProjectScript[];
+      keybinding?: string | null;
+      keybindingCommand: KeybindingCommand;
+    }) => {
+      const api = readNativeApi();
+      if (!api) return;
+
+      await api.orchestration.dispatchCommand({
+        type: "project.meta.update",
+        commandId: newCommandId(),
+        projectId: input.projectId,
+        scripts: input.nextScripts,
+      });
+
+      const keybindingRule = decodeProjectScriptKeybindingRule({
+        keybinding: input.keybinding,
+        command: input.keybindingCommand,
+      });
+
+      if (isElectron && keybindingRule) {
+        await api.server.upsertKeybinding({ rule: keybindingRule });
+        await queryClient.invalidateQueries({ queryKey: serverQueryKeys.all });
+      }
+    },
+    [queryClient],
+  );
+  const saveProjectScript = useCallback(
+    async (input: NewProjectScriptInput) => {
+      if (!activeProject) return;
+      const nextId = nextProjectScriptId(
+        input.name,
+        activeProject.scripts.map((script) => script.id),
+      );
+      const nextScript: ProjectScript = {
+        id: nextId,
+        name: input.name,
+        command: input.command,
+        icon: input.icon,
+        runOnWorktreeCreate: input.runOnWorktreeCreate,
+      };
+      const nextScripts = input.runOnWorktreeCreate
+        ? [
+            ...activeProject.scripts.map((script) =>
+              script.runOnWorktreeCreate ? { ...script, runOnWorktreeCreate: false } : script,
+            ),
+            nextScript,
+          ]
+        : [...activeProject.scripts, nextScript];
+
+      await persistProjectScripts({
+        projectId: activeProject.id,
+        nextScripts,
+        keybinding: input.keybinding,
+        keybindingCommand: commandForProjectScript(nextId),
+      });
+    },
+    [activeProject, persistProjectScripts],
+  );
+  const updateProjectScript = useCallback(
+    async (scriptId: string, input: NewProjectScriptInput) => {
+      if (!activeProject) return;
+      const existingScript = activeProject.scripts.find((script) => script.id === scriptId);
+      if (!existingScript) {
+        throw new Error("Script not found.");
+      }
+
+      const updatedScript: ProjectScript = {
+        ...existingScript,
+        name: input.name,
+        command: input.command,
+        icon: input.icon,
+        runOnWorktreeCreate: input.runOnWorktreeCreate,
+      };
+      const nextScripts = activeProject.scripts.map((script) =>
+        script.id === scriptId
+          ? updatedScript
+          : input.runOnWorktreeCreate
+            ? { ...script, runOnWorktreeCreate: false }
+            : script,
+      );
+
+      await persistProjectScripts({
+        projectId: activeProject.id,
+        nextScripts,
+        keybinding: input.keybinding,
+        keybindingCommand: commandForProjectScript(scriptId),
+      });
+    },
+    [activeProject, persistProjectScripts],
+  );
+  const deleteProjectScript = useCallback(
+    async (scriptId: string) => {
+      if (!activeProject) return;
+      const nextScripts = activeProject.scripts.filter((script) => script.id !== scriptId);
+
+      const deletedName = activeProject.scripts.find((s) => s.id === scriptId)?.name;
+      // Resolved before the `try`: a value block (`??`) inside a try body makes React
+      // Compiler bail out on the whole component.
+      const deletedScriptToastTitle = `Deleted action "${deletedName ?? "Unknown"}"`;
+
+      try {
+        await persistProjectScripts({
+          projectId: activeProject.id,
+          nextScripts,
+          keybinding: null,
+          keybindingCommand: commandForProjectScript(scriptId),
+        });
+        toastManager.add({
+          type: "success",
+          title: deletedScriptToastTitle,
+        });
+      } catch (error) {
+        toastManager.add({
+          type: "error",
+          title: "Could not delete action",
+          description: error instanceof Error ? error.message : "An unexpected error occurred.",
+        });
+      }
+    },
+    [activeProject, persistProjectScripts],
+  );
+  return {
+    runProjectScript,
+    saveProjectScript,
+    updateProjectScript,
+    deleteProjectScript,
+    lastInvokedScriptByProjectId,
+  };
+}

--- a/apps/web/src/components/chat/useChatProviderModels.ts
+++ b/apps/web/src/components/chat/useChatProviderModels.ts
@@ -1,0 +1,293 @@
+import {
+  ThreadId,
+  type ModelSelection,
+  type ProviderKind,
+  type ServerProviderStatus,
+} from "@synara/contracts";
+import { normalizeModelSlug } from "@synara/shared/model";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { useProviderStatusesForLocalConfig } from "~/hooks/useProviderStatusesForLocalConfig";
+import { resolveAvailableProviderPreference } from "~/lib/providerAvailability";
+import { resolveProviderDiscoveryCwd } from "~/lib/providerDiscovery";
+import {
+  hasReconciledServerProviderStatuses,
+  serverConfigQueryOptions,
+} from "~/lib/serverReactQuery";
+import type { AppSettings } from "../../appSettings";
+import { getProviderStartOptions } from "../../appSettings";
+import { useComposerThreadDraft, useEffectiveComposerModelState } from "../../composerDraftStore";
+import { buildSearchableModelOptions } from "../../hooks/useComposerCommandMenuItems";
+import { useProviderModelCatalog } from "../../hooks/useProviderModelCatalog";
+import { buildModelSelection } from "../../providerModelOptions";
+import type { Project } from "../../types";
+import { type Thread } from "../../types";
+import {
+  shouldShowComposerModelBootstrapSkeleton,
+  threadHasProviderLockingActivity,
+} from "../ChatView.logic";
+import { AVAILABLE_PROVIDER_OPTIONS } from "./ProviderModelPicker";
+import { getComposerProviderState } from "./composerProviderRegistry";
+import { resolveRuntimeModelDescriptor } from "./runtimeModelCapabilities";
+const EMPTY_PROVIDER_STATUSES: ServerProviderStatus[] = [];
+interface ChatProviderModelsInput {
+  threadId: ThreadId;
+  activeThread: Thread | undefined;
+  activeProject: Project | undefined;
+  composerDraft: ReturnType<typeof useComposerThreadDraft>;
+  settings: AppSettings;
+  isModelPickerOpen: boolean;
+  resolvedThreadWorktreePath: string | null;
+}
+
+export function useChatProviderModels({
+  threadId,
+  activeThread,
+  activeProject,
+  composerDraft,
+  settings,
+  isModelPickerOpen,
+  resolvedThreadWorktreePath,
+}: ChatProviderModelsInput) {
+  const queryClient = useQueryClient();
+  const prompt = composerDraft.prompt;
+  const sessionProvider = activeThread?.session?.provider ?? null;
+  const selectedProviderByThreadId = composerDraft.activeProvider ?? null;
+  const threadProvider =
+    activeThread?.modelSelection.provider ?? activeProject?.defaultModelSelection?.provider ?? null;
+  const hasThreadStarted = Boolean(
+    activeThread &&
+    (activeThread.latestTurn !== null ||
+      activeThread.messages.length > 0 ||
+      activeThread.session !== null),
+  );
+  // Side chats import source history as fork-import rows. Those imports must not lock the
+  // provider picker before the Side produces its first native turn (#810).
+  const hasProviderLockingActivity = Boolean(
+    activeThread && threadHasProviderLockingActivity(activeThread),
+  );
+  const lockedProvider: ProviderKind | null = hasProviderLockingActivity
+    ? (sessionProvider ?? threadProvider ?? selectedProviderByThreadId ?? null)
+    : null;
+  const serverConfigQuery = useQuery(serverConfigQueryOptions());
+  const localProviderStatuses = useProviderStatusesForLocalConfig();
+  const preferredDraftProvider =
+    selectedProviderByThreadId ?? threadProvider ?? settings.defaultProvider;
+  const providerStatusesReconciled = hasReconciledServerProviderStatuses(queryClient);
+  const selectedProvider = useMemo<ProviderKind>(
+    () =>
+      lockedProvider ??
+      // Keep an unstarted draft pinned to its explicit provider; availability is validated at send time.
+      selectedProviderByThreadId ??
+      resolveAvailableProviderPreference({
+        preferredProvider: preferredDraftProvider,
+        statuses: providerStatusesReconciled ? localProviderStatuses : EMPTY_PROVIDER_STATUSES,
+        providerOrder: settings.providerOrder,
+        hiddenProviders: settings.hiddenProviders,
+      }),
+    [
+      localProviderStatuses,
+      lockedProvider,
+      preferredDraftProvider,
+      providerStatusesReconciled,
+      selectedProviderByThreadId,
+      settings.hiddenProviders,
+      settings.providerOrder,
+    ],
+  );
+
+  const composerModelHintByProvider = useMemo<Record<ProviderKind, string | null>>(() => {
+    const threadModelSelection = activeThread?.modelSelection ?? null;
+    const projectModelSelection = activeProject?.defaultModelSelection ?? null;
+    const draftSelections = composerDraft.modelSelectionByProvider;
+
+    const resolveHint = (provider: ProviderKind): string | null =>
+      draftSelections[provider]?.model ??
+      (threadModelSelection?.provider === provider ? threadModelSelection.model : null) ??
+      (projectModelSelection?.provider === provider ? projectModelSelection.model : null);
+
+    return {
+      codex: resolveHint("codex"),
+      claudeAgent: resolveHint("claudeAgent"),
+      cursor: resolveHint("cursor"),
+      antigravity: resolveHint("antigravity"),
+      grok: resolveHint("grok"),
+      droid: resolveHint("droid"),
+      opencode: resolveHint("opencode"),
+      pi: resolveHint("pi"),
+      devin: resolveHint("devin"),
+    };
+  }, [
+    activeProject?.defaultModelSelection,
+    activeThread?.modelSelection,
+    composerDraft.modelSelectionByProvider,
+  ]);
+  const providerModelDiscoveryCwd = resolveProviderDiscoveryCwd({
+    activeThreadWorktreePath: resolvedThreadWorktreePath,
+    activeProjectCwd: activeProject?.cwd ?? null,
+    serverCwd: serverConfigQuery.data?.cwd ?? null,
+  });
+  const {
+    customModelsByProvider,
+    modelOptionsByProvider,
+    loadingModelProviders,
+    discoveryErrorsByProvider,
+    runtimeModelsByProvider,
+    selectedRuntimeAgents: dynamicAgents,
+    selectedProviderModelsLoading,
+    selectedProviderRuntimeModelDiscoveryPending,
+  } = useProviderModelCatalog({
+    selectedProvider,
+    discoveryEnabled: isModelPickerOpen,
+    cwd: providerModelDiscoveryCwd,
+    modelHintByProvider: composerModelHintByProvider,
+    agentDiscoveryPolicy: "eager-core",
+  });
+  const { modelOptions: composerModelOptions, selectedModel } = useEffectiveComposerModelState({
+    threadId,
+    selectedProvider,
+    threadModelSelection: activeThread?.modelSelection,
+    projectModelSelection: activeProject?.defaultModelSelection,
+    customModelsByProvider,
+    availableModelOptionsByProvider: modelOptionsByProvider,
+  });
+  const draftModelSelectionForSelectedProvider =
+    composerDraft.modelSelectionByProvider[selectedProvider] ?? null;
+  const persistedClaudeSupportsAutoMode =
+    selectedProvider === "claudeAgent"
+      ? draftModelSelectionForSelectedProvider?.provider === "claudeAgent" &&
+        draftModelSelectionForSelectedProvider.model === selectedModel
+        ? draftModelSelectionForSelectedProvider.supportsAutoMode
+        : activeThread?.modelSelection.provider === "claudeAgent" &&
+            activeThread.modelSelection.model === selectedModel
+          ? activeThread.modelSelection.supportsAutoMode
+          : undefined
+      : undefined;
+  const selectedRuntimeModel = useMemo(() => {
+    const discovered = resolveRuntimeModelDescriptor({
+      provider: selectedProvider,
+      model: selectedModel,
+      runtimeModels: runtimeModelsByProvider[selectedProvider],
+    });
+    if (discovered) {
+      return discovered;
+    }
+    return selectedProvider === "claudeAgent" &&
+      typeof persistedClaudeSupportsAutoMode === "boolean"
+      ? {
+          slug: selectedModel,
+          name: selectedModel,
+          supportsAutoMode: persistedClaudeSupportsAutoMode,
+        }
+      : undefined;
+  }, [persistedClaudeSupportsAutoMode, runtimeModelsByProvider, selectedModel, selectedProvider]);
+  const composerProviderState = useMemo(
+    () =>
+      getComposerProviderState({
+        provider: selectedProvider,
+        model: selectedModel,
+        runtimeModel: selectedRuntimeModel,
+        prompt,
+        modelOptions: composerModelOptions,
+      }),
+    [composerModelOptions, prompt, selectedModel, selectedProvider, selectedRuntimeModel],
+  );
+  const selectedPromptEffort = composerProviderState.promptEffort;
+  const selectedModelOptionsForDispatch = composerProviderState.modelOptionsForDispatch;
+  const selectedModelSelection = useMemo<ModelSelection>(() => {
+    if (selectedProvider === "pi" && draftModelSelectionForSelectedProvider?.provider === "pi") {
+      return buildModelSelection(
+        selectedProvider,
+        draftModelSelectionForSelectedProvider.model,
+        selectedModelOptionsForDispatch ?? draftModelSelectionForSelectedProvider.options,
+      );
+    }
+    return buildModelSelection(
+      selectedProvider,
+      selectedModel,
+      selectedModelOptionsForDispatch,
+      selectedProvider === "claudeAgent" ? selectedRuntimeModel?.supportsAutoMode : undefined,
+    );
+  }, [
+    draftModelSelectionForSelectedProvider,
+    selectedModel,
+    selectedModelOptionsForDispatch,
+    selectedProvider,
+    selectedRuntimeModel,
+  ]);
+  const providerOptionsForDispatch = useMemo(() => getProviderStartOptions(settings), [settings]);
+  const selectedModelForPicker =
+    selectedModelSelection.provider === selectedProvider
+      ? selectedModelSelection.model
+      : selectedModel;
+  const selectedModelForPickerWithCustomFallback = useMemo(() => {
+    const currentOptions = modelOptionsByProvider[selectedProvider];
+    return currentOptions.some((option) => option.slug === selectedModelForPicker)
+      ? selectedModelForPicker
+      : (normalizeModelSlug(selectedModelForPicker, selectedProvider) ?? selectedModelForPicker);
+  }, [modelOptionsByProvider, selectedModelForPicker, selectedProvider]);
+  const persistedComposerModelSelection =
+    sessionProvider && activeThread?.modelSelection.provider !== sessionProvider
+      ? activeProject?.defaultModelSelection?.provider === selectedProvider
+        ? activeProject.defaultModelSelection
+        : null
+      : (activeThread?.modelSelection ?? activeProject?.defaultModelSelection ?? null);
+  const providerModelsLoading = selectedProviderModelsLoading;
+  const selectedProviderRequiresRuntimeModels =
+    selectedProvider === "cursor" ||
+    selectedProvider === "antigravity" ||
+    selectedProvider === "droid" ||
+    selectedProvider === "opencode" ||
+    selectedProvider === "pi" ||
+    selectedProvider === "devin";
+  const showComposerModelBootstrapSkeleton = shouldShowComposerModelBootstrapSkeleton({
+    selectedProvider,
+    selectedModel,
+    persistedModelSelection: persistedComposerModelSelection,
+    draftModelSelection: draftModelSelectionForSelectedProvider,
+    providerModelsLoading,
+    requiresDiscoveredModels: selectedProviderRequiresRuntimeModels,
+  });
+  const searchableModelOptions = useMemo(
+    () =>
+      buildSearchableModelOptions({
+        providerOptions: AVAILABLE_PROVIDER_OPTIONS,
+        modelOptionsByProvider,
+        providerOrder: settings.providerOrder,
+        hiddenProviders: settings.hiddenProviders,
+        protectedProviders: [selectedProvider],
+        lockedProvider,
+      }),
+    [
+      lockedProvider,
+      modelOptionsByProvider,
+      selectedProvider,
+      settings.hiddenProviders,
+      settings.providerOrder,
+    ],
+  );
+  return {
+    hasThreadStarted,
+    lockedProvider,
+    serverConfigQuery,
+    selectedProvider,
+    providerModelDiscoveryCwd,
+    customModelsByProvider,
+    modelOptionsByProvider,
+    loadingModelProviders,
+    discoveryErrorsByProvider,
+    runtimeModelsByProvider,
+    dynamicAgents,
+    selectedProviderRuntimeModelDiscoveryPending,
+    composerModelOptions,
+    selectedModel,
+    selectedRuntimeModel,
+    composerProviderState,
+    selectedPromptEffort,
+    selectedModelSelection,
+    providerOptionsForDispatch,
+    selectedModelForPickerWithCustomFallback,
+    showComposerModelBootstrapSkeleton,
+    searchableModelOptions,
+  };
+}

--- a/apps/web/src/components/chat/useChatProviderStatus.ts
+++ b/apps/web/src/components/chat/useChatProviderStatus.ts
@@ -1,0 +1,165 @@
+import {
+  type ProviderKind,
+  type ProviderStartOptions,
+  type ServerProviderStatus,
+} from "@synara/contracts";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  normalizeCustomBinaryPath,
+  normalizeProviderStatusForLocalConfig,
+} from "~/lib/providerAvailability";
+import type { AppSettings } from "../../appSettings";
+import { getCustomBinaryPathForProvider } from "../../appSettings";
+import {
+  loadConfirmedCustomBinaryPaths,
+  saveConfirmedCustomBinaryPaths,
+} from "../../confirmedCustomBinaryPathStore";
+import { type Thread } from "../../types";
+import { shouldConsumePendingCustomBinaryConfirmation } from "../ChatView.logic";
+const EMPTY_PROVIDER_STATUSES: ServerProviderStatus[] = [];
+function getThreadProviderCustomBinaryPathKey(threadId: Thread["id"], provider: ProviderKind) {
+  return `${threadId}:${provider}`;
+}
+
+function getConfirmedCustomBinarySessionKey(
+  thread: Thread | null | undefined,
+  provider: ProviderKind,
+): string | null {
+  const session = thread?.session;
+  if (!thread || session?.provider !== provider) {
+    return null;
+  }
+  if (session.status !== "ready" && session.status !== "running") {
+    return null;
+  }
+  return getThreadProviderCustomBinaryPathKey(thread.id, provider);
+}
+
+function getProviderStartOptionsCustomBinaryPath(
+  providerOptions: ProviderStartOptions | undefined,
+  provider: ProviderKind,
+): string | null {
+  switch (provider) {
+    case "codex":
+      return normalizeCustomBinaryPath(providerOptions?.codex?.binaryPath);
+    case "claudeAgent":
+      return normalizeCustomBinaryPath(providerOptions?.claudeAgent?.binaryPath);
+    case "antigravity":
+      return normalizeCustomBinaryPath(providerOptions?.antigravity?.binaryPath);
+    case "grok":
+      return normalizeCustomBinaryPath(providerOptions?.grok?.binaryPath);
+    case "droid":
+      return normalizeCustomBinaryPath(providerOptions?.droid?.binaryPath);
+    case "opencode":
+      return normalizeCustomBinaryPath(providerOptions?.opencode?.binaryPath);
+    case "cursor":
+      return normalizeCustomBinaryPath(providerOptions?.cursor?.binaryPath);
+    case "devin":
+      return normalizeCustomBinaryPath(providerOptions?.devin?.binaryPath);
+    case "pi":
+      return normalizeCustomBinaryPath(providerOptions?.pi?.binaryPath);
+  }
+}
+interface ChatProviderStatusInput {
+  activeThread: Thread | undefined;
+  settings: AppSettings;
+  configuredProviderStatuses: readonly ServerProviderStatus[] | undefined;
+}
+
+export function useChatProviderStatus({
+  activeThread,
+  settings,
+  configuredProviderStatuses,
+}: ChatProviderStatusInput) {
+  const [confirmedCustomBinaryPathsByProvider, setConfirmedCustomBinaryPathsByProvider] = useState<
+    Partial<Record<ProviderKind, string>>
+  >(loadConfirmedCustomBinaryPaths);
+  const confirmedCustomBinarySessionKeysRef = useRef<Set<string>>(new Set());
+  const pendingCustomBinaryPathsByThreadProviderRef = useRef<Map<string, string>>(new Map());
+
+  const rememberCustomBinaryPathForDispatch = useCallback(
+    (input: {
+      threadId: Thread["id"];
+      provider: ProviderKind;
+      providerOptions: ProviderStartOptions | undefined;
+    }) => {
+      const pendingKey = getThreadProviderCustomBinaryPathKey(input.threadId, input.provider);
+      const customBinaryPath = getProviderStartOptionsCustomBinaryPath(
+        input.providerOptions,
+        input.provider,
+      );
+      if (!customBinaryPath) {
+        pendingCustomBinaryPathsByThreadProviderRef.current.delete(pendingKey);
+        return;
+      }
+      pendingCustomBinaryPathsByThreadProviderRef.current.set(pendingKey, customBinaryPath);
+    },
+    [],
+  );
+  useEffect(() => {
+    const provider = activeThread?.session?.provider;
+    if (!activeThread || !provider) {
+      return;
+    }
+
+    const sessionKey = getConfirmedCustomBinarySessionKey(activeThread, provider);
+    if (!sessionKey) {
+      confirmedCustomBinarySessionKeysRef.current.delete(
+        getThreadProviderCustomBinaryPathKey(activeThread.id, provider),
+      );
+      return;
+    }
+    const customBinaryPath =
+      pendingCustomBinaryPathsByThreadProviderRef.current.get(sessionKey) ?? null;
+    if (
+      !shouldConsumePendingCustomBinaryConfirmation({
+        sessionAlreadyChecked: confirmedCustomBinarySessionKeysRef.current.has(sessionKey),
+        pendingCustomBinaryPath: customBinaryPath,
+      })
+    ) {
+      return;
+    }
+    confirmedCustomBinarySessionKeysRef.current.add(sessionKey);
+
+    pendingCustomBinaryPathsByThreadProviderRef.current.delete(sessionKey);
+    if (!customBinaryPath) {
+      return;
+    }
+
+    setConfirmedCustomBinaryPathsByProvider((existing) =>
+      existing[provider] === customBinaryPath
+        ? existing
+        : {
+            ...existing,
+            [provider]: customBinaryPath,
+          },
+    );
+  }, [
+    activeThread,
+    activeThread?.id,
+    activeThread?.session?.provider,
+    activeThread?.session?.status,
+  ]);
+  // Persist confirmations so a custom binary path that already started a session
+  // stays trusted across restarts, instead of re-showing the availability warning.
+  useEffect(() => {
+    saveConfirmedCustomBinaryPaths(confirmedCustomBinaryPathsByProvider);
+  }, [confirmedCustomBinaryPathsByProvider]);
+  const providerStatuses = useMemo(
+    () =>
+      (configuredProviderStatuses ?? EMPTY_PROVIDER_STATUSES)
+        .map((status) => {
+          const customBinaryPath = getCustomBinaryPathForProvider(settings, status.provider);
+          return normalizeProviderStatusForLocalConfig({
+            provider: status.provider,
+            status,
+            customBinaryPath,
+            confirmedCustomBinaryPath: confirmedCustomBinaryPathsByProvider[status.provider],
+            disabled: settings.disabledProviders.includes(status.provider),
+          });
+        })
+        .flatMap((status) => (status ? [status] : [])),
+    [confirmedCustomBinaryPathsByProvider, configuredProviderStatuses, settings],
+  );
+  return { rememberCustomBinaryPathForDispatch, providerStatuses };
+}

--- a/apps/web/src/components/chat/useChatQueuedTurns.ts
+++ b/apps/web/src/components/chat/useChatQueuedTurns.ts
@@ -1,0 +1,473 @@
+import { ThreadId } from "@synara/contracts";
+import type { RefObject } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { collapseExpandedComposerCursor, detectComposerTrigger } from "../../composer-logic";
+import { type QueuedComposerTurn } from "../../composerDraftStore";
+import { cloneComposerImageAttachment } from "../../lib/composerSend";
+import {
+  armQueuedComposerSteerGate,
+  claimQueuedComposerAutoDispatch,
+  clearQueuedComposerAutoDispatchRetry,
+  clearQueuedComposerSteerGate,
+  getQueuedComposerAutoDispatchRetryDelay,
+  getQueuedComposerSteerGate,
+  isQueuedComposerAwaitingTurnStart,
+  recordQueuedComposerAutoDispatchFailure,
+  releaseQueuedComposerAutoDispatch,
+  runLockedQueuedComposerAutoDispatch,
+  tryBeginQueuedComposerAutoDispatch,
+} from "../../lib/queuedComposerDrain";
+import { derivePhase } from "../../session-logic";
+import { type ChatMessage, type Thread } from "../../types";
+import {
+  resolveQueuedComposerAutoDispatchHold,
+  resolveQueuedSteerGateTransition,
+  type QueuedSteerGate,
+} from "../ChatView.logic";
+import { useChatComposerDraft } from "./useChatComposerDraft";
+import { useChatLocalDispatch } from "./useChatLocalDispatch";
+import { useChatPendingInteractions } from "./useChatPendingInteractions";
+import { useComposerReferences } from "./useComposerReferences";
+import type { LateComposerSendHandlers } from "./chatSendTypes";
+const EMPTY_MESSAGES: ChatMessage[] = [];
+interface ChatQueuedTurnsInput {
+  threadId: ThreadId;
+  queuedComposerTurns: ReturnType<typeof useChatComposerDraft>["queuedComposerTurns"];
+  activeThread: Thread | undefined;
+  promptRef: ReturnType<typeof useChatComposerDraft>["promptRef"];
+  clearComposerDraftContent: ReturnType<typeof useChatComposerDraft>["clearComposerDraftContent"];
+  setComposerDraftPrompt: ReturnType<typeof useChatComposerDraft>["setComposerDraftPrompt"];
+  setDraftThreadContext: ReturnType<typeof useChatComposerDraft>["setDraftThreadContext"];
+  addComposerImagesToDraft: ReturnType<typeof useChatComposerDraft>["addComposerImagesToDraft"];
+  addComposerFilesToDraft: ReturnType<typeof useChatComposerDraft>["addComposerFilesToDraft"];
+  addComposerAssistantSelectionToDraft: ReturnType<
+    typeof useChatComposerDraft
+  >["addComposerAssistantSelectionToDraft"];
+  addComposerDraftBrowserAnnotations: ReturnType<
+    typeof useChatComposerDraft
+  >["addComposerDraftBrowserAnnotations"];
+  addComposerFileCommentToDraft: ReturnType<
+    typeof useChatComposerDraft
+  >["addComposerFileCommentToDraft"];
+  addComposerTerminalContextsToDraft: ReturnType<
+    typeof useChatComposerDraft
+  >["addComposerTerminalContextsToDraft"];
+  addComposerPastedTextsToDraft: ReturnType<
+    typeof useChatComposerDraft
+  >["addComposerPastedTextsToDraft"];
+  addComposerPullRequestContextsToDraft: ReturnType<
+    typeof useChatComposerDraft
+  >["addComposerPullRequestContextsToDraft"];
+  updateSelectedComposerSkills: ReturnType<
+    typeof useComposerReferences
+  >["updateSelectedComposerSkills"];
+  updateSelectedComposerMentions: ReturnType<
+    typeof useComposerReferences
+  >["updateSelectedComposerMentions"];
+  setRestoredQueuedSourceProposedPlan: ReturnType<
+    typeof useChatComposerDraft
+  >["setRestoredQueuedSourceProposedPlan"];
+  setComposerDraftModelSelection: ReturnType<
+    typeof useChatComposerDraft
+  >["setComposerDraftModelSelection"];
+  setComposerDraftRuntimeMode: ReturnType<
+    typeof useChatComposerDraft
+  >["setComposerDraftRuntimeMode"];
+  setComposerDraftInteractionMode: ReturnType<
+    typeof useChatComposerDraft
+  >["setComposerDraftInteractionMode"];
+  setComposerCursor: ReturnType<typeof useChatComposerDraft>["setComposerCursor"];
+  setComposerTrigger: ReturnType<typeof useChatComposerDraft>["setComposerTrigger"];
+  scheduleComposerFocus: () => void;
+  removeQueuedComposerTurnFromDraft: ReturnType<
+    typeof useChatComposerDraft
+  >["removeQueuedComposerTurnFromDraft"];
+  lateComposerSendHandlersRef: RefObject<LateComposerSendHandlers | null>;
+  insertQueuedComposerTurn: ReturnType<typeof useChatComposerDraft>["insertQueuedComposerTurn"];
+  phase: ReturnType<typeof derivePhase>;
+  localDispatch: ReturnType<typeof useChatLocalDispatch>["localDispatch"];
+  isLocalDraftThread: boolean;
+  activeLatestTurn: Thread["latestTurn"];
+  isConnecting: boolean;
+  activePendingApproval: ReturnType<typeof useChatPendingInteractions>["activePendingApproval"];
+  activePendingProgress: ReturnType<typeof useChatPendingInteractions>["activePendingProgress"];
+  pendingUserInputs: ReturnType<typeof useChatPendingInteractions>["pendingUserInputs"];
+  sendInFlightRef: RefObject<boolean>;
+  sendPreflightInFlightRef: RefObject<boolean>;
+}
+
+export function useChatQueuedTurns({
+  threadId,
+  queuedComposerTurns,
+  activeThread,
+  promptRef,
+  clearComposerDraftContent,
+  setComposerDraftPrompt,
+  setDraftThreadContext,
+  addComposerImagesToDraft,
+  addComposerFilesToDraft,
+  addComposerAssistantSelectionToDraft,
+  addComposerDraftBrowserAnnotations,
+  addComposerFileCommentToDraft,
+  addComposerTerminalContextsToDraft,
+  addComposerPastedTextsToDraft,
+  addComposerPullRequestContextsToDraft,
+  updateSelectedComposerSkills,
+  updateSelectedComposerMentions,
+  setRestoredQueuedSourceProposedPlan,
+  setComposerDraftModelSelection,
+  setComposerDraftRuntimeMode,
+  setComposerDraftInteractionMode,
+  setComposerCursor,
+  setComposerTrigger,
+  scheduleComposerFocus,
+  removeQueuedComposerTurnFromDraft,
+  lateComposerSendHandlersRef,
+  insertQueuedComposerTurn,
+  phase,
+  localDispatch,
+  isLocalDraftThread,
+  activeLatestTurn,
+  isConnecting,
+  activePendingApproval,
+  activePendingProgress,
+  pendingUserInputs,
+  sendInFlightRef,
+  sendPreflightInFlightRef,
+}: ChatQueuedTurnsInput) {
+  const queuedComposerTurnsRef = useRef<QueuedComposerTurn[]>([]);
+
+  const autoDispatchingQueuedTurnRef = useRef(false);
+
+  // Holds queued-composer auto-dispatch through a non-natively-steerable
+  // provider steer's interrupt→re-dispatch gap; see
+  // resolveQueuedSteerGateTransition. Seed from the shared map so a remount
+  // during the interrupt gap still sees the gate the watcher has been holding.
+
+  const [queuedSteerGate, setQueuedSteerGate] = useState<QueuedSteerGate | null>(() =>
+    getQueuedComposerSteerGate(threadId),
+  );
+  // Bumped to re-evaluate auto-dispatch when only non-reactive guards (refs)
+  // blocked it; nothing else re-triggers the effect once they reset.
+  const [queuedAutoDispatchTick, setQueuedAutoDispatchTick] = useState(0);
+
+  useEffect(() => {
+    queuedComposerTurnsRef.current = queuedComposerTurns;
+  }, [queuedComposerTurnsRef, queuedComposerTurns]);
+
+  useEffect(() => {
+    autoDispatchingQueuedTurnRef.current = false;
+  }, [autoDispatchingQueuedTurnRef, threadId]);
+
+  useLayoutEffect(() => {
+    claimQueuedComposerAutoDispatch(threadId);
+    setQueuedSteerGate(getQueuedComposerSteerGate(threadId));
+    return () => {
+      releaseQueuedComposerAutoDispatch(threadId);
+    };
+  }, [setQueuedSteerGate, threadId]);
+
+  const restoreQueuedTurnToComposer = useCallback(
+    (queuedTurn: QueuedComposerTurn) => {
+      if (!activeThread) {
+        return;
+      }
+      const nextPrompt = queuedTurn.kind === "chat" ? queuedTurn.prompt : queuedTurn.text;
+      const restoredImages =
+        queuedTurn.kind === "chat" ? queuedTurn.images.map(cloneComposerImageAttachment) : [];
+      const restoredFiles = queuedTurn.kind === "chat" ? queuedTurn.files : [];
+      const restoredAssistantSelections =
+        queuedTurn.kind === "chat" ? queuedTurn.assistantSelections : [];
+      const restoredBrowserAnnotations =
+        queuedTurn.kind === "chat" ? queuedTurn.browserAnnotations : [];
+      const restoredFileComments = queuedTurn.kind === "chat" ? queuedTurn.fileComments : [];
+      promptRef.current = nextPrompt;
+      clearComposerDraftContent(activeThread.id);
+      setComposerDraftPrompt(activeThread.id, nextPrompt);
+      // Editing a queued turn should recreate the same draft state the user queued.
+      setDraftThreadContext(activeThread.id, {
+        runtimeMode: queuedTurn.runtimeMode,
+        interactionMode: queuedTurn.interactionMode,
+        ...(queuedTurn.kind === "chat" ? { envMode: queuedTurn.envMode } : {}),
+      });
+      if (queuedTurn.kind === "chat") {
+        if (restoredImages.length > 0) {
+          addComposerImagesToDraft(restoredImages);
+        }
+        if (restoredFiles.length > 0) {
+          addComposerFilesToDraft(restoredFiles);
+        }
+        for (const selection of restoredAssistantSelections) {
+          addComposerAssistantSelectionToDraft(selection);
+        }
+        if (restoredBrowserAnnotations.length > 0) {
+          addComposerDraftBrowserAnnotations(activeThread.id, restoredBrowserAnnotations);
+        }
+        for (const comment of restoredFileComments) {
+          addComposerFileCommentToDraft(comment);
+        }
+        if (queuedTurn.terminalContexts.length > 0) {
+          addComposerTerminalContextsToDraft(queuedTurn.terminalContexts);
+        }
+        if (queuedTurn.pastedTexts.length > 0) {
+          addComposerPastedTextsToDraft(queuedTurn.pastedTexts);
+        }
+        addComposerPullRequestContextsToDraft(queuedTurn.pullRequestContexts);
+        updateSelectedComposerSkills(queuedTurn.skills);
+        updateSelectedComposerMentions(queuedTurn.mentions);
+      } else {
+        updateSelectedComposerSkills([]);
+        updateSelectedComposerMentions([]);
+      }
+      setRestoredQueuedSourceProposedPlan(
+        activeThread.id,
+        queuedTurn.kind === "chat" && queuedTurn.sourceProposedPlan
+          ? {
+              threadId: activeThread.id,
+              restoredPrompt: nextPrompt,
+              sourceProposedPlan: queuedTurn.sourceProposedPlan,
+            }
+          : null,
+      );
+      setComposerDraftModelSelection(activeThread.id, queuedTurn.modelSelection);
+      setComposerDraftRuntimeMode(activeThread.id, queuedTurn.runtimeMode);
+      setComposerDraftInteractionMode(activeThread.id, queuedTurn.interactionMode);
+      setComposerCursor(collapseExpandedComposerCursor(nextPrompt, nextPrompt.length));
+      setComposerTrigger(detectComposerTrigger(nextPrompt, nextPrompt.length));
+      scheduleComposerFocus();
+    },
+    [
+      promptRef,
+      setComposerCursor,
+      setComposerTrigger,
+      activeThread,
+      addComposerAssistantSelectionToDraft,
+      addComposerDraftBrowserAnnotations,
+      addComposerFileCommentToDraft,
+      addComposerFilesToDraft,
+      addComposerImagesToDraft,
+      addComposerTerminalContextsToDraft,
+      addComposerPastedTextsToDraft,
+      addComposerPullRequestContextsToDraft,
+      clearComposerDraftContent,
+      scheduleComposerFocus,
+      setDraftThreadContext,
+      setRestoredQueuedSourceProposedPlan,
+      setComposerDraftInteractionMode,
+      setComposerDraftModelSelection,
+      setComposerDraftPrompt,
+      setComposerDraftRuntimeMode,
+      updateSelectedComposerMentions,
+      updateSelectedComposerSkills,
+    ],
+  );
+
+  const removeQueuedComposerTurn = useCallback(
+    (queuedTurnId: string) => {
+      removeQueuedComposerTurnFromDraft(threadId, queuedTurnId);
+    },
+    [removeQueuedComposerTurnFromDraft, threadId],
+  );
+
+  const dispatchQueuedComposerTurn = useCallback(
+    async (queuedTurn: QueuedComposerTurn, dispatchMode: "queue" | "steer"): Promise<boolean> => {
+      const lateSendHandlers = lateComposerSendHandlersRef.current;
+      if (!lateSendHandlers) {
+        return false;
+      }
+      if (queuedTurn.kind === "chat") {
+        return lateSendHandlers.send(undefined, dispatchMode, queuedTurn);
+      }
+      return lateSendHandlers.submitPlanFollowUp({
+        text: queuedTurn.text,
+        interactionMode: queuedTurn.interactionMode,
+        dispatchMode,
+        queuedTurn,
+      });
+    },
+    [lateComposerSendHandlersRef],
+  );
+
+  const onSteerQueuedComposerTurn = useCallback(
+    async (queuedTurn: QueuedComposerTurn) => {
+      const previousQueue = queuedComposerTurnsRef.current;
+      const queuedIndex = previousQueue.findIndex((entry) => entry.id === queuedTurn.id);
+      if (queuedIndex < 0) {
+        return;
+      }
+      removeQueuedComposerTurnFromDraft(threadId, queuedTurn.id);
+      const succeeded = await dispatchQueuedComposerTurn(queuedTurn, "steer");
+      if (succeeded) {
+        clearQueuedComposerAutoDispatchRetry(threadId);
+        return;
+      }
+      insertQueuedComposerTurn(threadId, queuedTurn, queuedIndex);
+      recordQueuedComposerAutoDispatchFailure(threadId, queuedTurn.id);
+      setQueuedAutoDispatchTick((tick) => tick + 1);
+    },
+    [
+      queuedComposerTurnsRef,
+      setQueuedAutoDispatchTick,
+      dispatchQueuedComposerTurn,
+      insertQueuedComposerTurn,
+      removeQueuedComposerTurnFromDraft,
+      threadId,
+    ],
+  );
+
+  const onEditQueuedComposerTurn = useCallback(
+    (queuedTurn: QueuedComposerTurn) => {
+      removeQueuedComposerTurn(queuedTurn.id);
+      restoreQueuedTurnToComposer(queuedTurn);
+    },
+    [removeQueuedComposerTurn, restoreQueuedTurnToComposer],
+  );
+
+  // Advance/expire the steer gate as the session moves through the
+  // interrupt→steered-turn handoff (or fails out of it).
+  const sessionErroredForSteerGate = activeThread?.session?.status === "error";
+  const activeTurnIdForSteerGate = activeThread?.session?.activeTurnId ?? null;
+
+  useEffect(() => {
+    if (!queuedSteerGate) {
+      return;
+    }
+    const transition = resolveQueuedSteerGateTransition({
+      gate: queuedSteerGate,
+      phase,
+      sessionErrored: sessionErroredForSteerGate,
+      activeTurnId: activeTurnIdForSteerGate,
+      now: Date.now(),
+    });
+    if (transition.kind === "clear") {
+      setQueuedSteerGate(null);
+      clearQueuedComposerSteerGate(threadId);
+      return;
+    }
+    if (
+      transition.gate.sawInterruptGap !== queuedSteerGate.sawInterruptGap ||
+      transition.gate.gapStartedAt !== queuedSteerGate.gapStartedAt ||
+      transition.gate.armedActiveTurnId !== queuedSteerGate.armedActiveTurnId
+    ) {
+      setQueuedSteerGate(transition.gate);
+      armQueuedComposerSteerGate(threadId, transition.gate);
+      return;
+    }
+    if (transition.expiresInMs === null) {
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      setQueuedSteerGate(null);
+      clearQueuedComposerSteerGate(threadId);
+    }, transition.expiresInMs);
+    return () => window.clearTimeout(timer);
+  }, [
+    setQueuedSteerGate,
+    activeTurnIdForSteerGate,
+    phase,
+    queuedSteerGate,
+    sessionErroredForSteerGate,
+    threadId,
+  ]);
+
+  useEffect(() => {
+    if (
+      isQueuedComposerAwaitingTurnStart(threadId) ||
+      resolveQueuedComposerAutoDispatchHold({
+        localDispatch,
+        // A mini-composer submission queues the first turn before the draft has a session.
+        phase: isLocalDraftThread ? "ready" : phase,
+        latestTurn: activeLatestTurn,
+        session: activeThread?.session ?? null,
+        messages: activeThread?.messages ?? EMPTY_MESSAGES,
+        isConnecting,
+        queuedSteerGate: getQueuedComposerSteerGate(threadId) ?? queuedSteerGate,
+        hasPendingApproval: activePendingApproval !== null,
+        hasPendingProgress: activePendingProgress !== null,
+        hasPendingUserInput: pendingUserInputs.length > 0,
+        queuedTurnCount: queuedComposerTurns.length,
+        threadError: activeThread?.error,
+        now: Date.now(),
+      })
+    ) {
+      return;
+    }
+    if (
+      autoDispatchingQueuedTurnRef.current ||
+      sendInFlightRef.current ||
+      sendPreflightInFlightRef.current
+    ) {
+      // These guards are refs, so nothing re-triggers this effect once they
+      // reset; poll until the in-flight send settles instead of leaving the
+      // queue stuck at the end of a turn.
+      const timer = window.setTimeout(() => setQueuedAutoDispatchTick((tick) => tick + 1), 250);
+      return () => window.clearTimeout(timer);
+    }
+    const nextQueuedTurn = queuedComposerTurns[0];
+    if (!nextQueuedTurn) {
+      return;
+    }
+    const retryDelay = getQueuedComposerAutoDispatchRetryDelay(threadId, nextQueuedTurn.id);
+    if (retryDelay === null) {
+      return;
+    }
+    if (retryDelay !== undefined && retryDelay > 0) {
+      const timer = window.setTimeout(
+        () => setQueuedAutoDispatchTick((tick) => tick + 1),
+        retryDelay,
+      );
+      return () => window.clearTimeout(timer);
+    }
+    if (!tryBeginQueuedComposerAutoDispatch(threadId)) {
+      // The watcher already owns this thread's queue head (background drain
+      // started before this ChatView claimed). Poll until that send settles.
+      const timer = window.setTimeout(() => setQueuedAutoDispatchTick((tick) => tick + 1), 250);
+      return () => window.clearTimeout(timer);
+    }
+    autoDispatchingQueuedTurnRef.current = true;
+    void runLockedQueuedComposerAutoDispatch({
+      threadId,
+      run: async () => {
+        const succeeded = await dispatchQueuedComposerTurn(nextQueuedTurn, "queue");
+        if (succeeded) {
+          clearQueuedComposerAutoDispatchRetry(threadId);
+          removeQueuedComposerTurnFromDraft(threadId, nextQueuedTurn.id);
+          return;
+        }
+        recordQueuedComposerAutoDispatchFailure(threadId, nextQueuedTurn.id);
+        setQueuedAutoDispatchTick((tick) => tick + 1);
+      },
+      onSettled: () => {
+        autoDispatchingQueuedTurnRef.current = false;
+      },
+    });
+  }, [
+    autoDispatchingQueuedTurnRef,
+    setQueuedAutoDispatchTick,
+    sendInFlightRef,
+    sendPreflightInFlightRef,
+    activeLatestTurn,
+    activePendingApproval,
+    activePendingProgress,
+    activeThread?.error,
+    activeThread?.messages,
+    activeThread?.session,
+    dispatchQueuedComposerTurn,
+    isConnecting,
+    isLocalDraftThread,
+    localDispatch,
+    pendingUserInputs.length,
+    phase,
+    queuedAutoDispatchTick,
+    queuedComposerTurns,
+    queuedSteerGate,
+    removeQueuedComposerTurnFromDraft,
+    threadId,
+  ]);
+  return {
+    setQueuedSteerGate,
+    removeQueuedComposerTurn,
+    onSteerQueuedComposerTurn,
+    onEditQueuedComposerTurn,
+  };
+}

--- a/apps/web/src/components/chat/useChatRuntimeModes.ts
+++ b/apps/web/src/components/chat/useChatRuntimeModes.ts
@@ -1,0 +1,271 @@
+import {
+  ProviderInteractionMode,
+  RuntimeMode,
+  ThreadId,
+  type ModelSelection,
+  type ProviderKind,
+  type ServerProviderStatus,
+} from "@synara/contracts";
+import { useCallback, useEffect, useRef } from "react";
+import { newCommandId } from "~/lib/utils";
+import { readNativeApi } from "~/nativeApi";
+import { useComposerDraftStore } from "../../composerDraftStore";
+import { providerModelSupportsAutoRuntimeMode } from "../../lib/runtimeMode";
+import { type Thread } from "../../types";
+import {
+  createRuntimeModePersistenceQueue,
+  persistModelSelectionBeforeRuntimeMode,
+} from "../ChatView.logic";
+import { resolveRuntimeModelDescriptor } from "./runtimeModelCapabilities";
+import { toastManager } from "../ui/toast";
+
+interface ChatRuntimeModesInput {
+  threadId: ThreadId;
+  activeThread: Thread | undefined;
+  serverThread: Thread | undefined;
+  isLocalDraftThread: boolean;
+  runtimeMode: RuntimeMode;
+  interactionMode: ProviderInteractionMode;
+  selectedProvider: ProviderKind;
+  selectedRuntimeModel: ReturnType<typeof resolveRuntimeModelDescriptor>;
+  selectedModelSelection: ModelSelection;
+  activeProviderStatus: ServerProviderStatus | null;
+  scheduleComposerFocus: () => void;
+}
+
+export function useChatRuntimeModes({
+  threadId,
+  activeThread,
+  serverThread,
+  isLocalDraftThread,
+  runtimeMode,
+  interactionMode,
+  selectedProvider,
+  selectedRuntimeModel,
+  selectedModelSelection,
+  activeProviderStatus,
+  scheduleComposerFocus,
+}: ChatRuntimeModesInput) {
+  const setComposerDraftRuntimeMode = useComposerDraftStore((state) => state.setRuntimeMode);
+  const setDraftThreadContext = useComposerDraftStore((state) => state.setDraftThreadContext);
+  const setComposerDraftInteractionMode = useComposerDraftStore(
+    (state) => state.setInteractionMode,
+  );
+  const runtimeModePersistenceQueuesRef = useRef(
+    new Map<ThreadId, ReturnType<typeof createRuntimeModePersistenceQueue>>(),
+  );
+  useEffect(() => {
+    const existing = runtimeModePersistenceQueuesRef.current.get(threadId);
+    if (existing) {
+      existing.syncAcknowledgedMode(runtimeMode);
+      return;
+    }
+    runtimeModePersistenceQueuesRef.current.set(
+      threadId,
+      createRuntimeModePersistenceQueue(runtimeMode),
+    );
+  }, [runtimeMode, threadId]);
+
+  const persistRuntimeModeChange = useCallback(
+    async (mode: RuntimeMode): Promise<boolean> => {
+      let queue = runtimeModePersistenceQueuesRef.current.get(threadId);
+      if (!queue) {
+        queue = createRuntimeModePersistenceQueue(runtimeMode);
+        runtimeModePersistenceQueuesRef.current.set(threadId, queue);
+      }
+      return queue.persist(mode, async (currentMode, nextMode) => {
+        if (serverThread) {
+          const api = readNativeApi();
+          if (!api) {
+            toastManager.add({
+              type: "error",
+              title: "Could not update access mode",
+              description: "Synara is not connected to the server.",
+            });
+            return false;
+          }
+          const persistenceInput = {
+            currentModelSelection: serverThread.modelSelection,
+            ...(nextMode === "auto" ? { nextModelSelection: selectedModelSelection } : {}),
+            currentRuntimeMode: currentMode,
+            nextRuntimeMode: nextMode,
+            persistModelSelection: (modelSelection: ModelSelection) =>
+              api.orchestration.dispatchCommand({
+                type: "thread.meta.update",
+                commandId: newCommandId(),
+                threadId,
+                modelSelection,
+              }),
+            persistRuntimeMode: (runtimeMode: RuntimeMode) =>
+              api.orchestration.dispatchCommand({
+                type: "thread.runtime-mode.set",
+                commandId: newCommandId(),
+                threadId,
+                runtimeMode,
+                createdAt: new Date().toISOString(),
+              }),
+          };
+          try {
+            await persistModelSelectionBeforeRuntimeMode(persistenceInput);
+          } catch (error) {
+            toastManager.add({
+              type: "error",
+              title: "Could not update access mode",
+              description: error instanceof Error ? error.message : "An unexpected error occurred.",
+            });
+            return false;
+          }
+        }
+        setComposerDraftRuntimeMode(threadId, nextMode);
+        if (isLocalDraftThread) {
+          setDraftThreadContext(threadId, { runtimeMode: nextMode });
+        }
+        scheduleComposerFocus();
+        return true;
+      });
+    },
+    [
+      isLocalDraftThread,
+      runtimeMode,
+      scheduleComposerFocus,
+      selectedModelSelection,
+      serverThread,
+      setComposerDraftRuntimeMode,
+      setDraftThreadContext,
+      threadId,
+    ],
+  );
+  const handleRuntimeModeChange = useCallback(
+    (mode: RuntimeMode) => {
+      void persistRuntimeModeChange(mode);
+    },
+    [persistRuntimeModeChange],
+  );
+
+  useEffect(() => {
+    if (
+      activeThread &&
+      runtimeMode === "auto" &&
+      !providerModelSupportsAutoRuntimeMode(
+        selectedProvider,
+        selectedRuntimeModel,
+        activeProviderStatus,
+      )
+    ) {
+      handleRuntimeModeChange("approval-required");
+    }
+  }, [
+    activeProviderStatus,
+    activeThread,
+    handleRuntimeModeChange,
+    runtimeMode,
+    selectedProvider,
+    selectedRuntimeModel,
+  ]);
+
+  const handleInteractionModeChange = useCallback(
+    (mode: ProviderInteractionMode) => {
+      if (mode === interactionMode) return;
+      setComposerDraftInteractionMode(threadId, mode);
+      if (isLocalDraftThread) {
+        setDraftThreadContext(threadId, { interactionMode: mode });
+      }
+      if (serverThread) {
+        const api = readNativeApi();
+        if (api) {
+          void api.orchestration
+            .dispatchCommand({
+              type: "thread.interaction-mode.set",
+              commandId: newCommandId(),
+              threadId,
+              interactionMode: mode,
+              createdAt: new Date().toISOString(),
+            })
+            .catch((error) => {
+              toastManager.add({
+                type: "error",
+                title: "Could not update interaction mode",
+                description:
+                  error instanceof Error ? error.message : "An unexpected error occurred.",
+              });
+            });
+        }
+      }
+      scheduleComposerFocus();
+    },
+    [
+      interactionMode,
+      isLocalDraftThread,
+      scheduleComposerFocus,
+      serverThread,
+      setComposerDraftInteractionMode,
+      setDraftThreadContext,
+      threadId,
+    ],
+  );
+  const toggleInteractionMode = useCallback(() => {
+    handleInteractionModeChange(interactionMode === "plan" ? "default" : "plan");
+  }, [handleInteractionModeChange, interactionMode]);
+  const resetInteractionMode = useCallback(() => {
+    handleInteractionModeChange("default");
+  }, [handleInteractionModeChange]);
+
+  const persistThreadSettingsForNextTurn = useCallback(
+    async (input: {
+      threadId: ThreadId;
+      createdAt: string;
+      modelSelection?: ModelSelection;
+      runtimeMode: RuntimeMode;
+      interactionMode: ProviderInteractionMode;
+    }) => {
+      if (!serverThread) {
+        return;
+      }
+      const api = readNativeApi();
+      if (!api) {
+        return;
+      }
+
+      await persistModelSelectionBeforeRuntimeMode({
+        currentModelSelection: serverThread.modelSelection,
+        ...(input.modelSelection !== undefined ? { nextModelSelection: input.modelSelection } : {}),
+        currentRuntimeMode: serverThread.runtimeMode,
+        nextRuntimeMode: input.runtimeMode,
+        persistModelSelection: (modelSelection) =>
+          api.orchestration.dispatchCommand({
+            type: "thread.meta.update",
+            commandId: newCommandId(),
+            threadId: input.threadId,
+            modelSelection,
+          }),
+        persistRuntimeMode: (runtimeMode) =>
+          api.orchestration.dispatchCommand({
+            type: "thread.runtime-mode.set",
+            commandId: newCommandId(),
+            threadId: input.threadId,
+            runtimeMode,
+            createdAt: input.createdAt,
+          }),
+      });
+
+      if (input.interactionMode !== serverThread.interactionMode) {
+        await api.orchestration.dispatchCommand({
+          type: "thread.interaction-mode.set",
+          commandId: newCommandId(),
+          threadId: input.threadId,
+          interactionMode: input.interactionMode,
+          createdAt: input.createdAt,
+        });
+      }
+    },
+    [serverThread],
+  );
+  return {
+    persistRuntimeModeChange,
+    handleRuntimeModeChange,
+    handleInteractionModeChange,
+    toggleInteractionMode,
+    resetInteractionMode,
+    persistThreadSettingsForNextTurn,
+  };
+}

--- a/apps/web/src/components/chat/useChatTimelineMessages.ts
+++ b/apps/web/src/components/chat/useChatTimelineMessages.ts
@@ -1,0 +1,238 @@
+import { MessageId, ThreadId } from "@synara/contracts";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import type { Thread } from "../../types";
+import { type ChatMessage } from "../../types";
+import {
+  collectUserMessageBlobPreviewUrls,
+  filterSidechatTranscriptMessages,
+  revokeBlobPreviewUrl,
+  revokeUserMessagePreviewUrls,
+} from "../ChatView.logic";
+import type { PendingAutomationConversation } from "./useChatAutomationSetup";
+const ATTACHMENT_PREVIEW_HANDOFF_TTL_MS = 5000;
+function revokeBlobPreviewUrlsAfterPaint(previewUrls: readonly string[]): void {
+  if (previewUrls.length === 0 || typeof window === "undefined") {
+    return;
+  }
+  window.requestAnimationFrame(() => {
+    window.setTimeout(() => {
+      for (const previewUrl of previewUrls) {
+        revokeBlobPreviewUrl(previewUrl);
+      }
+    }, 0);
+  });
+}
+interface ChatTimelineMessagesInput {
+  threadId: ThreadId;
+  activeThread: Thread | undefined;
+  pendingAutomationConversation: PendingAutomationConversation | null;
+}
+
+export function useChatTimelineMessages({
+  threadId,
+  activeThread,
+  pendingAutomationConversation,
+}: ChatTimelineMessagesInput) {
+  const [optimisticUserMessages, setOptimisticUserMessages] = useState<ChatMessage[]>([]);
+  const optimisticUserMessagesRef = useRef(optimisticUserMessages);
+  // Mirror during the commit, before events or async continuations can observe
+  // the new UI with the previous render's preview URLs.
+  useLayoutEffect(() => {
+    optimisticUserMessagesRef.current = optimisticUserMessages;
+  }, [optimisticUserMessages]);
+
+  // The pane stays mounted across thread switches. Clear outgoing optimistic
+  // messages before paint so they never appear in the newly selected thread.
+  useLayoutEffect(() => {
+    setOptimisticUserMessages((existing) => {
+      if (existing.length === 0) return existing;
+      for (const message of existing) {
+        revokeUserMessagePreviewUrls(message);
+      }
+      return [];
+    });
+  }, [threadId]);
+
+  const [attachmentPreviewHandoffByMessageId, setAttachmentPreviewHandoffByMessageId] = useState<
+    Record<string, string[]>
+  >({});
+
+  const attachmentPreviewHandoffByMessageIdRef = useRef<Record<string, string[]>>({});
+  const attachmentPreviewHandoffTimeoutByMessageIdRef = useRef<Record<string, number>>({});
+
+  useLayoutEffect(() => {
+    attachmentPreviewHandoffByMessageIdRef.current = attachmentPreviewHandoffByMessageId;
+  }, [attachmentPreviewHandoffByMessageId]);
+  const clearAttachmentPreviewHandoffs = useCallback(() => {
+    for (const timeoutId of Object.values(attachmentPreviewHandoffTimeoutByMessageIdRef.current)) {
+      window.clearTimeout(timeoutId);
+    }
+    attachmentPreviewHandoffTimeoutByMessageIdRef.current = {};
+    for (const previewUrls of Object.values(attachmentPreviewHandoffByMessageIdRef.current)) {
+      for (const previewUrl of previewUrls) {
+        revokeBlobPreviewUrl(previewUrl);
+      }
+    }
+    attachmentPreviewHandoffByMessageIdRef.current = {};
+    setAttachmentPreviewHandoffByMessageId({});
+  }, []);
+  useEffect(() => {
+    return () => {
+      clearAttachmentPreviewHandoffs();
+      for (const message of optimisticUserMessagesRef.current) {
+        revokeUserMessagePreviewUrls(message);
+      }
+    };
+  }, [clearAttachmentPreviewHandoffs]);
+  const handoffAttachmentPreviews = useCallback((messageId: MessageId, previewUrls: string[]) => {
+    if (previewUrls.length === 0) return;
+
+    const previousPreviewUrls = attachmentPreviewHandoffByMessageIdRef.current[messageId] ?? [];
+    const replacedPreviewUrls = previousPreviewUrls.filter(
+      (previewUrl) => !previewUrls.includes(previewUrl),
+    );
+    revokeBlobPreviewUrlsAfterPaint(replacedPreviewUrls);
+    setAttachmentPreviewHandoffByMessageId((existing) => {
+      const next = {
+        ...existing,
+        [messageId]: previewUrls,
+      };
+      attachmentPreviewHandoffByMessageIdRef.current = next;
+      return next;
+    });
+
+    const existingTimeout = attachmentPreviewHandoffTimeoutByMessageIdRef.current[messageId];
+    if (typeof existingTimeout === "number") {
+      window.clearTimeout(existingTimeout);
+    }
+    attachmentPreviewHandoffTimeoutByMessageIdRef.current[messageId] = window.setTimeout(() => {
+      const currentPreviewUrls = attachmentPreviewHandoffByMessageIdRef.current[messageId];
+      setAttachmentPreviewHandoffByMessageId((existing) => {
+        if (!(messageId in existing)) return existing;
+        const next = { ...existing };
+        delete next[messageId];
+        attachmentPreviewHandoffByMessageIdRef.current = next;
+        return next;
+      });
+      delete attachmentPreviewHandoffTimeoutByMessageIdRef.current[messageId];
+      // Let React swap the transcript back to persisted /attachments URLs before
+      // invalidating blob previews that may still be mounted in the old row.
+      if (currentPreviewUrls) {
+        revokeBlobPreviewUrlsAfterPaint(currentPreviewUrls);
+      }
+    }, ATTACHMENT_PREVIEW_HANDOFF_TTL_MS);
+  }, []);
+  const serverMessages = activeThread?.messages;
+  const timelineMessages = useMemo(() => {
+    const messages = filterSidechatTranscriptMessages(
+      serverMessages ?? [],
+      Boolean(activeThread?.sidechatSourceThreadId),
+    );
+    const serverMessagesWithPreviewHandoff =
+      Object.keys(attachmentPreviewHandoffByMessageId).length === 0
+        ? messages
+        : // Spread only fires for the few messages that actually changed;
+          // unchanged ones early-return their original reference.
+          // In-place mutation would break React's immutable state contract.
+          // oxlint-disable-next-line no-map-spread
+          messages.map((message) => {
+            if (
+              message.role !== "user" ||
+              !message.attachments ||
+              message.attachments.length === 0
+            ) {
+              return message;
+            }
+            const handoffPreviewUrls = attachmentPreviewHandoffByMessageId[message.id];
+            if (!handoffPreviewUrls || handoffPreviewUrls.length === 0) {
+              return message;
+            }
+
+            let changed = false;
+            let imageIndex = 0;
+            const attachments = message.attachments.map((attachment) => {
+              if (attachment.type !== "image") {
+                return attachment;
+              }
+              const handoffPreviewUrl = handoffPreviewUrls[imageIndex];
+              imageIndex += 1;
+              if (!handoffPreviewUrl || attachment.previewUrl === handoffPreviewUrl) {
+                return attachment;
+              }
+              changed = true;
+              return {
+                ...attachment,
+                previewUrl: handoffPreviewUrl,
+              };
+            });
+
+            return changed ? { ...message, attachments } : message;
+          });
+
+    // Ephemeral automation-setup bubbles render after everything else, at the tail.
+    // Gated on the originating thread so a same-pane switch never leaks the previous
+    // thread's setup into the newly rendered conversation (the reset effect runs after
+    // the first render, so the guard must be here too).
+    const setupBubbles =
+      pendingAutomationConversation && pendingAutomationConversation.threadId === threadId
+        ? pendingAutomationConversation.bubbles
+        : [];
+    // Optimistic messages exist only briefly after a send; skip the full-transcript
+    // id Set on the common (streaming-flush) path where there is nothing to reconcile.
+    let pendingMessages = optimisticUserMessages;
+    if (optimisticUserMessages.length > 0) {
+      const serverIds = new Set(serverMessagesWithPreviewHandoff.map((message) => message.id));
+      pendingMessages = optimisticUserMessages.filter((message) => !serverIds.has(message.id));
+    }
+    const withPending =
+      pendingMessages.length === 0
+        ? serverMessagesWithPreviewHandoff
+        : [...serverMessagesWithPreviewHandoff, ...pendingMessages];
+    return setupBubbles.length === 0 ? withPending : [...withPending, ...setupBubbles];
+  }, [
+    activeThread?.sidechatSourceThreadId,
+    serverMessages,
+    attachmentPreviewHandoffByMessageId,
+    optimisticUserMessages,
+    pendingAutomationConversation,
+    threadId,
+  ]);
+
+  useEffect(() => {
+    if (!activeThread?.id) return;
+    if (activeThread.messages.length === 0) {
+      return;
+    }
+    // No optimistic messages → nothing to reconcile; skip the full-transcript id Set
+    // this effect would otherwise rebuild on every streaming flush.
+    if (optimisticUserMessages.length === 0) {
+      return;
+    }
+    const serverIds = new Set(activeThread.messages.map((message) => message.id));
+    const removedMessages = optimisticUserMessages.filter((message) => serverIds.has(message.id));
+    if (removedMessages.length === 0) {
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      setOptimisticUserMessages((existing) =>
+        existing.filter((message) => !serverIds.has(message.id)),
+      );
+    }, 0);
+    for (const removedMessage of removedMessages) {
+      const previewUrls = collectUserMessageBlobPreviewUrls(removedMessage);
+      if (previewUrls.length > 0) {
+        handoffAttachmentPreviews(removedMessage.id, previewUrls);
+        continue;
+      }
+      revokeUserMessagePreviewUrls(removedMessage);
+    }
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [activeThread?.id, activeThread?.messages, handoffAttachmentPreviews, optimisticUserMessages]);
+  return {
+    timelineMessages,
+    optimisticUserMessages,
+    setOptimisticUserMessages,
+  };
+}

--- a/apps/web/src/components/chat/useChatTranscriptScroll.ts
+++ b/apps/web/src/components/chat/useChatTranscriptScroll.ts
@@ -1,0 +1,570 @@
+import type { LegendListRef } from "@legendapp/list/react";
+import { ThreadId } from "@synara/contracts";
+import { Debouncer } from "@tanstack/react-pacer";
+import type { RefObject } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent,
+  type WheelEvent,
+} from "react";
+import { flushSync } from "react-dom";
+import { isScrollContainerNearBottom } from "../../chat-scroll";
+import { isEditableEventTarget } from "../../lib/editableEventTarget";
+import type { TimelineEntry } from "../../session-logic";
+import { buildTranscriptAutoFollowSignal, buildTranscriptTailKey } from "../ChatView.logic";
+import {
+  scrollTranscriptToSettledEnd,
+  stopTranscriptScrollAtCurrentOffset,
+} from "./transcriptScroll";
+
+interface ChatTranscriptScrollInput {
+  activeThreadId: ThreadId | null;
+  legendListRef: RefObject<LegendListRef | null>;
+  timelineEntries: readonly TimelineEntry[];
+  hasStreamingAssistantText: boolean;
+  composerTranscriptInsetPx: number;
+  isInactiveSplitPane: boolean;
+}
+
+export function useChatTranscriptScroll({
+  activeThreadId,
+  legendListRef,
+  timelineEntries,
+  hasStreamingAssistantText,
+  composerTranscriptInsetPx,
+  isInactiveSplitPane,
+}: ChatTranscriptScrollInput) {
+  const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+
+  const isAtEndRef = useRef(true);
+  const autoFollowThreadIdRef = useRef<ThreadId | null>(null);
+  const pendingInteractionAnchorRef = useRef<{
+    element: HTMLElement;
+    top: number;
+  } | null>(null);
+  const pendingInteractionAnchorFrameRef = useRef<number | null>(null);
+  const showScrollDebouncer = useRef(
+    new Debouncer(() => setShowScrollToBottom(true), { wait: 150 }),
+  );
+
+  useEffect(() => {
+    const scrollDebouncer = showScrollDebouncer.current;
+    return () => {
+      scrollDebouncer.cancel();
+      const pendingFrame = pendingInteractionAnchorFrameRef.current;
+      if (pendingFrame !== null) {
+        window.cancelAnimationFrame(pendingFrame);
+      }
+    };
+  }, []);
+
+  const tailAnchorScrollInFlightRef = useRef(false);
+
+  // Scroll helpers stay list-owned so transcript updates stop bouncing through
+  // a separate measurement/controller loop during streaming.
+  // Guards isAtEndRef from flipping during reflow-induced scroll events that
+  // fire immediately after an explicit scrollToEnd.
+  const programmaticScrollUntilRef = useRef(0);
+  // User scroll gestures take ownership from streaming auto-follow. Ref updates
+  // are immediate; state updates project into the `followLiveOutput` prop.
+  const [isUserScrollDetached, setIsUserScrollDetached] = useState(false);
+  const isUserScrollDetachedRef = useRef(isUserScrollDetached);
+  const setTranscriptScrollDetached = useCallback((detached: boolean) => {
+    isUserScrollDetachedRef.current = detached;
+    setIsUserScrollDetached(detached);
+  }, []);
+  const pendingScrollGestureRef = useRef<{
+    container: HTMLElement;
+    scrollTop: number;
+    wasFollowing: boolean;
+    keyboard?: boolean;
+  } | null>(null);
+  const pendingScrollGestureFrameRef = useRef<number | null>(null);
+  const cancelPendingScrollGesture = useCallback(() => {
+    const frameId = pendingScrollGestureFrameRef.current;
+    if (frameId !== null) window.cancelAnimationFrame(frameId);
+    pendingScrollGestureFrameRef.current = null;
+    pendingScrollGestureRef.current = null;
+  }, []);
+  useEffect(() => cancelPendingScrollGesture, [activeThreadId, cancelPendingScrollGesture]);
+  // The arrow's smooth jump is followed by one exact settle after LegendList
+  // has measured the tail. A user gesture invalidates that pending settle.
+  const settledScrollRequestRef = useRef(0);
+  const settledScrollInFlightRef = useRef(false);
+  // Smooth only the first auto-follow after a send; live stream re-sticks stay cheap.
+  const animateNextAutoFollowScrollRef = useRef(false);
+  const scrollToEnd = useCallback(
+    (animated = false) => {
+      programmaticScrollUntilRef.current = performance.now() + 200;
+      legendListRef.current?.scrollToEnd?.({ animated });
+    },
+    [legendListRef],
+  );
+  const armTranscriptAutoFollow = useCallback(
+    (targetThreadId: ThreadId, animated = false) => {
+      cancelPendingScrollGesture();
+      autoFollowThreadIdRef.current = targetThreadId;
+      animateNextAutoFollowScrollRef.current = animated;
+      isAtEndRef.current = true;
+      setTranscriptScrollDetached(false);
+      showScrollDebouncer.current.cancel();
+      setShowScrollToBottom(false);
+    },
+    [cancelPendingScrollGesture, setTranscriptScrollDetached],
+  );
+  const clearTranscriptAutoFollow = useCallback(
+    (synchronous = false) => {
+      cancelPendingScrollGesture();
+      const scrollTarget = settledScrollInFlightRef.current ? legendListRef.current : null;
+      autoFollowThreadIdRef.current = null;
+      animateNextAutoFollowScrollRef.current = false;
+      settledScrollRequestRef.current += 1;
+      settledScrollInFlightRef.current = false;
+      programmaticScrollUntilRef.current = 0;
+      // A user scroll gesture takes over from any in-flight tail-anchor slide.
+      tailAnchorScrollInFlightRef.current = false;
+      const container = legendListRef.current?.getScrollableNode();
+      const detached =
+        container instanceof HTMLElement && container.scrollHeight > container.clientHeight + 1;
+      if (detached !== isUserScrollDetachedRef.current) {
+        // Disable list-owned follow before an already queued animation frame can
+        // run. Continuous wheel events otherwise defer this prop update in React.
+        if (synchronous) flushSync(() => setTranscriptScrollDetached(detached));
+        else setTranscriptScrollDetached(detached);
+      }
+      if (scrollTarget) {
+        void stopTranscriptScrollAtCurrentOffset(scrollTarget);
+      }
+    },
+    [legendListRef, cancelPendingScrollGesture, setTranscriptScrollDetached],
+  );
+  const onTranscriptNavigate = useCallback(() => {
+    // Search can navigate from an effect. Its ref ownership changes immediately,
+    // while React applies the list prop before the animated jump's next frame.
+    clearTranscriptAutoFollow();
+    isAtEndRef.current = false;
+    showScrollDebouncer.current.maybeExecute();
+  }, [clearTranscriptAutoFollow]);
+  const transcriptMessageCount = useMemo(
+    () => timelineEntries.filter((entry) => entry.kind === "message").length,
+    [timelineEntries],
+  );
+  const latestTranscriptMessage = useMemo(() => {
+    for (let index = timelineEntries.length - 1; index >= 0; index -= 1) {
+      const entry = timelineEntries[index];
+      if (entry?.kind === "message") {
+        return entry.message;
+      }
+    }
+    return null;
+  }, [timelineEntries]);
+  const transcriptTailKey = buildTranscriptTailKey(latestTranscriptMessage);
+  const transcriptAutoFollowSignal = buildTranscriptAutoFollowSignal({
+    messageCount: transcriptMessageCount,
+    tailKey: transcriptTailKey,
+  });
+  const onIsAtEndChange = useCallback(
+    (isAtEnd: boolean) => {
+      const container = legendListRef.current?.getScrollableNode();
+      const pending = pendingScrollGestureRef.current;
+      if (pending?.keyboard && container === pending.container) {
+        // Native key scrolling can begin after keyup and after multiple frames.
+        if (container.scrollTop >= pending.scrollTop || isScrollContainerNearBottom(container, 1))
+          return;
+        pendingScrollGestureRef.current = null;
+      }
+      if (!isAtEnd && !isUserScrollDetachedRef.current) {
+        if (
+          hasStreamingAssistantText &&
+          container instanceof HTMLElement &&
+          !isScrollContainerNearBottom(container, 1) &&
+          !tailAnchorScrollInFlightRef.current &&
+          !settledScrollInFlightRef.current &&
+          performance.now() >= programmaticScrollUntilRef.current
+        ) {
+          const request = settledScrollRequestRef.current;
+          programmaticScrollUntilRef.current = performance.now() + 200;
+          window.requestAnimationFrame(() => {
+            if (
+              request === settledScrollRequestRef.current &&
+              !isUserScrollDetachedRef.current &&
+              !tailAnchorScrollInFlightRef.current &&
+              !settledScrollInFlightRef.current &&
+              legendListRef.current?.getScrollableNode() === container &&
+              !isScrollContainerNearBottom(container, 1)
+            )
+              scrollToEnd();
+          });
+        }
+        return;
+      }
+      if (
+        !isAtEnd &&
+        (tailAnchorScrollInFlightRef.current ||
+          settledScrollInFlightRef.current ||
+          performance.now() < programmaticScrollUntilRef.current)
+      ) {
+        return;
+      }
+      // The list can report its content end while the viewport is still inside
+      // the bottom inset. A detached reader resumes only at the actual bottom.
+      const atEnd =
+        isAtEnd &&
+        (!isUserScrollDetachedRef.current ||
+          !(container instanceof HTMLElement) ||
+          isScrollContainerNearBottom(container, 1));
+      if (atEnd === isAtEndRef.current && (!atEnd || !isUserScrollDetachedRef.current)) return;
+      // A gesture can detach without changing the previous edge notification.
+      if (atEnd) {
+        setTranscriptScrollDetached(false);
+        showScrollDebouncer.current.cancel();
+        setShowScrollToBottom(false);
+      } else {
+        // A changing layout can temporarily leave the end during output. Only
+        // user gestures detach live follow; a geometry notification must not.
+        showScrollDebouncer.current.maybeExecute();
+      }
+      isAtEndRef.current = atEnd;
+    },
+    [legendListRef, hasStreamingAssistantText, scrollToEnd, setTranscriptScrollDetached],
+  );
+  const cancelPendingInteractionAnchorAdjustment = useCallback(() => {
+    const pendingFrame = pendingInteractionAnchorFrameRef.current;
+    if (pendingFrame === null) return;
+    pendingInteractionAnchorFrameRef.current = null;
+    window.cancelAnimationFrame(pendingFrame);
+  }, []);
+  const onMessagesClickCaptureBase = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      const scrollContainer = legendListRef.current?.getScrollableNode?.();
+      if (!(scrollContainer instanceof HTMLElement) || !(event.target instanceof Element)) return;
+
+      const trigger = event.target.closest<HTMLElement>(
+        "button, summary, [role='button'], [data-scroll-anchor-target]",
+      );
+      if (!trigger || !scrollContainer.contains(trigger)) return;
+      if (trigger.closest("[data-scroll-anchor-ignore]")) return;
+
+      pendingInteractionAnchorRef.current = {
+        element: trigger,
+        top: trigger.getBoundingClientRect().top,
+      };
+
+      cancelPendingInteractionAnchorAdjustment();
+      pendingInteractionAnchorFrameRef.current = window.requestAnimationFrame(() => {
+        pendingInteractionAnchorFrameRef.current = null;
+        const anchor = pendingInteractionAnchorRef.current;
+        pendingInteractionAnchorRef.current = null;
+        const activeScrollContainer = legendListRef.current?.getScrollableNode?.();
+        if (!(activeScrollContainer instanceof HTMLElement) || !anchor) return;
+        if (!anchor.element.isConnected || !activeScrollContainer.contains(anchor.element)) return;
+
+        const nextTop = anchor.element.getBoundingClientRect().top;
+        const delta = nextTop - anchor.top;
+        if (Math.abs(delta) < 0.5) return;
+
+        activeScrollContainer.scrollTop += delta;
+      });
+    },
+    [legendListRef, cancelPendingInteractionAnchorAdjustment],
+  );
+  const onMessagesPointerDownBase = useCallback(() => {
+    clearTranscriptAutoFollow(true);
+  }, [clearTranscriptAutoFollow]);
+  const releaseTranscriptScrollGesture = useCallback(() => {
+    const state = legendListRef.current?.getState();
+    if (state) onIsAtEndChange(state.isAtEnd);
+  }, [legendListRef, onIsAtEndChange]);
+  const onMessagesPointerCancelBase = releaseTranscriptScrollGesture;
+  const onMessagesPointerUpBase = releaseTranscriptScrollGesture;
+  const onMessagesScrollBase = useCallback(() => {}, []);
+  const onMessagesTouchEndBase = releaseTranscriptScrollGesture;
+  const onMessagesTouchMoveBase = useCallback(() => {
+    clearTranscriptAutoFollow(true);
+  }, [clearTranscriptAutoFollow]);
+  const onMessagesTouchStartBase = useCallback(() => {
+    clearTranscriptAutoFollow(true);
+  }, [clearTranscriptAutoFollow]);
+  const onMessagesScrollGesture = useCallback(
+    (upward: boolean) => {
+      const container = legendListRef.current?.getScrollableNode();
+      if (!(container instanceof HTMLElement)) return;
+      if (!upward && isAtEndRef.current && isScrollContainerNearBottom(container, 1)) return;
+      const pending = pendingScrollGestureRef.current;
+      const origin =
+        pending?.container === container
+          ? pending
+          : {
+              container,
+              scrollTop: container.scrollTop,
+              wasFollowing:
+                isAtEndRef.current &&
+                !isUserScrollDetachedRef.current &&
+                (!upward || isScrollContainerNearBottom(container, 1)),
+            };
+      clearTranscriptAutoFollow(true);
+      pendingScrollGestureRef.current = origin;
+      // Native scrolling can settle on the next rendering pass. Keep one
+      // pending check per gesture burst, preserving ownership from its first event.
+      pendingScrollGestureFrameRef.current = window.requestAnimationFrame(() => {
+        pendingScrollGestureFrameRef.current = window.requestAnimationFrame(() => {
+          pendingScrollGestureFrameRef.current = null;
+          pendingScrollGestureRef.current = null;
+          if (origin.wasFollowing && container.scrollTop >= origin.scrollTop) {
+            // A nested or no-op wheel must not strand follow, even if new text
+            // increased the distance from the bottom while the gesture settled.
+            setTranscriptScrollDetached(false);
+            onIsAtEndChange(true);
+            scrollToEnd();
+          } else {
+            releaseTranscriptScrollGesture();
+          }
+        });
+      });
+    },
+    [
+      legendListRef,
+      clearTranscriptAutoFollow,
+      onIsAtEndChange,
+      releaseTranscriptScrollGesture,
+      scrollToEnd,
+      setTranscriptScrollDetached,
+    ],
+  );
+  const onMessagesWheelBase = useCallback(
+    (event: WheelEvent<HTMLDivElement>) => {
+      // Horizontal scroll, zoom, and scrolling down at the end do not leave it.
+      if (event.ctrlKey || event.deltaY === 0) return;
+      onMessagesScrollGesture(event.deltaY < 0);
+    },
+    [onMessagesScrollGesture],
+  );
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      const container = legendListRef.current?.getScrollableNode();
+      if (
+        !(container instanceof HTMLElement) ||
+        !(event.target instanceof Element) ||
+        !container.contains(event.target) ||
+        event.defaultPrevented ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.altKey ||
+        isEditableEventTarget(event)
+      )
+        return;
+      if (!["ArrowUp", "ArrowDown", "PageUp", "PageDown", "Home", "End", " "].includes(event.key))
+        return;
+      if (event.key === " " && event.target.closest("button, a, [role='button']")) return;
+      const upward =
+        event.key === "ArrowUp" ||
+        event.key === "PageUp" ||
+        event.key === "Home" ||
+        (event.key === " " && event.shiftKey);
+      if (upward) {
+        if (container.scrollTop <= 0) return;
+        const pending = pendingScrollGestureRef.current;
+        const origin =
+          pending?.keyboard && pending.container === container
+            ? pending
+            : {
+                container,
+                scrollTop: container.scrollTop,
+                wasFollowing: isAtEndRef.current && !isUserScrollDetachedRef.current,
+                keyboard: true,
+              };
+        clearTranscriptAutoFollow(true);
+        pendingScrollGestureRef.current = origin;
+        isAtEndRef.current = false;
+        showScrollDebouncer.current.maybeExecute();
+      } else {
+        onMessagesScrollGesture(false);
+      }
+    };
+    const releaseKeyboardGesture = () => {
+      const origin = pendingScrollGestureRef.current;
+      if (!origin?.keyboard) return;
+      const previousFrame = pendingScrollGestureFrameRef.current;
+      if (previousFrame !== null) window.cancelAnimationFrame(previousFrame);
+      // Native key scrolling may begin after keyup. Give it rendering time to
+      // move, then recover a no-op/nested gesture instead of holding indefinitely.
+      const deadline = performance.now() + 150;
+      const check = () => {
+        pendingScrollGestureFrameRef.current = null;
+        if (pendingScrollGestureRef.current !== origin) return;
+        const movedUp = origin.container.scrollTop < origin.scrollTop - 1;
+        if (!movedUp && performance.now() < deadline) {
+          pendingScrollGestureFrameRef.current = window.requestAnimationFrame(check);
+          return;
+        }
+        pendingScrollGestureRef.current = null;
+        if (origin.wasFollowing && !movedUp) {
+          setTranscriptScrollDetached(false);
+          onIsAtEndChange(true);
+          scrollToEnd();
+        } else {
+          releaseTranscriptScrollGesture();
+        }
+      };
+      pendingScrollGestureFrameRef.current = window.requestAnimationFrame(check);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", releaseKeyboardGesture);
+    window.addEventListener("blur", releaseKeyboardGesture);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", releaseKeyboardGesture);
+      window.removeEventListener("blur", releaseKeyboardGesture);
+    };
+  }, [
+    legendListRef,
+    clearTranscriptAutoFollow,
+    onIsAtEndChange,
+    onMessagesScrollGesture,
+    releaseTranscriptScrollGesture,
+    scrollToEnd,
+    setTranscriptScrollDetached,
+  ]);
+  useLayoutEffect(() => {
+    const shouldFollowPendingTurn =
+      activeThreadId !== null && autoFollowThreadIdRef.current === activeThreadId;
+    if (isUserScrollDetachedRef.current || (!isAtEndRef.current && !shouldFollowPendingTurn)) {
+      return;
+    }
+    // Re-apply the bottom stick only for real transcript messages; tool/work
+    // rows can arrive quickly and should not churn scroll/layout work.
+    const frameId = window.requestAnimationFrame(() => {
+      // The tail-anchor slide owns the scroll after a send; a re-snap here
+      // would hard-jump past the smooth slide mid-flight. Once the anchor
+      // settles the spacer keeps the end position exact, so nothing is missed.
+      if (tailAnchorScrollInFlightRef.current || isUserScrollDetachedRef.current) {
+        return;
+      }
+      const shouldAnimate = animateNextAutoFollowScrollRef.current;
+      animateNextAutoFollowScrollRef.current = false;
+      scrollToEnd(shouldAnimate);
+    });
+    return () => {
+      window.cancelAnimationFrame(frameId);
+    };
+  }, [activeThreadId, scrollToEnd, transcriptAutoFollowSignal]);
+
+  // A composer that grows (attachments, approval cards, queued turns) eats into the
+  // transcript's bottom content inset, which would push the tail behind the frosted
+  // surface. Re-stick a transcript that was already parked at the end.
+  //
+  // This is driven by the *committed* inset rather than by a ResizeObserver on the
+  // composer: the inset lands a render after the measurement, so a scroll scheduled
+  // from the observer would race the padding it is supposed to compensate for. Here
+  // the new padding is already in the DOM, so the pre-resize viewport is simply the
+  // current one with the inset delta backed out.
+  const previousComposerTranscriptInsetRef = useRef({
+    threadId: activeThreadId ?? null,
+    insetPx: composerTranscriptInsetPx,
+  });
+  useLayoutEffect(() => {
+    const threadId = activeThreadId ?? null;
+    const previous = previousComposerTranscriptInsetRef.current;
+    previousComposerTranscriptInsetRef.current = {
+      threadId,
+      insetPx: composerTranscriptInsetPx,
+    };
+    if (previous.threadId !== threadId) return;
+
+    const insetDeltaPx = composerTranscriptInsetPx - previous.insetPx;
+    if (isInactiveSplitPane || Math.abs(insetDeltaPx) < 0.5) return;
+
+    const scrollContainer = legendListRef.current?.getScrollableNode?.();
+    if (!(scrollContainer instanceof HTMLElement)) return;
+    const wasNearEndBeforeResize = isScrollContainerNearBottom({
+      scrollTop: scrollContainer.scrollTop,
+      clientHeight: scrollContainer.clientHeight,
+      scrollHeight: scrollContainer.scrollHeight - insetDeltaPx,
+    });
+    if (!wasNearEndBeforeResize) return;
+
+    // Compensate by the exact inset delta rather than asking the list to scroll to its
+    // end: LegendList re-measures the padded viewport on its own schedule, so an
+    // end-scroll issued in this commit would aim at the pre-padding content height and
+    // land a composer-growth short of the tail.
+    programmaticScrollUntilRef.current = performance.now() + 200;
+    scrollContainer.scrollTop += insetDeltaPx;
+  }, [legendListRef, activeThreadId, composerTranscriptInsetPx, isInactiveSplitPane]);
+
+  const onScrollToBottom = useCallback(() => {
+    cancelPendingScrollGesture();
+    tailAnchorScrollInFlightRef.current = false;
+    setTranscriptScrollDetached(false);
+    isAtEndRef.current = true;
+    showScrollDebouncer.current.cancel();
+    setShowScrollToBottom(false);
+    const target = legendListRef.current;
+    if (!target) {
+      return;
+    }
+
+    const requestId = settledScrollRequestRef.current + 1;
+    settledScrollRequestRef.current = requestId;
+    settledScrollInFlightRef.current = true;
+    programmaticScrollUntilRef.current = performance.now() + 200;
+    void scrollTranscriptToSettledEnd({
+      target,
+      isCurrent: () =>
+        settledScrollRequestRef.current === requestId && legendListRef.current === target,
+      beforeFinalScroll: () => {
+        programmaticScrollUntilRef.current = performance.now() + 200;
+      },
+    })
+      .then((settled) => {
+        if (settledScrollRequestRef.current !== requestId) {
+          return;
+        }
+        settledScrollInFlightRef.current = false;
+        if (!settled) {
+          return;
+        }
+        isAtEndRef.current = true;
+        showScrollDebouncer.current.cancel();
+        setShowScrollToBottom(false);
+      })
+      .catch(() => {
+        if (settledScrollRequestRef.current === requestId) {
+          settledScrollInFlightRef.current = false;
+        }
+      });
+  }, [legendListRef, cancelPendingScrollGesture, setTranscriptScrollDetached]);
+  useEffect(() => {
+    isAtEndRef.current = true;
+    settledScrollRequestRef.current += 1;
+    settledScrollInFlightRef.current = false;
+    programmaticScrollUntilRef.current = 0;
+    setTranscriptScrollDetached(false);
+    showScrollDebouncer.current.cancel();
+    const settle = window.setTimeout(() => setShowScrollToBottom(false), 0);
+    return () => window.clearTimeout(settle);
+  }, [activeThreadId, setTranscriptScrollDetached]);
+
+  return {
+    showScrollToBottom,
+    isUserScrollDetached,
+    tailAnchorScrollInFlightRef,
+    armTranscriptAutoFollow,
+    onTranscriptNavigate,
+    onIsAtEndChange,
+    onScrollToBottom,
+    onMessagesClickCaptureBase,
+    onMessagesPointerDownBase,
+    onMessagesPointerUpBase,
+    onMessagesPointerCancelBase,
+    onMessagesScrollBase,
+    onMessagesTouchEndBase,
+    onMessagesTouchMoveBase,
+    onMessagesTouchStartBase,
+    onMessagesWheelBase,
+  };
+}

--- a/apps/web/src/components/chat/useChatTurnExecution.ts
+++ b/apps/web/src/components/chat/useChatTurnExecution.ts
@@ -1,0 +1,860 @@
+import type {
+  ProjectId,
+  ProjectScript,
+  ProviderMentionReference,
+  ProviderSkillReference,
+} from "@synara/contracts";
+import {
+  DEFAULT_MODEL_BY_PROVIDER,
+  MessageId,
+  ProviderInteractionMode,
+  RuntimeMode,
+  ThreadId,
+  type ModelSelection,
+  type ProviderStartOptions,
+} from "@synara/contracts";
+import { buildTemporaryWorktreeBranchName } from "@synara/shared/git";
+import { getDefaultModel } from "@synara/shared/model";
+import { providerSupportsNativeTurnSteering } from "@synara/shared/providerMetadata";
+import { useCallback } from "react";
+import { promoteThreadCreate } from "~/lib/threadCreatePromotion";
+import { newCommandId, randomUUID } from "~/lib/utils";
+import { readNativeApi } from "~/nativeApi";
+import { dispatchThreadNotes } from "~/pinnedMessages";
+import {
+  mergeProjectInstructionsIntoThreadNotes,
+  useProjectInstructionsStore,
+} from "~/projectInstructionsStore";
+import { dispatchThreadGoal } from "~/threadGoal";
+import { collapseExpandedComposerCursor, detectComposerTrigger } from "../../composer-logic";
+import { type DraftThreadEnvMode, type QueuedComposerChatTurn } from "../../composerDraftStore";
+import {
+  cloneComposerImageAttachment,
+  stageUploadComposerAttachments,
+} from "../../lib/composerSend";
+import { armQueuedComposerSteerGate } from "../../lib/queuedComposerDrain";
+import { clearPendingTurnDispatch } from "../../pendingTurnDispatch";
+import { buildModelSelection } from "../../providerModelOptions";
+import { type Thread } from "../../types";
+import {
+  WorktreeSetupCancelledError,
+  createWorktreeSetupResolution,
+  revokeUserMessagePreviewUrls,
+  runWorktreeCreationFlow,
+} from "../ChatView.logic";
+import type { ChatTurnSubmissionInput } from "./chatSendTypes";
+import { waitForSetupScriptTerminalActivity } from "./projectScriptRuntime";
+interface PreparedChatTurn {
+  nextThreadEnvMode: DraftThreadEnvMode;
+  nextThreadBranch: string | null;
+  nextThreadWorktreePath: string | null;
+  nextAssociatedWorktreePath: string | null;
+  nextAssociatedWorktreeBranch: string | null;
+  nextAssociatedWorktreeRef: string | null;
+  api: NonNullable<ReturnType<typeof readNativeApi>>;
+  targetProjectCwdForSend: string;
+  threadIdForSend: ThreadId;
+  worktreeSetupResolution: ReturnType<typeof createWorktreeSetupResolution> | null;
+  baseBranchForWorktree: string | null;
+  worktreeCopiesLocalChanges: boolean;
+  worktreeSetupScriptName: string | null;
+  selectedModelSelectionForSend: ModelSelection;
+  selectedModelForSend: string;
+  targetProjectDefaultModelSelectionForSend: ModelSelection | null;
+  targetProjectIdForSend: ProjectId;
+  title: string;
+  nextRuntimeModeForSend: RuntimeMode;
+  interactionModeForSend: ProviderInteractionMode;
+  nextThreadWorkingDirectory: string | null;
+  activeThread: Thread;
+  targetProjectKindForSend: "project" | "chat" | "studio";
+  setupScriptForWorktree: ProjectScript | null;
+  messageCreatedAt: string;
+  turnAttachmentsPromise: ReturnType<typeof stageUploadComposerAttachments>;
+  messageIdForSend: MessageId;
+  providerOptionsForDispatchForSend: ProviderStartOptions | undefined;
+  outgoingMessageText: string;
+  mentionedSkillsForSend: ProviderSkillReference[];
+  mentionedPluginMentionsForSend: ProviderMentionReference[];
+  dispatchMode: "queue" | "steer";
+  sourceProposedPlanForSend: QueuedComposerChatTurn["sourceProposedPlan"];
+  shouldResumeSettledLocalThread: boolean;
+  currentActiveGitBranchForSend: string | null;
+  queuedChatTurn: QueuedComposerChatTurn | null;
+  promptForSend: string;
+  composerImagesSnapshot: ChatTurnSubmissionInput["composerImages"];
+  composerFilesSnapshot: ChatTurnSubmissionInput["composerFiles"];
+  composerAssistantSelectionsSnapshot: ChatTurnSubmissionInput["composerAssistantSelections"];
+  composerBrowserAnnotationsSnapshot: ChatTurnSubmissionInput["composerBrowserAnnotations"];
+  composerFileCommentsSnapshot: ChatTurnSubmissionInput["composerFileComments"];
+  composerTerminalContextsSnapshot: ChatTurnSubmissionInput["composerTerminalContexts"];
+  composerPastedTextsSnapshot: ChatTurnSubmissionInput["composerPastedTexts"];
+  composerPullRequestContextsSnapshot: ChatTurnSubmissionInput["composerPullRequestContexts"];
+  composerSkillsSnapshot: ProviderSkillReference[];
+  composerMentionsSnapshot: ProviderMentionReference[];
+}
+type ChatTurnExecutionInput = Pick<
+  ChatTurnSubmissionInput,
+  | "isServerThread"
+  | "setStoreThreadWorkspace"
+  | "clearLocalDispatchWorktreeSetup"
+  | "createWorktreeMutation"
+  | "beginLocalDispatch"
+  | "isLocalDraftThread"
+  | "threadNotes"
+  | "runProjectScript"
+  | "persistThreadSettingsForNextTurn"
+  | "rememberCustomBinaryPathForDispatch"
+  | "assistantDeliveryMode"
+  | "setSettledThreadBranchWarningDismissedThreadId"
+  | "armLocalDispatchAckFallback"
+  | "setQueuedSteerGate"
+  | "threadId"
+  | "planSidebarDismissedForTurnRef"
+  | "setPlanSidebarOpen"
+  | "setRestoredQueuedSourceProposedPlan"
+  | "failLocalDispatchWorktreeSetup"
+  | "setOptimisticUserMessages"
+  | "promptRef"
+  | "composerImagesRef"
+  | "composerFilesRef"
+  | "composerAssistantSelectionsRef"
+  | "composerBrowserAnnotationsRef"
+  | "composerFileCommentsRef"
+  | "composerTerminalContextsRef"
+  | "composerPastedTextsRef"
+  | "composerPullRequestContextsRef"
+  | "setPrompt"
+  | "setComposerCursor"
+  | "addComposerImagesToDraft"
+  | "addComposerFilesToDraft"
+  | "addComposerAssistantSelectionToDraft"
+  | "addComposerDraftBrowserAnnotations"
+  | "addComposerFileCommentToDraft"
+  | "addComposerTerminalContextsToDraft"
+  | "addComposerPastedTextsToDraft"
+  | "addComposerPullRequestContextsToDraft"
+  | "updateSelectedComposerSkills"
+  | "updateSelectedComposerMentions"
+  | "setComposerTrigger"
+  | "setThreadError"
+  | "sendInFlightRef"
+  | "worktreeSetupResolutionRef"
+  | "scheduleFailedWorktreeSetupDispatchReset"
+  | "resetLocalDispatch"
+>;
+
+export function useChatTurnExecution({
+  isServerThread,
+  setStoreThreadWorkspace,
+  clearLocalDispatchWorktreeSetup,
+  createWorktreeMutation,
+  beginLocalDispatch,
+  isLocalDraftThread,
+  threadNotes,
+  runProjectScript,
+  persistThreadSettingsForNextTurn,
+  rememberCustomBinaryPathForDispatch,
+  assistantDeliveryMode,
+  setSettledThreadBranchWarningDismissedThreadId,
+  armLocalDispatchAckFallback,
+  setQueuedSteerGate,
+  threadId,
+  planSidebarDismissedForTurnRef,
+  setPlanSidebarOpen,
+  setRestoredQueuedSourceProposedPlan,
+  failLocalDispatchWorktreeSetup,
+  setOptimisticUserMessages,
+  promptRef,
+  composerImagesRef,
+  composerFilesRef,
+  composerAssistantSelectionsRef,
+  composerBrowserAnnotationsRef,
+  composerFileCommentsRef,
+  composerTerminalContextsRef,
+  composerPastedTextsRef,
+  composerPullRequestContextsRef,
+  setPrompt,
+  setComposerCursor,
+  addComposerImagesToDraft,
+  addComposerFilesToDraft,
+  addComposerAssistantSelectionToDraft,
+  addComposerDraftBrowserAnnotations,
+  addComposerFileCommentToDraft,
+  addComposerTerminalContextsToDraft,
+  addComposerPastedTextsToDraft,
+  addComposerPullRequestContextsToDraft,
+  updateSelectedComposerSkills,
+  updateSelectedComposerMentions,
+  setComposerTrigger,
+  setThreadError,
+  sendInFlightRef,
+  worktreeSetupResolutionRef,
+  scheduleFailedWorktreeSetupDispatchReset,
+  resetLocalDispatch,
+}: ChatTurnExecutionInput) {
+  return useCallback(
+    async (preparedTurn: PreparedChatTurn): Promise<boolean> => {
+      let {
+        nextThreadEnvMode,
+        nextThreadBranch,
+        nextThreadWorktreePath,
+        nextAssociatedWorktreePath,
+        nextAssociatedWorktreeBranch,
+        nextAssociatedWorktreeRef,
+        api,
+        targetProjectCwdForSend,
+        threadIdForSend,
+        worktreeSetupResolution,
+        baseBranchForWorktree,
+        worktreeCopiesLocalChanges,
+        worktreeSetupScriptName,
+        selectedModelSelectionForSend,
+        selectedModelForSend,
+        targetProjectDefaultModelSelectionForSend,
+        targetProjectIdForSend,
+        title,
+        nextRuntimeModeForSend,
+        interactionModeForSend,
+        nextThreadWorkingDirectory,
+        activeThread,
+        targetProjectKindForSend,
+        setupScriptForWorktree,
+        messageCreatedAt,
+        turnAttachmentsPromise,
+        messageIdForSend,
+        providerOptionsForDispatchForSend,
+        outgoingMessageText,
+        mentionedSkillsForSend,
+        mentionedPluginMentionsForSend,
+        dispatchMode,
+        sourceProposedPlanForSend,
+        shouldResumeSettledLocalThread,
+        currentActiveGitBranchForSend,
+        queuedChatTurn,
+        promptForSend,
+        composerImagesSnapshot,
+        composerFilesSnapshot,
+        composerAssistantSelectionsSnapshot,
+        composerBrowserAnnotationsSnapshot,
+        composerFileCommentsSnapshot,
+        composerTerminalContextsSnapshot,
+        composerPastedTextsSnapshot,
+        composerPullRequestContextsSnapshot,
+        composerSkillsSnapshot,
+        composerMentionsSnapshot,
+      } = preparedTurn;
+
+      let createdServerThreadForLocalDraft = false;
+      let createdWorktreeForSendPath: string | null = null;
+      let switchedToLocalCheckout = false;
+      let turnStartSucceeded = false;
+      let settledLocalBranchUpdatedForSend = false;
+      await (async () => {
+        // "Work locally" from the setup card: drop any prepared worktree and
+        // point the send (and the thread's metadata) back at the project
+        // checkout. Awaited before the turn dispatch so the session resolves the
+        // local cwd instead of the abandoned worktree.
+        const applyWorkLocallySwitch = async () => {
+          switchedToLocalCheckout = true;
+          nextThreadEnvMode = "local";
+          nextThreadBranch = null;
+          nextThreadWorktreePath = null;
+          nextAssociatedWorktreePath = null;
+          nextAssociatedWorktreeBranch = null;
+          nextAssociatedWorktreeRef = null;
+          const worktreePathToRemove = createdWorktreeForSendPath;
+          createdWorktreeForSendPath = null;
+          if (worktreePathToRemove) {
+            // Best-effort: a leftover worktree is inert and reclaimable later.
+            void api.git
+              .removeWorktree({
+                cwd: targetProjectCwdForSend,
+                path: worktreePathToRemove,
+                force: true,
+                reclaimTemporaryBranch: true,
+              })
+              .catch(() => undefined);
+          }
+          if (isServerThread || createdServerThreadForLocalDraft) {
+            await api.orchestration.dispatchCommand({
+              type: "thread.meta.update",
+              commandId: newCommandId(),
+              threadId: threadIdForSend,
+              envMode: "local",
+              branch: null,
+              worktreePath: null,
+              associatedWorktreePath: null,
+              associatedWorktreeBranch: null,
+              associatedWorktreeRef: null,
+            });
+            setStoreThreadWorkspace(threadIdForSend, {
+              envMode: "local",
+              branch: null,
+              worktreePath: null,
+              associatedWorktreePath: null,
+              associatedWorktreeBranch: null,
+              associatedWorktreeRef: null,
+            });
+          }
+          clearLocalDispatchWorktreeSetup();
+        };
+
+        // Honors a Cancel / Work locally choice at a step boundary. Cancel
+        // unwinds through the shared send-failure path below; the cancelled
+        // sentinel keeps that path from painting error state.
+        const consumeWorktreeSetupResolution = async () => {
+          const action = worktreeSetupResolution?.action ?? null;
+          if (action === null || switchedToLocalCheckout) {
+            return;
+          }
+          if (action === "cancel") {
+            throw new WorktreeSetupCancelledError();
+          }
+          await applyWorkLocallySwitch();
+        };
+
+        // On first message: lock in branch + create worktree if needed.
+        if (baseBranchForWorktree && worktreeSetupResolution) {
+          // The server streams each real setup phase (branch → worktree → copy
+          // changes); advance the card's rows from those events instead of
+          // letting one row spin through the whole creation.
+          const worktreeProgressId = randomUUID();
+          const creationFlow = await runWorktreeCreationFlow({
+            progressId: worktreeProgressId,
+            subscribeToProgress: (listener) => api.git.onWorktreeSetupProgress(listener),
+            startCreation: () =>
+              createWorktreeMutation.mutateAsync({
+                cwd: targetProjectCwdForSend,
+                ref: baseBranchForWorktree,
+                newBranch: buildTemporaryWorktreeBranchName(),
+                progressId: worktreeProgressId,
+                ...(worktreeCopiesLocalChanges ? { copyChangesFrom: targetProjectCwdForSend } : {}),
+              }),
+            resolution: worktreeSetupResolution,
+            onCreationStep: (stepId) =>
+              beginLocalDispatch({
+                worktreeSetupStepId: stepId,
+                setupScriptName: worktreeSetupScriptName,
+                copyLocalChanges: worktreeCopiesLocalChanges,
+              }),
+            removeWorktree: (worktreePath) =>
+              api.git.removeWorktree({
+                cwd: targetProjectCwdForSend,
+                path: worktreePath,
+                force: true,
+                reclaimTemporaryBranch: true,
+              }),
+          });
+          if (creationFlow.outcome === "resolved") {
+            await consumeWorktreeSetupResolution();
+          } else {
+            const result = creationFlow.result;
+            beginLocalDispatch({
+              worktreeSetupStepId: "prepare-thread",
+              setupScriptName: worktreeSetupScriptName,
+              copyLocalChanges: worktreeCopiesLocalChanges,
+            });
+            nextThreadBranch = result.worktree.branch;
+            nextThreadWorktreePath = result.worktree.path;
+            createdWorktreeForSendPath = result.worktree.path;
+            const nextAssociatedWorktree = {
+              associatedWorktreePath: result.worktree.path,
+              associatedWorktreeBranch: result.worktree.branch,
+              associatedWorktreeRef: result.worktree.ref,
+            };
+            nextAssociatedWorktreePath = nextAssociatedWorktree.associatedWorktreePath;
+            nextAssociatedWorktreeBranch = nextAssociatedWorktree.associatedWorktreeBranch;
+            nextAssociatedWorktreeRef = nextAssociatedWorktree.associatedWorktreeRef;
+            if (isServerThread) {
+              await api.orchestration.dispatchCommand({
+                type: "thread.meta.update",
+                commandId: newCommandId(),
+                threadId: threadIdForSend,
+                envMode: "worktree",
+                branch: result.worktree.branch,
+                worktreePath: result.worktree.path,
+                associatedWorktreePath: nextAssociatedWorktree.associatedWorktreePath,
+                associatedWorktreeBranch: nextAssociatedWorktree.associatedWorktreeBranch,
+                associatedWorktreeRef: nextAssociatedWorktree.associatedWorktreeRef,
+              });
+              // Keep local thread state in sync immediately so terminal drawer opens
+              // with the worktree cwd/env instead of briefly using the project root.
+              setStoreThreadWorkspace(threadIdForSend, {
+                branch: result.worktree.branch,
+                worktreePath: result.worktree.path,
+                ...nextAssociatedWorktree,
+              });
+            }
+          }
+        }
+
+        const threadCreateModelSelection: ModelSelection = buildModelSelection(
+          selectedModelSelectionForSend.provider,
+          selectedModelSelectionForSend.model ||
+            selectedModelForSend ||
+            targetProjectDefaultModelSelectionForSend?.model ||
+            getDefaultModel(selectedModelSelectionForSend.provider) ||
+            DEFAULT_MODEL_BY_PROVIDER.codex,
+          selectedModelSelectionForSend.options,
+          selectedModelSelectionForSend.provider === "claudeAgent"
+            ? selectedModelSelectionForSend.supportsAutoMode
+            : undefined,
+        );
+
+        if (isLocalDraftThread) {
+          const inheritedProjectInstructions =
+            useProjectInstructionsStore.getState().instructionsByProjectId[
+              targetProjectIdForSend
+            ] ?? "";
+          const inheritedThreadNotes = mergeProjectInstructionsIntoThreadNotes({
+            threadNotes,
+            projectInstructions: inheritedProjectInstructions,
+          });
+          await promoteThreadCreate(
+            {
+              type: "thread.create",
+              commandId: newCommandId(),
+              threadId: threadIdForSend,
+              projectId: targetProjectIdForSend,
+              title,
+              modelSelection: threadCreateModelSelection,
+              runtimeMode: nextRuntimeModeForSend,
+              interactionMode: interactionModeForSend,
+              envMode: nextThreadEnvMode,
+              branch: nextThreadBranch,
+              worktreePath: nextThreadWorktreePath,
+              workingDirectory: nextThreadWorkingDirectory,
+              associatedWorktreePath: nextAssociatedWorktreePath,
+              associatedWorktreeBranch: nextAssociatedWorktreeBranch,
+              associatedWorktreeRef: nextAssociatedWorktreeRef,
+              lastKnownPr: activeThread.lastKnownPr ?? null,
+              createdAt: activeThread.createdAt,
+            },
+            api,
+          );
+          // `thread.create` does not carry notes, so seed the freshly created
+          // server thread's notepad with the inherited project instructions via a
+          // dedicated meta update. Best-effort: a failure here must not abort the turn.
+          if (inheritedThreadNotes !== threadNotes && inheritedThreadNotes.trim().length > 0) {
+            try {
+              await dispatchThreadNotes(threadIdForSend, inheritedThreadNotes);
+            } catch {
+              // Seeding is non-critical; project instructions can still be copied
+              // into the notepad manually from the Environment panel.
+            }
+          }
+          // Same for a goal staged on the draft via /goal: persist it now so the
+          // decider stamps goalStartedAt when the thread actually starts working.
+          const draftGoalForSend = activeThread.goal?.trim() ?? "";
+          if (draftGoalForSend.length > 0) {
+            try {
+              await dispatchThreadGoal(threadIdForSend, draftGoalForSend, {
+                startBehavior: "defer",
+              });
+            } catch {
+              // Non-critical: the goal can be set again with /goal on the live thread.
+            }
+          }
+          if (targetProjectKindForSend === "chat") {
+            await api.orchestration.dispatchCommand({
+              type: "project.meta.update",
+              commandId: newCommandId(),
+              projectId: targetProjectIdForSend,
+              title,
+            });
+          }
+          createdServerThreadForLocalDraft = true;
+        }
+
+        const setupScript = switchedToLocalCheckout ? null : setupScriptForWorktree;
+        if (setupScript) {
+          let shouldRunSetupScript = false;
+          if (isServerThread) {
+            shouldRunSetupScript = true;
+          } else {
+            if (createdServerThreadForLocalDraft) {
+              shouldRunSetupScript = true;
+            }
+          }
+          if (shouldRunSetupScript) {
+            beginLocalDispatch({
+              worktreeSetupStepId: "run-setup-action",
+              setupScriptName: setupScript.name,
+              copyLocalChanges: worktreeCopiesLocalChanges,
+            });
+            const setupScriptOptions: Parameters<typeof runProjectScript>[1] = {
+              worktreePath: nextThreadWorktreePath,
+              rememberAsLastInvoked: false,
+              throwOnError: true,
+            };
+            if (nextThreadWorktreePath) {
+              setupScriptOptions.cwd = nextThreadWorktreePath;
+            }
+            const setupTerminal = await runProjectScript(setupScript, setupScriptOptions);
+            if (setupTerminal) {
+              const setupActivityAbortController = new AbortController();
+              const setupActivityWait = waitForSetupScriptTerminalActivity({
+                threadId: threadIdForSend,
+                terminalId: setupTerminal.terminalId,
+                signal: setupActivityAbortController.signal,
+              });
+              // Setup scripts can run for minutes; let Cancel / Work locally win
+              // the wait. The script itself keeps running — a cancelled worktree
+              // is force-removed, a local switch just stops waiting on it.
+              await (
+                worktreeSetupResolution
+                  ? Promise.race([setupActivityWait, worktreeSetupResolution.promise])
+                  : setupActivityWait
+              ).finally(() => setupActivityAbortController.abort());
+            }
+          }
+        }
+        // Covers a resolution set while the thread was linked or the setup
+        // script ran (the creation-step race above only guards the first step).
+        await consumeWorktreeSetupResolution();
+
+        if (isServerThread) {
+          await persistThreadSettingsForNextTurn({
+            threadId: threadIdForSend,
+            createdAt: messageCreatedAt,
+            modelSelection: selectedModelSelectionForSend,
+            runtimeMode: nextRuntimeModeForSend,
+            interactionMode: interactionModeForSend,
+          });
+        }
+
+        const stagedTurnAttachments = await turnAttachmentsPromise;
+
+        if (
+          isServerThread &&
+          activeThread.settledAt != null &&
+          nextThreadEnvMode === "local" &&
+          nextThreadWorktreePath === null &&
+          nextThreadBranch !== activeThread.branch
+        ) {
+          await api.orchestration.dispatchCommand({
+            type: "thread.meta.update",
+            commandId: newCommandId(),
+            threadId: threadIdForSend,
+            envMode: "local",
+            branch: nextThreadBranch,
+            worktreePath: null,
+            associatedWorktreePath: nextAssociatedWorktreePath,
+            associatedWorktreeBranch: nextAssociatedWorktreeBranch,
+            associatedWorktreeRef: nextAssociatedWorktreeRef,
+          });
+          settledLocalBranchUpdatedForSend = true;
+          setStoreThreadWorkspace(threadIdForSend, {
+            envMode: "local",
+            branch: nextThreadBranch,
+            worktreePath: null,
+            associatedWorktreePath: nextAssociatedWorktreePath,
+            associatedWorktreeBranch: nextAssociatedWorktreeBranch,
+            associatedWorktreeRef: nextAssociatedWorktreeRef,
+          });
+        }
+        // Keep setup resolvable while attachment uploads are still preparing the
+        // turn. Once they settle, consume the last possible choice before the
+        // card advances to the non-resolvable "Starting session" step.
+        await consumeWorktreeSetupResolution();
+        // Carry the expected message id so a snapshot rebuilt after an interim
+        // reset (thread switch, ack effect) keeps the message-echo ack signal.
+        beginLocalDispatch({
+          expectedUserMessageId: messageIdForSend,
+          ...(baseBranchForWorktree && !switchedToLocalCheckout
+            ? {
+                worktreeSetupStepId: "start-session" as const,
+                setupScriptName: worktreeSetupScriptName,
+                copyLocalChanges: worktreeCopiesLocalChanges,
+              }
+            : {}),
+        });
+        rememberCustomBinaryPathForDispatch({
+          threadId: threadIdForSend,
+          provider: selectedModelSelectionForSend.provider,
+          providerOptions: providerOptionsForDispatchForSend,
+        });
+        await stagedTurnAttachments.runWithDispatch((turnAttachments) =>
+          api.orchestration.dispatchCommand({
+            type: "thread.turn.start",
+            commandId: newCommandId(),
+            threadId: threadIdForSend,
+            message: {
+              messageId: messageIdForSend,
+              role: "user",
+              text: outgoingMessageText,
+              attachments: turnAttachments,
+              ...(mentionedSkillsForSend.length > 0 ? { skills: mentionedSkillsForSend } : {}),
+              ...(mentionedPluginMentionsForSend.length > 0
+                ? { mentions: mentionedPluginMentionsForSend }
+                : {}),
+            },
+            modelSelection: selectedModelSelectionForSend,
+            ...(providerOptionsForDispatchForSend
+              ? { providerOptions: providerOptionsForDispatchForSend }
+              : {}),
+            assistantDeliveryMode,
+            dispatchMode,
+            runtimeMode: nextRuntimeModeForSend,
+            interactionMode: interactionModeForSend,
+            ...(sourceProposedPlanForSend ? { sourceProposedPlan: sourceProposedPlanForSend } : {}),
+            createdAt: messageCreatedAt,
+          }),
+        );
+        turnStartSucceeded = true;
+        if (
+          shouldResumeSettledLocalThread &&
+          currentActiveGitBranchForSend !== null &&
+          nextThreadBranch === currentActiveGitBranchForSend
+        ) {
+          setSettledThreadBranchWarningDismissedThreadId(threadIdForSend);
+        }
+        armLocalDispatchAckFallback(threadIdForSend);
+        // Steers on providers without native mid-turn steering interrupt the live
+        // turn before re-dispatching; hold queued auto-dispatch through that gap
+        // so it can't race the steer. The live session provider decides the
+        // interrupt path server-side, so the gate keys off it rather than the
+        // requested model selection.
+        const liveProviderForSteerGate =
+          activeThread?.session?.provider ?? selectedModelSelectionForSend.provider;
+        if (
+          dispatchMode === "steer" &&
+          !providerSupportsNativeTurnSteering(liveProviderForSteerGate)
+        ) {
+          const nextSteerGate = {
+            sawInterruptGap: false,
+            gapStartedAt: null,
+            armedActiveTurnId: activeThread?.session?.activeTurnId ?? null,
+          };
+          setQueuedSteerGate(nextSteerGate);
+          armQueuedComposerSteerGate(threadId, nextSteerGate);
+        }
+        if (sourceProposedPlanForSend) {
+          planSidebarDismissedForTurnRef.current = null;
+          setPlanSidebarOpen(true);
+        }
+        if (queuedChatTurn === null) {
+          setRestoredQueuedSourceProposedPlan(threadIdForSend, null);
+        }
+      })().catch(async (err: unknown) => {
+        // A user-cancelled worktree setup unwinds through this same rollback,
+        // but silently: no error styling on the step row, no thread error.
+        const setupCancelled = err instanceof WorktreeSetupCancelledError;
+        // Uploads start in parallel with workspace/session preparation. If any
+        // earlier step fails, settle that promise and release every staged blob.
+        await turnAttachmentsPromise.then(
+          (staged) => staged.cleanup(),
+          () => undefined,
+        );
+        // Surface the failure on whichever setup step was active (no-op for
+        // sends without a worktree setup in flight).
+        if (!setupCancelled) {
+          failLocalDispatchWorktreeSetup();
+        }
+        if (!turnStartSucceeded) {
+          // The turn RPC never resolved, so no server turn exists for the
+          // watchdog to recover — drop the marker armed when the dispatch began.
+          clearPendingTurnDispatch(threadIdForSend);
+        }
+        if (settledLocalBranchUpdatedForSend && !turnStartSucceeded) {
+          await api.orchestration
+            .dispatchCommand({
+              type: "thread.meta.update",
+              commandId: newCommandId(),
+              threadId: threadIdForSend,
+              envMode: "local",
+              branch: activeThread.branch,
+              worktreePath: null,
+              associatedWorktreePath: activeThread.associatedWorktreePath ?? null,
+              associatedWorktreeBranch: activeThread.associatedWorktreeBranch ?? null,
+              associatedWorktreeRef: activeThread.associatedWorktreeRef ?? null,
+            })
+            .then(
+              () =>
+                setStoreThreadWorkspace(threadIdForSend, {
+                  envMode: "local",
+                  branch: activeThread.branch,
+                  worktreePath: null,
+                  associatedWorktreePath: activeThread.associatedWorktreePath ?? null,
+                  associatedWorktreeBranch: activeThread.associatedWorktreeBranch ?? null,
+                  associatedWorktreeRef: activeThread.associatedWorktreeRef ?? null,
+                }),
+              () => undefined,
+            );
+        }
+        if (createdServerThreadForLocalDraft && !turnStartSucceeded) {
+          // This rollback cleans up a retryable draft promotion; do not tombstone the draft id.
+          await api.orchestration
+            .dispatchCommand({
+              type: "thread.delete",
+              commandId: newCommandId(),
+              threadId: threadIdForSend,
+            })
+            .catch(() => undefined);
+        }
+        if (createdWorktreeForSendPath && !turnStartSucceeded) {
+          const removed = await api.git
+            .removeWorktree({
+              cwd: targetProjectCwdForSend,
+              path: createdWorktreeForSendPath,
+              force: true,
+              reclaimTemporaryBranch: true,
+            })
+            .then(
+              () => true,
+              () => false,
+            );
+          if (removed && isServerThread) {
+            await api.orchestration
+              .dispatchCommand({
+                type: "thread.meta.update",
+                commandId: newCommandId(),
+                threadId: threadIdForSend,
+                envMode: "local",
+                branch: null,
+                worktreePath: null,
+                associatedWorktreePath: null,
+                associatedWorktreeBranch: null,
+                associatedWorktreeRef: null,
+              })
+              .then(
+                () =>
+                  setStoreThreadWorkspace(threadIdForSend, {
+                    branch: null,
+                    worktreePath: null,
+                    associatedWorktreePath: null,
+                    associatedWorktreeBranch: null,
+                    associatedWorktreeRef: null,
+                  }),
+                () => undefined,
+              );
+          }
+        }
+        if (queuedChatTurn !== null && !turnStartSucceeded) {
+          // The queued snapshot remains available for retry/edit after a rejected
+          // dispatch. Drop only this attempt's optimistic transcript row; its
+          // attachment preview URLs still belong to the queued snapshot.
+          setOptimisticUserMessages((existing) => {
+            const next = existing.filter((message) => message.id !== messageIdForSend);
+            return next.length === existing.length ? existing : next;
+          });
+        }
+        if (
+          queuedChatTurn === null &&
+          !turnStartSucceeded &&
+          promptRef.current.length === 0 &&
+          composerImagesRef.current.length === 0 &&
+          composerFilesRef.current.length === 0 &&
+          composerAssistantSelectionsRef.current.length === 0 &&
+          composerBrowserAnnotationsRef.current.length === 0 &&
+          composerFileCommentsRef.current.length === 0 &&
+          composerTerminalContextsRef.current.length === 0 &&
+          composerPastedTextsRef.current.length === 0 &&
+          composerPullRequestContextsRef.current.length === 0
+        ) {
+          setOptimisticUserMessages((existing) => {
+            const removed = existing.filter((message) => message.id === messageIdForSend);
+            for (const message of removed) {
+              revokeUserMessagePreviewUrls(message);
+            }
+            const next = existing.filter((message) => message.id !== messageIdForSend);
+            return next.length === existing.length ? existing : next;
+          });
+          promptRef.current = promptForSend;
+          setPrompt(promptForSend);
+          if (sourceProposedPlanForSend) {
+            setRestoredQueuedSourceProposedPlan(threadIdForSend, {
+              threadId: threadIdForSend,
+              restoredPrompt: promptForSend,
+              sourceProposedPlan: sourceProposedPlanForSend,
+            });
+          }
+          setComposerCursor(collapseExpandedComposerCursor(promptForSend, promptForSend.length));
+          addComposerImagesToDraft(composerImagesSnapshot.map(cloneComposerImageAttachment));
+          addComposerFilesToDraft(composerFilesSnapshot);
+          for (const selection of composerAssistantSelectionsSnapshot) {
+            addComposerAssistantSelectionToDraft(selection);
+          }
+          addComposerDraftBrowserAnnotations(threadIdForSend, composerBrowserAnnotationsSnapshot);
+          for (const comment of composerFileCommentsSnapshot) {
+            addComposerFileCommentToDraft(comment);
+          }
+          addComposerTerminalContextsToDraft(composerTerminalContextsSnapshot);
+          addComposerPastedTextsToDraft(composerPastedTextsSnapshot);
+          addComposerPullRequestContextsToDraft(composerPullRequestContextsSnapshot);
+          updateSelectedComposerSkills(composerSkillsSnapshot);
+          updateSelectedComposerMentions(composerMentionsSnapshot);
+          setComposerTrigger(detectComposerTrigger(promptForSend, promptForSend.length));
+        }
+        if (!setupCancelled) {
+          setThreadError(
+            threadIdForSend,
+            err instanceof Error ? err.message : "Failed to send message.",
+          );
+        }
+      });
+      sendInFlightRef.current = false;
+      worktreeSetupResolutionRef.current = null;
+      if (!turnStartSucceeded) {
+        if (baseBranchForWorktree && (worktreeSetupResolution?.action ?? null) === null) {
+          scheduleFailedWorktreeSetupDispatchReset();
+        } else {
+          // A resolved setup (cancelled, or switched to local and then failed)
+          // has no error step to hold on screen — release the marker directly.
+          resetLocalDispatch();
+        }
+      }
+      return turnStartSucceeded;
+    },
+    [
+      isServerThread,
+      setStoreThreadWorkspace,
+      clearLocalDispatchWorktreeSetup,
+      createWorktreeMutation,
+      beginLocalDispatch,
+      isLocalDraftThread,
+      threadNotes,
+      runProjectScript,
+      persistThreadSettingsForNextTurn,
+      rememberCustomBinaryPathForDispatch,
+      assistantDeliveryMode,
+      setSettledThreadBranchWarningDismissedThreadId,
+      armLocalDispatchAckFallback,
+      setQueuedSteerGate,
+      threadId,
+      planSidebarDismissedForTurnRef,
+      setPlanSidebarOpen,
+      setRestoredQueuedSourceProposedPlan,
+      failLocalDispatchWorktreeSetup,
+      setOptimisticUserMessages,
+      promptRef,
+      composerImagesRef,
+      composerFilesRef,
+      composerAssistantSelectionsRef,
+      composerBrowserAnnotationsRef,
+      composerFileCommentsRef,
+      composerTerminalContextsRef,
+      composerPastedTextsRef,
+      composerPullRequestContextsRef,
+      setPrompt,
+      setComposerCursor,
+      addComposerImagesToDraft,
+      addComposerFilesToDraft,
+      addComposerAssistantSelectionToDraft,
+      addComposerDraftBrowserAnnotations,
+      addComposerFileCommentToDraft,
+      addComposerTerminalContextsToDraft,
+      addComposerPastedTextsToDraft,
+      addComposerPullRequestContextsToDraft,
+      updateSelectedComposerSkills,
+      updateSelectedComposerMentions,
+      setComposerTrigger,
+      setThreadError,
+      sendInFlightRef,
+      worktreeSetupResolutionRef,
+      scheduleFailedWorktreeSetupDispatchReset,
+      resetLocalDispatch,
+    ],
+  );
+}

--- a/apps/web/src/components/chat/useChatTurnFollowUps.ts
+++ b/apps/web/src/components/chat/useChatTurnFollowUps.ts
@@ -1,0 +1,610 @@
+import {
+  MessageId,
+  ProviderInteractionMode,
+  RuntimeMode,
+  ThreadId,
+  type ModelSelection,
+  type ProviderKind,
+  type ProviderStartOptions,
+} from "@synara/contracts";
+import { resolveTailUserMessageEditTarget } from "@synara/shared/conversationEdit";
+import { providerSupportsNativeTurnSteering } from "@synara/shared/providerMetadata";
+import { deriveAssociatedWorktreeMetadata } from "@synara/shared/threadWorkspace";
+import { useNavigate } from "@tanstack/react-router";
+import type { Dispatch, RefObject, SetStateAction } from "react";
+import { useCallback } from "react";
+import { newCommandId, newMessageId, newThreadId, randomUUID } from "~/lib/utils";
+import { readNativeApi } from "~/nativeApi";
+import { type DraftThreadEnvMode, type QueuedComposerPlanFollowUp } from "../../composerDraftStore";
+import { formatOutgoingComposerPrompt } from "../../lib/composerSend";
+import { reconcileDeletedThreadFromClient } from "../../lib/deletedThreadClientReconciliation";
+import { armQueuedComposerSteerGate } from "../../lib/queuedComposerDrain";
+import { appendOriginalComposerPromptBlocks } from "../../lib/terminalContext";
+import { clearPendingTurnDispatch, markPendingTurnDispatch } from "../../pendingTurnDispatch";
+import {
+  buildPlanImplementationPrompt,
+  buildPlanImplementationThreadTitle,
+} from "../../proposedPlan";
+import type { LatestProposedPlanState } from "../../session-logic";
+import { buildSourceProposedPlanReference } from "../../session-logic";
+import { useStore } from "../../store";
+import { truncateTitle } from "../../truncateTitle";
+import type { Project } from "../../types";
+import { type Thread } from "../../types";
+import { type QueuedSteerGate } from "../ChatView.logic";
+import { buildWorkflowResumePrompt } from "./WorkflowRunCard.logic";
+import { useChatComposerDraft } from "./useChatComposerDraft";
+import { useChatLocalDispatch } from "./useChatLocalDispatch";
+import { useChatProviderModels } from "./useChatProviderModels";
+import { useChatProviderStatus } from "./useChatProviderStatus";
+import { useChatRuntimeModes } from "./useChatRuntimeModes";
+import { useChatTimelineMessages } from "./useChatTimelineMessages";
+import { useChatTranscriptScroll } from "./useChatTranscriptScroll";
+import { useChatWorkLog } from "./useChatWorkLog";
+import { toastManager } from "../ui/toast";
+
+import type { LateComposerSendHandlers } from "./chatSendTypes";
+interface ChatTurnFollowUpsInput {
+  threadId: ThreadId;
+  activeThread: Thread | undefined;
+  isServerThread: boolean;
+  isConnecting: boolean;
+  sendInFlightRef: RefObject<boolean>;
+  setThreadError: (targetThreadId: ThreadId | null, error: string | null) => void;
+  setTailAnchor: Dispatch<SetStateAction<{ threadId: ThreadId; messageId: MessageId } | null>>;
+  runtimeMode: RuntimeMode;
+  activeProposedPlan: LatestProposedPlanState | null;
+  assistantDeliveryMode: "streaming" | "buffered";
+  setQueuedSteerGate: Dispatch<SetStateAction<QueuedSteerGate | null>>;
+  planSidebarDismissedForTurnRef: RefObject<string | null>;
+  setPlanSidebarOpen: Dispatch<SetStateAction<boolean>>;
+  isRevertingCheckpoint: boolean;
+  setIsRevertingCheckpoint: Dispatch<SetStateAction<boolean>>;
+  interactionMode: ProviderInteractionMode;
+  isSendBusy: ReturnType<typeof useChatLocalDispatch>["isSendBusy"];
+  beginLocalDispatch: ReturnType<typeof useChatLocalDispatch>["beginLocalDispatch"];
+  armLocalDispatchAckFallback: ReturnType<
+    typeof useChatLocalDispatch
+  >["armLocalDispatchAckFallback"];
+  resetLocalDispatch: ReturnType<typeof useChatLocalDispatch>["resetLocalDispatch"];
+  selectedProvider: ProviderKind;
+  selectedModel: string;
+  selectedPromptEffort: ReturnType<typeof useChatProviderModels>["selectedPromptEffort"];
+  selectedModelSelection: ModelSelection;
+  providerOptionsForDispatch: ProviderStartOptions | undefined;
+  setOptimisticUserMessages: ReturnType<
+    typeof useChatTimelineMessages
+  >["setOptimisticUserMessages"];
+  armTranscriptAutoFollow: ReturnType<typeof useChatTranscriptScroll>["armTranscriptAutoFollow"];
+  tailAnchorScrollInFlightRef: ReturnType<
+    typeof useChatTranscriptScroll
+  >["tailAnchorScrollInFlightRef"];
+  persistThreadSettingsForNextTurn: ReturnType<
+    typeof useChatRuntimeModes
+  >["persistThreadSettingsForNextTurn"];
+  setComposerDraftInteractionMode: ReturnType<
+    typeof useChatComposerDraft
+  >["setComposerDraftInteractionMode"];
+  rememberCustomBinaryPathForDispatch: ReturnType<
+    typeof useChatProviderStatus
+  >["rememberCustomBinaryPathForDispatch"];
+  workflowRunState: ReturnType<typeof useChatWorkLog>["workflowRunState"];
+  lateComposerSendHandlersRef: RefObject<LateComposerSendHandlers | null>;
+  envMode: DraftThreadEnvMode;
+  activeThreadId: ThreadId | null;
+  markWorkflowRunDismissed: (threadId: ThreadId, workflowTaskId: string) => void;
+  activeProject: Project | undefined;
+  activeThreadAssociatedWorktree: ReturnType<typeof deriveAssociatedWorktreeMetadata>;
+  syncServerShellSnapshot: ReturnType<typeof useStore.getState>["syncServerShellSnapshot"];
+  planSidebarOpenOnNextThreadRef: RefObject<boolean>;
+  navigate: ReturnType<typeof useNavigate>;
+}
+
+export function useChatTurnFollowUps({
+  threadId,
+  activeThread,
+  isServerThread,
+  isConnecting,
+  sendInFlightRef,
+  setThreadError,
+  setTailAnchor,
+  runtimeMode,
+  activeProposedPlan,
+  assistantDeliveryMode,
+  setQueuedSteerGate,
+  planSidebarDismissedForTurnRef,
+  setPlanSidebarOpen,
+  isRevertingCheckpoint,
+  setIsRevertingCheckpoint,
+  interactionMode,
+  isSendBusy,
+  beginLocalDispatch,
+  armLocalDispatchAckFallback,
+  resetLocalDispatch,
+  selectedProvider,
+  selectedModel,
+  selectedPromptEffort,
+  selectedModelSelection,
+  providerOptionsForDispatch,
+  setOptimisticUserMessages,
+  armTranscriptAutoFollow,
+  tailAnchorScrollInFlightRef,
+  persistThreadSettingsForNextTurn,
+  setComposerDraftInteractionMode,
+  rememberCustomBinaryPathForDispatch,
+  workflowRunState,
+  lateComposerSendHandlersRef,
+  envMode,
+  activeThreadId,
+  markWorkflowRunDismissed,
+  activeProject,
+  activeThreadAssociatedWorktree,
+  syncServerShellSnapshot,
+  planSidebarOpenOnNextThreadRef,
+  navigate,
+}: ChatTurnFollowUpsInput) {
+  async function onSubmitPlanFollowUp({
+    text,
+    interactionMode: nextInteractionMode,
+    dispatchMode,
+    queuedTurn,
+  }: {
+    text: string;
+    interactionMode: "default" | "plan";
+    dispatchMode: "queue" | "steer";
+    queuedTurn?: QueuedComposerPlanFollowUp;
+  }): Promise<boolean> {
+    const api = readNativeApi();
+    if (
+      !api ||
+      !activeThread ||
+      !isServerThread ||
+      isSendBusy ||
+      isConnecting ||
+      sendInFlightRef.current
+    ) {
+      return false;
+    }
+
+    const trimmed = text.trim();
+    if (!trimmed) {
+      return false;
+    }
+
+    const threadIdForSend = activeThread.id;
+    const messageIdForSend = newMessageId();
+    const messageCreatedAt = new Date().toISOString();
+    const outgoingMessageText = formatOutgoingComposerPrompt({
+      provider: queuedTurn?.selectedProvider ?? selectedProvider,
+      model: queuedTurn?.selectedModel ?? selectedModel,
+      effort: queuedTurn?.selectedPromptEffort ?? selectedPromptEffort,
+      text: trimmed,
+    });
+
+    sendInFlightRef.current = true;
+    beginLocalDispatch({ expectedUserMessageId: messageIdForSend });
+    setThreadError(threadIdForSend, null);
+    setOptimisticUserMessages((existing) => [
+      ...existing,
+      {
+        id: messageIdForSend,
+        role: "user",
+        text: outgoingMessageText,
+        dispatchMode,
+        createdAt: messageCreatedAt,
+        streaming: false,
+        source: "native",
+      },
+    ]);
+    armTranscriptAutoFollow(threadIdForSend, true);
+    tailAnchorScrollInFlightRef.current = true;
+    setTailAnchor({ threadId: threadIdForSend, messageId: messageIdForSend });
+
+    // Nested function so the `try` body holds no value blocks — see the comment on
+    // `deleteEmptyTerminalThread` above for why React Compiler requires this shape.
+    const dispatchPlanFollowUpTurn = async () => {
+      await persistThreadSettingsForNextTurn({
+        threadId: threadIdForSend,
+        createdAt: messageCreatedAt,
+        modelSelection: queuedTurn?.modelSelection ?? selectedModelSelection,
+        runtimeMode: queuedTurn?.runtimeMode ?? runtimeMode,
+        interactionMode: nextInteractionMode,
+      });
+
+      // Keep the mode toggle and plan-follow-up banner in sync immediately
+      // while the same-thread implementation turn is starting.
+      setComposerDraftInteractionMode(threadIdForSend, nextInteractionMode);
+
+      const providerOptionsForPlanDispatch =
+        queuedTurn?.providerOptionsForDispatch ?? providerOptionsForDispatch;
+      const modelSelectionForPlanDispatch = queuedTurn?.modelSelection ?? selectedModelSelection;
+      const sourceProposedPlan =
+        nextInteractionMode === "default"
+          ? buildSourceProposedPlanReference({
+              threadId: activeThread.id,
+              proposedPlan: activeProposedPlan,
+            })
+          : undefined;
+      rememberCustomBinaryPathForDispatch({
+        threadId: threadIdForSend,
+        provider: modelSelectionForPlanDispatch.provider,
+        providerOptions: providerOptionsForPlanDispatch,
+      });
+      await api.orchestration.dispatchCommand({
+        type: "thread.turn.start",
+        commandId: newCommandId(),
+        threadId: threadIdForSend,
+        message: {
+          messageId: messageIdForSend,
+          role: "user",
+          text: outgoingMessageText,
+          attachments: [],
+        },
+        modelSelection: modelSelectionForPlanDispatch,
+        ...(providerOptionsForPlanDispatch
+          ? {
+              providerOptions: providerOptionsForPlanDispatch,
+            }
+          : {}),
+        assistantDeliveryMode,
+        dispatchMode,
+        runtimeMode: queuedTurn?.runtimeMode ?? runtimeMode,
+        interactionMode: nextInteractionMode,
+        ...(sourceProposedPlan ? { sourceProposedPlan } : {}),
+        createdAt: messageCreatedAt,
+      });
+      // Steers on providers without native mid-turn steering interrupt the live
+      // turn before re-dispatching; hold queued auto-dispatch through that gap
+      // so it can't race the steer. The live session provider decides the
+      // interrupt path server-side, so the gate keys off it rather than the
+      // requested model selection.
+      const livePlanProviderForSteerGate =
+        activeThread?.session?.provider ?? modelSelectionForPlanDispatch.provider;
+      if (
+        dispatchMode === "steer" &&
+        !providerSupportsNativeTurnSteering(livePlanProviderForSteerGate)
+      ) {
+        const nextSteerGate = {
+          sawInterruptGap: false,
+          gapStartedAt: null,
+          armedActiveTurnId: activeThread?.session?.activeTurnId ?? null,
+        };
+        setQueuedSteerGate(nextSteerGate);
+        armQueuedComposerSteerGate(threadId, nextSteerGate);
+      }
+      // Optimistically open the plan sidebar when implementing (not refining).
+      // "default" mode here means the agent is executing the plan, which produces
+      // step-tracking activities that the sidebar will display.
+      if (nextInteractionMode === "default") {
+        planSidebarDismissedForTurnRef.current = null;
+        setPlanSidebarOpen(true);
+      }
+    };
+
+    try {
+      await dispatchPlanFollowUpTurn();
+      armLocalDispatchAckFallback(threadIdForSend);
+      sendInFlightRef.current = false;
+      return true;
+    } catch (err) {
+      setOptimisticUserMessages((existing) =>
+        existing.filter((message) => message.id !== messageIdForSend),
+      );
+      setThreadError(
+        threadIdForSend,
+        err instanceof Error ? err.message : "Failed to send plan follow-up.",
+      );
+      sendInFlightRef.current = false;
+      // The turn RPC failed, so no server turn exists for the watchdog to
+      // recover — drop the marker armed when the dispatch began.
+      clearPendingTurnDispatch(threadIdForSend);
+      resetLocalDispatch();
+      return false;
+    }
+  }
+
+  const onEditUserMessage = useCallback(
+    async (messageId: MessageId, text: string): Promise<boolean> => {
+      const api = readNativeApi();
+      if (!api || !activeThread || !isServerThread || isRevertingCheckpoint) {
+        return false;
+      }
+      const editTarget = resolveTailUserMessageEditTarget({
+        messages: activeThread.messages,
+        messageId,
+        activeTurnId:
+          activeThread.session?.orchestrationStatus === "running"
+            ? (activeThread.session.activeTurnId ?? null)
+            : null,
+      });
+      if (!editTarget.editable) {
+        setThreadError(activeThread.id, "Only the latest rollbackable user message can be edited.");
+        return false;
+      }
+      const originalMessage = activeThread.messages[editTarget.messageIndex];
+      if (!originalMessage || originalMessage.role !== "user") {
+        setThreadError(activeThread.id, "Only the latest rollbackable user message can be edited.");
+        return false;
+      }
+      if (isSendBusy || isConnecting || sendInFlightRef.current) {
+        setThreadError(activeThread.id, "Wait for the current send to start before editing.");
+        return false;
+      }
+
+      setIsRevertingCheckpoint(true);
+      setThreadError(activeThread.id, null);
+      const messageCreatedAt = new Date().toISOString();
+      const editedTextWithOriginalContext = appendOriginalComposerPromptBlocks({
+        editedPrompt: text,
+        originalPrompt: originalMessage.text,
+        messageId,
+      });
+      const outgoingMessageText = formatOutgoingComposerPrompt({
+        provider: selectedProvider,
+        model: selectedModel,
+        effort: selectedPromptEffort,
+        text: editedTextWithOriginalContext,
+      });
+      return await (async () => {
+        await persistThreadSettingsForNextTurn({
+          threadId: activeThread.id,
+          createdAt: messageCreatedAt,
+          modelSelection: selectedModelSelection,
+          runtimeMode,
+          interactionMode,
+        });
+        await api.orchestration.dispatchCommand({
+          type: "thread.message.edit-and-resend",
+          commandId: newCommandId(),
+          threadId: activeThread.id,
+          messageId,
+          text: outgoingMessageText,
+          modelSelection: selectedModelSelection,
+          ...(providerOptionsForDispatch ? { providerOptions: providerOptionsForDispatch } : {}),
+          assistantDeliveryMode,
+          runtimeMode,
+          interactionMode,
+          createdAt: messageCreatedAt,
+        });
+        return true;
+      })()
+        .catch((err: unknown) => {
+          setThreadError(
+            activeThread.id,
+            err instanceof Error ? err.message : "Failed to edit message.",
+          );
+          return false;
+        })
+        .finally(() => {
+          setIsRevertingCheckpoint(false);
+        });
+    },
+    [
+      sendInFlightRef,
+      setIsRevertingCheckpoint,
+      activeThread,
+      isConnecting,
+      isRevertingCheckpoint,
+      isSendBusy,
+      isServerThread,
+      interactionMode,
+      persistThreadSettingsForNextTurn,
+      providerOptionsForDispatch,
+      runtimeMode,
+      selectedModel,
+      selectedModelSelection,
+      selectedPromptEffort,
+      selectedProvider,
+      setThreadError,
+      assistantDeliveryMode,
+    ],
+  );
+  // Resuming a workflow is a normal composer turn instructing the agent to
+  // re-invoke the Workflow tool against the persisted script; completed agent()
+  // calls replay from cache, so a paused run picks up where it stopped. Sent as
+  // a pre-built chat turn so it takes the exact send path a queued turn does.
+
+  const onResumeWorkflowRun = useCallback(async () => {
+    if (!workflowRunState?.scriptPath || !workflowRunState.runId) return;
+    const lateSendHandlers = lateComposerSendHandlersRef.current;
+    if (!lateSendHandlers) return;
+    const { workflowTaskId } = workflowRunState;
+    const prompt = buildWorkflowResumePrompt(workflowRunState.scriptPath, workflowRunState.runId);
+    const sent = await lateSendHandlers.send(undefined, "queue", {
+      id: randomUUID(),
+      kind: "chat",
+      createdAt: new Date().toISOString(),
+      previewText: prompt,
+      prompt,
+      images: [],
+      files: [],
+      assistantSelections: [],
+      browserAnnotations: [],
+      terminalContexts: [],
+      fileComments: [],
+      pastedTexts: [],
+      pullRequestContexts: [],
+      skills: [],
+      mentions: [],
+      selectedProvider,
+      selectedModel,
+      selectedPromptEffort,
+      modelSelection: selectedModelSelection,
+      ...(providerOptionsForDispatch ? { providerOptionsForDispatch } : {}),
+      runtimeMode,
+      interactionMode,
+      envMode,
+    });
+    if (sent && activeThreadId) {
+      markWorkflowRunDismissed(activeThreadId, workflowTaskId);
+    }
+  }, [
+    lateComposerSendHandlersRef,
+    activeThreadId,
+    envMode,
+    interactionMode,
+    markWorkflowRunDismissed,
+    providerOptionsForDispatch,
+    runtimeMode,
+    selectedModel,
+    selectedModelSelection,
+    selectedPromptEffort,
+    selectedProvider,
+    workflowRunState,
+  ]);
+
+  const onImplementPlanInNewThread = useCallback(async () => {
+    const api = readNativeApi();
+    if (
+      !api ||
+      !activeThread ||
+      !activeProject ||
+      !activeProposedPlan ||
+      !isServerThread ||
+      isSendBusy ||
+      isConnecting ||
+      sendInFlightRef.current
+    ) {
+      return;
+    }
+
+    const createdAt = new Date().toISOString();
+    const nextThreadId = newThreadId();
+    const planMarkdown = activeProposedPlan.planMarkdown;
+    const implementationPrompt = buildPlanImplementationPrompt(planMarkdown);
+    const outgoingImplementationPrompt = formatOutgoingComposerPrompt({
+      provider: selectedProvider,
+      model: selectedModel,
+      effort: selectedPromptEffort,
+      text: implementationPrompt,
+    });
+    const nextThreadTitle = truncateTitle(buildPlanImplementationThreadTitle(planMarkdown));
+    const nextThreadModelSelection: ModelSelection = selectedModelSelection;
+    const sourceProposedPlan = buildSourceProposedPlanReference({
+      threadId: activeThread.id,
+      proposedPlan: activeProposedPlan,
+    });
+
+    sendInFlightRef.current = true;
+    beginLocalDispatch();
+    const finish = () => {
+      sendInFlightRef.current = false;
+      resetLocalDispatch();
+    };
+
+    await api.orchestration
+      .dispatchCommand({
+        type: "thread.create",
+        commandId: newCommandId(),
+        threadId: nextThreadId,
+        projectId: activeProject.id,
+        title: nextThreadTitle,
+        modelSelection: nextThreadModelSelection,
+        runtimeMode,
+        interactionMode: "default",
+        envMode: activeThread.envMode ?? (activeThread.worktreePath ? "worktree" : "local"),
+        branch: activeThread.branch,
+        worktreePath: activeThread.worktreePath,
+        workingDirectory: activeThread.workingDirectory ?? null,
+        lastKnownPr: activeThread.lastKnownPr ?? null,
+        associatedWorktreePath: activeThreadAssociatedWorktree.associatedWorktreePath,
+        associatedWorktreeBranch: activeThreadAssociatedWorktree.associatedWorktreeBranch,
+        associatedWorktreeRef: activeThreadAssociatedWorktree.associatedWorktreeRef,
+        createdAt,
+      })
+      .then(() => {
+        rememberCustomBinaryPathForDispatch({
+          threadId: nextThreadId,
+          provider: selectedModelSelection.provider,
+          providerOptions: providerOptionsForDispatch,
+        });
+        return api.orchestration.dispatchCommand({
+          type: "thread.turn.start",
+          commandId: newCommandId(),
+          threadId: nextThreadId,
+          message: {
+            messageId: newMessageId(),
+            role: "user",
+            text: outgoingImplementationPrompt,
+            attachments: [],
+          },
+          modelSelection: selectedModelSelection,
+          ...(providerOptionsForDispatch ? { providerOptions: providerOptionsForDispatch } : {}),
+          assistantDeliveryMode,
+          dispatchMode: "queue",
+          runtimeMode,
+          interactionMode: "default",
+          ...(sourceProposedPlan ? { sourceProposedPlan } : {}),
+          createdAt,
+        });
+      })
+      .then(() => {
+        // The turn RPC resolved for a thread this view never made active, so
+        // arm the watchdog marker with that exact thread id before navigation.
+        markPendingTurnDispatch(nextThreadId);
+        return api.orchestration.getShellSnapshot();
+      })
+      .then((snapshot) => {
+        syncServerShellSnapshot(snapshot);
+        // Signal that the plan sidebar should open on the new thread.
+        planSidebarOpenOnNextThreadRef.current = true;
+        return navigate({
+          to: "/$threadId",
+          params: { threadId: nextThreadId },
+        });
+      })
+      .catch(async (err) => {
+        const deletedOnServer = await api.orchestration
+          .dispatchCommand({
+            type: "thread.delete",
+            commandId: newCommandId(),
+            threadId: nextThreadId,
+          })
+          .then(() => true)
+          .catch(() => false);
+        if (deletedOnServer) {
+          clearPendingTurnDispatch(nextThreadId);
+          void reconcileDeletedThreadFromClient({
+            threadId: nextThreadId,
+            removeDeletedThreadFromClientState:
+              useStore.getState().removeDeletedThreadFromClientState,
+          });
+        }
+        toastManager.add({
+          type: "error",
+          title: "Could not start implementation thread",
+          description:
+            err instanceof Error ? err.message : "An error occurred while creating the new thread.",
+        });
+      })
+      .then(finish, finish);
+  }, [
+    planSidebarOpenOnNextThreadRef,
+    sendInFlightRef,
+    activeProject,
+    activeProposedPlan,
+    activeThread,
+    activeThreadAssociatedWorktree,
+    beginLocalDispatch,
+    isConnecting,
+    isSendBusy,
+    isServerThread,
+    navigate,
+    resetLocalDispatch,
+    runtimeMode,
+    selectedPromptEffort,
+    selectedModelSelection,
+    providerOptionsForDispatch,
+    rememberCustomBinaryPathForDispatch,
+    selectedProvider,
+    assistantDeliveryMode,
+    syncServerShellSnapshot,
+    selectedModel,
+  ]);
+  return {
+    onSubmitPlanFollowUp,
+    onEditUserMessage,
+    onResumeWorkflowRun,
+    onImplementPlanInNewThread,
+  };
+}

--- a/apps/web/src/components/chat/useChatTurnSubmission.ts
+++ b/apps/web/src/components/chat/useChatTurnSubmission.ts
@@ -1,0 +1,969 @@
+import { useCallback } from "react";
+import {
+  filterPromptProviderMentionReferences,
+  filterPromptSkillReferences,
+} from "~/lib/composerMentions";
+import { resolveProviderSendAvailabilityWithRefresh } from "~/lib/providerAvailability";
+import { newMessageId, randomUUID } from "~/lib/utils";
+import { readNativeApi } from "~/nativeApi";
+import { resolveFollowUpDispatchMode } from "../../appSettings";
+import { useComposerDraftStore, type QueuedComposerChatTurn } from "../../composerDraftStore";
+import { appendAssistantSelectionsToPrompt } from "../../lib/assistantSelections";
+import { appendBrowserAnnotationsToPrompt } from "../../lib/browserAnnotations";
+import { appendPastedTextsToPrompt } from "../../lib/composerPastedText";
+import {
+  findPendingBlobComposerAttachments,
+  formatOutgoingComposerPrompt,
+  hydratePendingBlobComposerAttachments,
+  readFileAsDataUrl,
+  stageUploadComposerAttachments,
+} from "../../lib/composerSend";
+import { appendFileCommentsToPrompt } from "../../lib/fileComments";
+import { appendPullRequestContextsToPrompt } from "../../lib/pullRequestContext";
+import {
+  IMAGE_ONLY_BOOTSTRAP_PROMPT,
+  appendTerminalContextsToPrompt,
+} from "../../lib/terminalContext";
+import { setPendingUserInputCustomAnswer } from "../../pendingUserInput";
+import { resolvePlanFollowUpSubmission } from "../../proposedPlan";
+import { buildSourceProposedPlanReference } from "../../session-logic";
+import {
+  buildExpiredTerminalContextToastCopy,
+  createWorktreeSetupResolution,
+  deriveComposerSendState,
+  resolveEnvironmentPanelPreferenceAfterFirstSend,
+} from "../ChatView.logic";
+import { toastManager } from "../ui/toast";
+import type { ChatTurnSubmissionInput } from "./chatSendTypes";
+import { handleChatAutomationSend } from "./handleChatAutomationSend";
+import { prepareChatSendWorkspace } from "./prepareChatSendWorkspace";
+import {
+  buildQueuedComposerPreviewText,
+  composerPromptStillMatchesRestoredQueuedDraft,
+} from "./queuedComposerPreview";
+import { resolveChatPromptCaptures } from "./resolveChatPromptCaptures";
+import { useChatTurnExecution } from "./useChatTurnExecution";
+
+export function useChatTurnSubmission({
+  threadId,
+  hasLiveTurn,
+  lateComposerSendHandlersRef,
+  activeThread,
+  isConnecting,
+  sendPreflightInFlightRef,
+  sendInFlightRef,
+  runtimeMode,
+  interactionMode,
+  envMode,
+  showPlanFollowUpPrompt,
+  activeProposedPlan,
+  hasQueueableLiveTurn,
+  clearComposerInput,
+  scheduleComposerFocus,
+  activeProject,
+  threadWorkspaceCwd,
+  refreshProviderStatuses,
+  isServerThread,
+  hasNativeUserMessages,
+  chatWorkspaceRoot,
+  isHomeChatContainer,
+  isStudioContainer,
+  resolvedThreadWorktreePath,
+  resolvedThreadWorkingDirectory,
+  currentActiveGitBranch,
+  isContainerLandingProject,
+  syncServerShellSnapshot,
+  activeRootBranch,
+  gitBranchSourceCwd,
+  setStoreThreadError,
+  queryClient,
+  isCenteredEmptyLanding,
+  setEnvironmentPanelPreferenceOpen,
+  environmentPanelPreferenceOpen,
+  setTailAnchor,
+  setThreadError,
+  setComposerHighlightedItemId,
+  setStoreThreadWorkspace,
+  createWorktreeMutation,
+  isLocalDraftThread,
+  threadNotes,
+  assistantDeliveryMode,
+  setSettledThreadBranchWarningDismissedThreadId,
+  setQueuedSteerGate,
+  planSidebarDismissedForTurnRef,
+  setPlanSidebarOpen,
+  settings,
+  isSendBusy,
+  worktreeSetupResolutionRef,
+  setWorktreeSetupPendingAction,
+  beginLocalDispatch,
+  clearLocalDispatchWorktreeSetup,
+  armLocalDispatchAckFallback,
+  failLocalDispatchWorktreeSetup,
+  scheduleFailedWorktreeSetupDispatchReset,
+  resetLocalDispatch,
+  isVoiceTranscribing,
+  waitForPendingComposerImages,
+  activePendingProgress,
+  activePendingUserInputKey,
+  pendingUserInputAnswersByRequestIdRef,
+  setPendingUserInputAnswersByRequestId,
+  composerEditorRef,
+  promptRef,
+  composerImages,
+  composerFiles,
+  composerAssistantSelections,
+  composerBrowserAnnotations,
+  composerFileComments,
+  composerTerminalContexts,
+  composerPastedTexts,
+  composerPullRequestContexts,
+  restoredQueuedSourceProposedPlanRef,
+  enqueueQueuedComposerTurn,
+  setComposerDraftPrompt,
+  setComposerTrigger,
+  clearProjectDraftThreadId,
+  setDraftThreadContext,
+  promptHistoryNavigationRef,
+  applyingPromptHistoryNavigationRef,
+  expectedPromptHistoryPromptRef,
+  clearComposerDraftContent,
+  setComposerDraftInteractionMode,
+  setComposerCursor,
+  setRestoredQueuedSourceProposedPlan,
+  composerImagesRef,
+  composerFilesRef,
+  composerAssistantSelectionsRef,
+  composerBrowserAnnotationsRef,
+  composerFileCommentsRef,
+  composerTerminalContextsRef,
+  composerPastedTextsRef,
+  composerPullRequestContextsRef,
+  setPrompt,
+  addComposerImagesToDraft,
+  addComposerFilesToDraft,
+  addComposerAssistantSelectionToDraft,
+  addComposerDraftBrowserAnnotations,
+  addComposerFileCommentToDraft,
+  addComposerTerminalContextsToDraft,
+  addComposerPastedTextsToDraft,
+  addComposerPullRequestContextsToDraft,
+  selectedComposerSkillsRef,
+  selectedComposerMentionsRef,
+  updateSelectedComposerSkills,
+  updateSelectedComposerMentions,
+  selectedProvider,
+  selectedModel,
+  selectedPromptEffort,
+  selectedModelSelection,
+  providerOptionsForDispatch,
+  pendingAutomationConversationRef,
+  setPendingAutomationConversation,
+  pendingAutomationConversation,
+  activeThreadIdRef,
+  hasLiveTurnRef,
+  automationProjects,
+  setAutomationDraftWarningContext,
+  setAutomationDraftForm,
+  setAutomationDraftWarnings,
+  setAcknowledgedAutomationWarnings,
+  setAutomationDraftOpen,
+  armTranscriptAutoFollow,
+  tailAnchorScrollInFlightRef,
+  prepareAutomationFormForCreate,
+  createAutomationFromForm,
+  providerStatuses,
+  rememberCustomBinaryPathForDispatch,
+  setOptimisticUserMessages,
+  runProjectScript,
+  persistThreadSettingsForNextTurn,
+}: ChatTurnSubmissionInput) {
+  const executePreparedTurn = useChatTurnExecution({
+    isServerThread,
+    setStoreThreadWorkspace,
+    clearLocalDispatchWorktreeSetup,
+    createWorktreeMutation,
+    beginLocalDispatch,
+    isLocalDraftThread,
+    threadNotes,
+    runProjectScript,
+    persistThreadSettingsForNextTurn,
+    rememberCustomBinaryPathForDispatch,
+    assistantDeliveryMode,
+    setSettledThreadBranchWarningDismissedThreadId,
+    armLocalDispatchAckFallback,
+    setQueuedSteerGate,
+    threadId,
+    planSidebarDismissedForTurnRef,
+    setPlanSidebarOpen,
+    setRestoredQueuedSourceProposedPlan,
+    failLocalDispatchWorktreeSetup,
+    setOptimisticUserMessages,
+    promptRef,
+    composerImagesRef,
+    composerFilesRef,
+    composerAssistantSelectionsRef,
+    composerBrowserAnnotationsRef,
+    composerFileCommentsRef,
+    composerTerminalContextsRef,
+    composerPastedTextsRef,
+    composerPullRequestContextsRef,
+    setPrompt,
+    setComposerCursor,
+    addComposerImagesToDraft,
+    addComposerFilesToDraft,
+    addComposerAssistantSelectionToDraft,
+    addComposerDraftBrowserAnnotations,
+    addComposerFileCommentToDraft,
+    addComposerTerminalContextsToDraft,
+    addComposerPastedTextsToDraft,
+    addComposerPullRequestContextsToDraft,
+    updateSelectedComposerSkills,
+    updateSelectedComposerMentions,
+    setComposerTrigger,
+    setThreadError,
+    sendInFlightRef,
+    worktreeSetupResolutionRef,
+    scheduleFailedWorktreeSetupDispatchReset,
+    resetLocalDispatch,
+  });
+
+  const onSend = useCallback(
+    async (
+      e?: { preventDefault: () => void },
+      requestedDispatchMode?: "queue" | "steer",
+      queuedTurn?: QueuedComposerChatTurn,
+    ): Promise<boolean> => {
+      const dispatchMode =
+        requestedDispatchMode ??
+        resolveFollowUpDispatchMode({
+          behavior: settings.followUpBehavior,
+          hasLiveTurn,
+        });
+      e?.preventDefault();
+      const api = readNativeApi();
+      const lateSendHandlers = lateComposerSendHandlersRef.current;
+      if (
+        !api ||
+        !lateSendHandlers ||
+        !activeThread ||
+        activeThread.sidechatExpiredAt ||
+        isSendBusy ||
+        isConnecting ||
+        isVoiceTranscribing ||
+        sendPreflightInFlightRef.current ||
+        sendInFlightRef.current
+      ) {
+        return false;
+      }
+      if (!queuedTurn) {
+        sendPreflightInFlightRef.current = true;
+        await waitForPendingComposerImages();
+        sendPreflightInFlightRef.current = false;
+      }
+      if (activePendingProgress) {
+        const activeQuestion = activePendingProgress.activeQuestion;
+        const liveComposerSnapshot = composerEditorRef.current?.readSnapshot() ?? null;
+        const livePendingAnswerText = liveComposerSnapshot?.value ?? promptRef.current;
+        const currentDraftAnswer =
+          activePendingUserInputKey && activeQuestion
+            ? pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey]?.[
+                activeQuestion.id
+              ]
+            : undefined;
+        const answerOverrides =
+          activeQuestion && livePendingAnswerText.trim().length > 0
+            ? {
+                [activeQuestion.id]: setPendingUserInputCustomAnswer(
+                  currentDraftAnswer,
+                  livePendingAnswerText,
+                ),
+              }
+            : undefined;
+        if (activePendingUserInputKey && answerOverrides) {
+          const nextRequestAnswers = {
+            ...pendingUserInputAnswersByRequestIdRef.current[activePendingUserInputKey],
+            ...answerOverrides,
+          };
+          pendingUserInputAnswersByRequestIdRef.current = {
+            ...pendingUserInputAnswersByRequestIdRef.current,
+            [activePendingUserInputKey]: nextRequestAnswers,
+          };
+          setPendingUserInputAnswersByRequestId((existing) => ({
+            ...existing,
+            [activePendingUserInputKey]: nextRequestAnswers,
+          }));
+        }
+        return lateSendHandlers.advanceActivePendingUserInput(answerOverrides);
+      }
+      const queuedChatTurn = queuedTurn ?? null;
+      const liveComposerSnapshot =
+        queuedChatTurn === null ? (composerEditorRef.current?.readSnapshot() ?? null) : null;
+      let promptForSend =
+        queuedChatTurn?.prompt ?? liveComposerSnapshot?.value ?? promptRef.current;
+      let composerImagesForSend =
+        queuedChatTurn?.images ??
+        useComposerDraftStore.getState().draftsByThreadId[activeThread.id]?.images ??
+        composerImages;
+      // AppSnap captures persist as IndexedDB blobs and hydrate into `images`
+      // asynchronously (see AppSnapCoordinator). Right after a reload the user can
+      // hit send before that hydration finishes; without this, the not-yet-hydrated
+      // capture would be silently dropped from the message and then have its blob
+      // deleted when the composer clears after send. Live sends only: a queued turn
+      // already captured a fully-resolved image snapshot when it was queued.
+      if (queuedChatTurn === null) {
+        const pendingBlobAttachments = findPendingBlobComposerAttachments({
+          persistedAttachments:
+            useComposerDraftStore.getState().draftsByThreadId[activeThread.id]
+              ?.persistedAttachments ?? [],
+          images: composerImagesForSend,
+        });
+        if (pendingBlobAttachments.length > 0) {
+          const hydratedPendingImages =
+            await hydratePendingBlobComposerAttachments(pendingBlobAttachments);
+          if (hydratedPendingImages.length > 0) {
+            composerImagesForSend = [...composerImagesForSend, ...hydratedPendingImages];
+          }
+        }
+      }
+      const composerFilesForSend = queuedChatTurn?.files ?? composerFiles;
+      const composerAssistantSelectionsForSend =
+        queuedChatTurn?.assistantSelections ?? composerAssistantSelections;
+      const composerBrowserAnnotationsForSend =
+        queuedChatTurn?.browserAnnotations ?? composerBrowserAnnotations;
+      const composerFileCommentsForSend = queuedChatTurn?.fileComments ?? composerFileComments;
+      const composerTerminalContextsForSend =
+        queuedChatTurn?.terminalContexts ?? composerTerminalContexts;
+      const composerPastedTextsForSend = queuedChatTurn?.pastedTexts ?? composerPastedTexts;
+      const composerPullRequestContextsForSend =
+        queuedChatTurn?.pullRequestContexts ?? composerPullRequestContexts;
+      const selectedComposerSkillsForSend =
+        queuedChatTurn?.skills ?? selectedComposerSkillsRef.current;
+      const selectedComposerMentionsForSend =
+        queuedChatTurn?.mentions ?? selectedComposerMentionsRef.current;
+      const selectedProviderForSend = queuedChatTurn?.selectedProvider ?? selectedProvider;
+      const selectedModelForSend = queuedChatTurn?.selectedModel ?? selectedModel;
+      const selectedPromptEffortForSend =
+        queuedChatTurn?.selectedPromptEffort ?? selectedPromptEffort;
+      const selectedModelSelectionForSend =
+        queuedChatTurn?.modelSelection ?? selectedModelSelection;
+      const providerOptionsForDispatchForSend =
+        queuedChatTurn?.providerOptionsForDispatch ?? providerOptionsForDispatch;
+      const runtimeModeForSend = queuedChatTurn?.runtimeMode ?? runtimeMode;
+      let interactionModeForSend = queuedChatTurn?.interactionMode ?? interactionMode;
+      const envModeForSend = queuedChatTurn?.envMode ?? envMode;
+      const {
+        trimmedPrompt: trimmed,
+        sendableTerminalContexts: sendableComposerTerminalContexts,
+        expiredTerminalContextCount,
+        sendablePastedTexts: sendableComposerPastedTexts,
+        sendablePullRequestContexts: sendableComposerPullRequestContexts,
+        hasSendableContent,
+      } = deriveComposerSendState({
+        prompt: promptForSend,
+        imageCount: composerImagesForSend.length,
+        fileCount: composerFilesForSend.length,
+        assistantSelectionCount: composerAssistantSelectionsForSend.length,
+        browserAnnotationCount: composerBrowserAnnotationsForSend.length,
+        fileCommentCount: composerFileCommentsForSend.length,
+        terminalContexts: composerTerminalContextsForSend,
+        pastedTexts: composerPastedTextsForSend,
+        pullRequestContexts: composerPullRequestContextsForSend,
+      });
+      let trimmedPromptForSend = trimmed;
+      const restoredQueuedPlanDraftSource =
+        queuedChatTurn === null &&
+        restoredQueuedSourceProposedPlanRef.current?.threadId === activeThread.id &&
+        composerPromptStillMatchesRestoredQueuedDraft(
+          restoredQueuedSourceProposedPlanRef.current.restoredPrompt,
+          promptForSend,
+        )
+          ? restoredQueuedSourceProposedPlanRef.current
+          : null;
+      const isLivePlanFollowUpSubmission =
+        queuedChatTurn === null &&
+        restoredQueuedPlanDraftSource === null &&
+        showPlanFollowUpPrompt &&
+        activeProposedPlan !== null;
+      const hasStructuredPlanFollowUpContent =
+        composerImagesForSend.length > 0 ||
+        composerFilesForSend.length > 0 ||
+        composerAssistantSelectionsForSend.length > 0 ||
+        composerBrowserAnnotationsForSend.length > 0 ||
+        composerFileCommentsForSend.length > 0 ||
+        sendableComposerTerminalContexts.length > 0 ||
+        sendableComposerPastedTexts.length > 0;
+      // Queued chat turns already captured their intended mode. Live plan follow-ups
+      // with attachments must use the normal send path so references are preserved.
+      if (isLivePlanFollowUpSubmission) {
+        const followUp = resolvePlanFollowUpSubmission({
+          draftText: trimmed,
+          planMarkdown: activeProposedPlan.planMarkdown,
+        });
+        if (hasStructuredPlanFollowUpContent) {
+          promptForSend = followUp.text;
+          interactionModeForSend = followUp.interactionMode;
+          trimmedPromptForSend = followUp.text.trim();
+        } else {
+          if (hasQueueableLiveTurn && dispatchMode === "queue") {
+            clearComposerInput(activeThread.id);
+            scheduleComposerFocus();
+            enqueueQueuedComposerTurn(activeThread.id, {
+              id: randomUUID(),
+              kind: "plan-follow-up",
+              createdAt: new Date().toISOString(),
+              previewText: followUp.text.trim(),
+              text: followUp.text,
+              interactionMode: followUp.interactionMode,
+              selectedProvider,
+              selectedModel,
+              selectedPromptEffort,
+              modelSelection: selectedModelSelection,
+              ...(providerOptionsForDispatch ? { providerOptionsForDispatch } : {}),
+              runtimeMode,
+            });
+            return true;
+          }
+          clearComposerInput(activeThread.id);
+          scheduleComposerFocus();
+          return lateSendHandlers.submitPlanFollowUp({
+            text: followUp.text,
+            interactionMode: followUp.interactionMode,
+            dispatchMode,
+          });
+        }
+      }
+      const hasNoStructuredComposerContext =
+        composerImagesForSend.length === 0 &&
+        composerFilesForSend.length === 0 &&
+        composerAssistantSelectionsForSend.length === 0 &&
+        composerBrowserAnnotationsForSend.length === 0 &&
+        composerFileCommentsForSend.length === 0 &&
+        sendableComposerTerminalContexts.length === 0 &&
+        sendableComposerPastedTexts.length === 0 &&
+        // Provider mentions are structured turn metadata, and automation definitions persist text only.
+        selectedComposerMentionsForSend.length === 0;
+      const hasPromptOnlySendableContent = hasNoStructuredComposerContext;
+      if (hasPromptOnlySendableContent) {
+        const handledSlashCommand =
+          await lateSendHandlers.handleStandaloneSlashCommand(trimmedPromptForSend);
+        if (handledSlashCommand) {
+          // A slash command (e.g. /clear) consumes the composer, so abandon any in-progress
+          // automation setup rather than leaving a stale banner/request behind.
+          pendingAutomationConversationRef.current = null;
+          setPendingAutomationConversation(null);
+          return true;
+        }
+      }
+      const sourceProposedPlanForSend =
+        queuedChatTurn?.sourceProposedPlan ??
+        restoredQueuedPlanDraftSource?.sourceProposedPlan ??
+        (isLivePlanFollowUpSubmission && activeProposedPlan && interactionModeForSend === "default"
+          ? buildSourceProposedPlanReference({
+              threadId: activeThread.id,
+              proposedPlan: activeProposedPlan,
+            })
+          : undefined);
+      if (!hasSendableContent) {
+        if (expiredTerminalContextCount > 0) {
+          const toastCopy = buildExpiredTerminalContextToastCopy(
+            expiredTerminalContextCount,
+            "empty",
+          );
+          toastManager.add({
+            type: "warning",
+            title: toastCopy.title,
+            description: toastCopy.description,
+          });
+        }
+        return false;
+      }
+      if (!activeProject) return false;
+      if (queuedChatTurn === null && !isLivePlanFollowUpSubmission) {
+        const handled = await handleChatAutomationSend({
+          threadId,
+          pendingAutomationConversation,
+          trimmedPromptForSend,
+          threadWorkspaceCwd,
+          activeProject,
+          api,
+          activeThreadIdRef,
+          pendingAutomationConversationRef,
+          hasLiveTurn,
+          hasLiveTurnRef,
+          hasPromptOnlySendableContent,
+          promptRef,
+          setComposerDraftPrompt,
+          activeThread,
+          setComposerTrigger,
+          armTranscriptAutoFollow,
+          setPendingAutomationConversation,
+          automationProjects,
+          selectedModelSelectionForSend,
+          setAutomationDraftWarningContext,
+          setAutomationDraftForm,
+          setAutomationDraftWarnings,
+          setAcknowledgedAutomationWarnings,
+          setAutomationDraftOpen,
+          prepareAutomationFormForCreate,
+          createAutomationFromForm,
+          providerOptionsForDispatchForSend,
+        });
+        if (handled) return true;
+      }
+      sendPreflightInFlightRef.current = true;
+      const sendProviderAvailability = await resolveProviderSendAvailabilityWithRefresh({
+        provider: selectedModelSelectionForSend.provider,
+        statuses: providerStatuses,
+        refreshStatuses: () => refreshProviderStatuses({ silent: true }),
+      }).finally(() => {
+        sendPreflightInFlightRef.current = false;
+      });
+      if (!sendProviderAvailability.usable) {
+        toastManager.add({
+          type: "error",
+          title: sendProviderAvailability.unavailableReason,
+        });
+        return false;
+      }
+
+      const captures = await resolveChatPromptCaptures({
+        api,
+        activeThread,
+        promptForSend,
+        composerImagesForSend,
+        composerFilesForSend,
+        composerAssistantSelectionsForSend,
+      });
+      composerImagesForSend = captures.composerImagesForSend;
+
+      if (hasQueueableLiveTurn && dispatchMode === "queue" && queuedChatTurn === null) {
+        clearComposerInput(activeThread.id);
+        scheduleComposerFocus();
+        const queuedImagesForPersistence = await Promise.all(
+          composerImagesForSend.map(async (image) => {
+            try {
+              return {
+                ...image,
+                previewUrl: await readFileAsDataUrl(image.file),
+              };
+            } catch {
+              return image;
+            }
+          }),
+        );
+        enqueueQueuedComposerTurn(activeThread.id, {
+          id: randomUUID(),
+          kind: "chat",
+          createdAt: new Date().toISOString(),
+          previewText: buildQueuedComposerPreviewText({
+            trimmedPrompt: trimmed,
+            images: queuedImagesForPersistence,
+            files: composerFilesForSend,
+            assistantSelections: composerAssistantSelectionsForSend,
+            browserAnnotations: composerBrowserAnnotationsForSend,
+            terminalContexts: sendableComposerTerminalContexts,
+            fileComments: composerFileCommentsForSend,
+            pastedTexts: sendableComposerPastedTexts,
+            pullRequestContexts: sendableComposerPullRequestContexts,
+          }),
+          prompt: promptForSend,
+          images: queuedImagesForPersistence,
+          files: composerFilesForSend,
+          assistantSelections: composerAssistantSelectionsForSend,
+          browserAnnotations: composerBrowserAnnotationsForSend,
+          fileComments: composerFileCommentsForSend,
+          terminalContexts: sendableComposerTerminalContexts,
+          pastedTexts: sendableComposerPastedTexts,
+          pullRequestContexts: sendableComposerPullRequestContexts,
+          skills: selectedComposerSkillsForSend,
+          mentions: selectedComposerMentionsForSend,
+          selectedProvider: selectedProviderForSend,
+          selectedModel: selectedModelForSend,
+          selectedPromptEffort: selectedPromptEffortForSend,
+          modelSelection: selectedModelSelectionForSend,
+          ...(providerOptionsForDispatchForSend
+            ? { providerOptionsForDispatch: providerOptionsForDispatchForSend }
+            : {}),
+          ...(sourceProposedPlanForSend ? { sourceProposedPlan: sourceProposedPlanForSend } : {}),
+          runtimeMode: runtimeModeForSend,
+          interactionMode: interactionModeForSend,
+          envMode: envModeForSend,
+        });
+        return true;
+      }
+      const workspace = await prepareChatSendWorkspace({
+        activeThread,
+        isServerThread,
+        hasNativeUserMessages,
+        composerImagesForSend,
+        trimmedPromptForSend,
+        composerFilesForSend,
+        composerAssistantSelectionsForSend,
+        composerBrowserAnnotationsForSend,
+        sendableComposerTerminalContexts,
+        composerFileCommentsForSend,
+        sendableComposerPastedTexts,
+        selectedModelSelectionForSend,
+        selectedModelForSend,
+        activeProject,
+        chatWorkspaceRoot,
+        isHomeChatContainer,
+        isStudioContainer,
+        resolvedThreadWorktreePath,
+        runtimeModeForSend,
+        envModeForSend,
+        resolvedThreadWorkingDirectory,
+        currentActiveGitBranch,
+        isContainerLandingProject,
+        api,
+        syncServerShellSnapshot,
+        clearProjectDraftThreadId,
+        setDraftThreadContext,
+        activeRootBranch,
+        gitBranchSourceCwd,
+        setStoreThreadError,
+        queryClient,
+      });
+      if (workspace === false) return false;
+      const {
+        threadIdForSend,
+        title,
+        targetProjectIdForSend,
+        targetProjectKindForSend,
+        targetProjectCwdForSend,
+        targetProjectDefaultModelSelectionForSend,
+        nextRuntimeModeForSend,
+        nextThreadEnvMode,
+        nextThreadBranch,
+        nextThreadWorktreePath,
+        nextThreadWorkingDirectory,
+        nextAssociatedWorktreePath,
+        nextAssociatedWorktreeBranch,
+        nextAssociatedWorktreeRef,
+        shouldResumeSettledLocalThread,
+        currentActiveGitBranchForSend,
+        baseBranchForWorktree,
+        setupScriptForWorktree,
+        worktreeSetupScriptName,
+        worktreeCopiesLocalChanges,
+      } = workspace;
+      const messageIdForSend = newMessageId();
+      const worktreeSetupResolution = baseBranchForWorktree
+        ? createWorktreeSetupResolution()
+        : null;
+      worktreeSetupResolutionRef.current = worktreeSetupResolution;
+      if (worktreeSetupResolution) {
+        setWorktreeSetupPendingAction(null);
+      }
+
+      sendInFlightRef.current = true;
+      beginLocalDispatch({
+        expectedUserMessageId: messageIdForSend,
+        ...(baseBranchForWorktree
+          ? {
+              worktreeSetupStepId: "create-branch" as const,
+              setupScriptName: worktreeSetupScriptName,
+              copyLocalChanges: worktreeCopiesLocalChanges,
+            }
+          : {}),
+      });
+
+      const composerImagesSnapshot = [...composerImagesForSend];
+      const composerFilesSnapshot = [...composerFilesForSend];
+      const composerAssistantSelectionsSnapshot = [...composerAssistantSelectionsForSend];
+      const composerBrowserAnnotationsSnapshot = composerBrowserAnnotationsForSend.map(
+        (annotation) => ({ ...annotation, source: { ...annotation.source } }),
+      );
+      const composerFileCommentsSnapshot = [...composerFileCommentsForSend];
+      const composerTerminalContextsSnapshot = [...sendableComposerTerminalContexts];
+      const composerPastedTextsSnapshot = [...sendableComposerPastedTexts];
+      const composerPullRequestContextsSnapshot = [...sendableComposerPullRequestContexts];
+      const composerSkillsSnapshot = [...selectedComposerSkillsForSend];
+      const composerMentionsSnapshot = [...selectedComposerMentionsForSend];
+      // Trailing blocks are appended innermost-to-outermost: assistant selections,
+      // terminal contexts, file comments, pasted text, pull request contexts, then
+      // browser annotations (outermost). The display extractors unwrap them in the
+      // reverse order.
+      const messageTextForSend = appendBrowserAnnotationsToPrompt(
+        appendPullRequestContextsToPrompt(
+          appendPastedTextsToPrompt(
+            appendFileCommentsToPrompt(
+              appendTerminalContextsToPrompt(
+                appendAssistantSelectionsToPrompt(
+                  promptForSend,
+                  composerAssistantSelectionsSnapshot,
+                ),
+                composerTerminalContextsSnapshot,
+              ),
+              composerFileCommentsSnapshot,
+            ),
+            composerPastedTextsSnapshot,
+          ),
+          composerPullRequestContextsSnapshot,
+        ),
+        composerBrowserAnnotationsSnapshot,
+        messageIdForSend,
+      );
+      const messageCreatedAt = new Date().toISOString();
+      const outgoingTextSeed =
+        messageTextForSend ||
+        (composerImagesSnapshot.length > 0 ? IMAGE_ONLY_BOOTSTRAP_PROMPT : "");
+      const outgoingMessageText = formatOutgoingComposerPrompt({
+        provider: selectedProviderForSend,
+        model: selectedModelForSend,
+        effort: selectedPromptEffortForSend,
+        text: outgoingTextSeed,
+      });
+      const mentionedSkillsForSend = filterPromptSkillReferences(
+        outgoingMessageText,
+        selectedComposerSkillsForSend,
+        selectedProviderForSend,
+      );
+      const mentionedPluginMentionsForSend = filterPromptProviderMentionReferences(
+        outgoingMessageText,
+        selectedComposerMentionsForSend,
+      );
+      const turnAttachmentsPromise = stageUploadComposerAttachments({
+        threadId: threadIdForSend,
+        images: composerImagesSnapshot,
+        files: composerFilesSnapshot,
+        assistantSelections: composerAssistantSelectionsSnapshot,
+      });
+      const optimisticAttachments = [
+        ...composerAssistantSelectionsSnapshot,
+        ...composerImagesSnapshot.map((image) => ({
+          type: "image" as const,
+          id: image.id,
+          name: image.name,
+          mimeType: image.mimeType,
+          sizeBytes: image.sizeBytes,
+          previewUrl: image.previewUrl,
+        })),
+        ...composerFilesSnapshot.map((file) => ({
+          type: "file" as const,
+          id: file.id,
+          name: file.name,
+          mimeType: file.mimeType,
+          sizeBytes: file.sizeBytes,
+        })),
+      ];
+      // Sending the first message flips the centered empty landing into a normal
+      // transcript. Clear session-only landing overrides when default-open is enabled;
+      // otherwise keep the transition closed.
+      if (isCenteredEmptyLanding) {
+        setEnvironmentPanelPreferenceOpen(
+          resolveEnvironmentPanelPreferenceAfterFirstSend({
+            isCenteredEmptyLanding,
+            settingsDefaultOpen: settings.environmentPanelDefaultOpen,
+            currentPreferenceOpen: environmentPanelPreferenceOpen,
+          }),
+        );
+      }
+      setOptimisticUserMessages((existing) => [
+        ...existing,
+        {
+          id: messageIdForSend,
+          role: "user",
+          text: outgoingMessageText,
+          dispatchMode,
+          ...(optimisticAttachments.length > 0 ? { attachments: optimisticAttachments } : {}),
+          ...(mentionedSkillsForSend.length > 0 ? { skills: mentionedSkillsForSend } : {}),
+          ...(mentionedPluginMentionsForSend.length > 0
+            ? { mentions: mentionedPluginMentionsForSend }
+            : {}),
+          createdAt: messageCreatedAt,
+          streaming: false,
+          source: "native",
+        },
+      ]);
+      // Mark the transcript as anchored before the optimistic row lands. The tail
+      // anchor sizes the spacer that lets this message sit at the viewport top,
+      // and its hook owns the slide; auto-follow stays armed for bookkeeping but
+      // pauses until the in-flight flag clears.
+      armTranscriptAutoFollow(threadIdForSend, true);
+      tailAnchorScrollInFlightRef.current = true;
+      setTailAnchor({ threadId: threadIdForSend, messageId: messageIdForSend });
+
+      setThreadError(threadIdForSend, null);
+      if (expiredTerminalContextCount > 0) {
+        const toastCopy = buildExpiredTerminalContextToastCopy(
+          expiredTerminalContextCount,
+          "omitted",
+        );
+        toastManager.add({
+          type: "warning",
+          title: toastCopy.title,
+          description: toastCopy.description,
+        });
+      }
+      // Queued turns are dispatched from their captured snapshot, so this send path
+      // must not clear a separate live draft the user may already be editing.
+      if (queuedChatTurn === null) {
+        promptHistoryNavigationRef.current = null;
+        applyingPromptHistoryNavigationRef.current = false;
+        expectedPromptHistoryPromptRef.current = null;
+        promptRef.current = "";
+        clearComposerDraftContent(threadIdForSend, { preservePreviewUrls: true });
+        if (isLivePlanFollowUpSubmission) {
+          setComposerDraftInteractionMode(threadIdForSend, interactionModeForSend);
+        }
+        setComposerHighlightedItemId(null);
+        setComposerCursor(0);
+        setComposerTrigger(null);
+        // A clicked submit button steals focus; return it after the controlled
+        // draft reset so rapid follow-up typing lands in the composer.
+        scheduleComposerFocus();
+      }
+
+      return executePreparedTurn({
+        nextThreadEnvMode,
+        nextThreadBranch,
+        nextThreadWorktreePath,
+        nextAssociatedWorktreePath,
+        nextAssociatedWorktreeBranch,
+        nextAssociatedWorktreeRef,
+        api,
+        targetProjectCwdForSend,
+        threadIdForSend,
+        worktreeSetupResolution,
+        baseBranchForWorktree,
+        worktreeCopiesLocalChanges,
+        worktreeSetupScriptName,
+        selectedModelSelectionForSend,
+        selectedModelForSend,
+        targetProjectDefaultModelSelectionForSend,
+        targetProjectIdForSend,
+        title,
+        nextRuntimeModeForSend,
+        interactionModeForSend,
+        nextThreadWorkingDirectory,
+        activeThread,
+        targetProjectKindForSend,
+        setupScriptForWorktree,
+        messageCreatedAt,
+        turnAttachmentsPromise,
+        messageIdForSend,
+        providerOptionsForDispatchForSend,
+        outgoingMessageText,
+        mentionedSkillsForSend,
+        mentionedPluginMentionsForSend,
+        dispatchMode,
+        sourceProposedPlanForSend,
+        shouldResumeSettledLocalThread,
+        currentActiveGitBranchForSend,
+        queuedChatTurn,
+        promptForSend,
+        composerImagesSnapshot,
+        composerFilesSnapshot,
+        composerAssistantSelectionsSnapshot,
+        composerBrowserAnnotationsSnapshot,
+        composerFileCommentsSnapshot,
+        composerTerminalContextsSnapshot,
+        composerPastedTextsSnapshot,
+        composerPullRequestContextsSnapshot,
+        composerSkillsSnapshot,
+        composerMentionsSnapshot,
+      });
+    },
+    [
+      threadId,
+      hasLiveTurn,
+      lateComposerSendHandlersRef,
+      activeThread,
+      isConnecting,
+      sendPreflightInFlightRef,
+      sendInFlightRef,
+      runtimeMode,
+      interactionMode,
+      envMode,
+      showPlanFollowUpPrompt,
+      activeProposedPlan,
+      hasQueueableLiveTurn,
+      clearComposerInput,
+      scheduleComposerFocus,
+      activeProject,
+      threadWorkspaceCwd,
+      refreshProviderStatuses,
+      isServerThread,
+      hasNativeUserMessages,
+      chatWorkspaceRoot,
+      isHomeChatContainer,
+      isStudioContainer,
+      resolvedThreadWorktreePath,
+      resolvedThreadWorkingDirectory,
+      currentActiveGitBranch,
+      isContainerLandingProject,
+      syncServerShellSnapshot,
+      activeRootBranch,
+      gitBranchSourceCwd,
+      setStoreThreadError,
+      queryClient,
+      isCenteredEmptyLanding,
+      setEnvironmentPanelPreferenceOpen,
+      environmentPanelPreferenceOpen,
+      setTailAnchor,
+      setThreadError,
+      setComposerHighlightedItemId,
+      settings,
+      isSendBusy,
+      worktreeSetupResolutionRef,
+      setWorktreeSetupPendingAction,
+      beginLocalDispatch,
+      isVoiceTranscribing,
+      waitForPendingComposerImages,
+      activePendingProgress,
+      activePendingUserInputKey,
+      pendingUserInputAnswersByRequestIdRef,
+      setPendingUserInputAnswersByRequestId,
+      composerEditorRef,
+      promptRef,
+      composerImages,
+      composerFiles,
+      composerAssistantSelections,
+      composerBrowserAnnotations,
+      composerFileComments,
+      composerTerminalContexts,
+      composerPastedTexts,
+      composerPullRequestContexts,
+      restoredQueuedSourceProposedPlanRef,
+      enqueueQueuedComposerTurn,
+      setComposerDraftPrompt,
+      setComposerTrigger,
+      clearProjectDraftThreadId,
+      setDraftThreadContext,
+      promptHistoryNavigationRef,
+      applyingPromptHistoryNavigationRef,
+      expectedPromptHistoryPromptRef,
+      clearComposerDraftContent,
+      setComposerDraftInteractionMode,
+      setComposerCursor,
+      selectedComposerSkillsRef,
+      selectedComposerMentionsRef,
+      selectedProvider,
+      selectedModel,
+      selectedPromptEffort,
+      selectedModelSelection,
+      providerOptionsForDispatch,
+      pendingAutomationConversationRef,
+      setPendingAutomationConversation,
+      pendingAutomationConversation,
+      activeThreadIdRef,
+      hasLiveTurnRef,
+      automationProjects,
+      setAutomationDraftWarningContext,
+      setAutomationDraftForm,
+      setAutomationDraftWarnings,
+      setAcknowledgedAutomationWarnings,
+      setAutomationDraftOpen,
+      armTranscriptAutoFollow,
+      tailAnchorScrollInFlightRef,
+      prepareAutomationFormForCreate,
+      createAutomationFromForm,
+      providerStatuses,
+      setOptimisticUserMessages,
+      executePreparedTurn,
+    ],
+  );
+  return { onSend };
+}

--- a/apps/web/src/components/chat/useChatWorkLog.ts
+++ b/apps/web/src/components/chat/useChatWorkLog.ts
@@ -1,0 +1,343 @@
+import { OrchestrationThreadActivity, ThreadId, type TurnId } from "@synara/contracts";
+import { useEffect, useMemo } from "react";
+import {
+  deriveWorkLogEntries,
+  isLatestTurnSettled,
+  omitRoutedSubagentWorkEntries,
+} from "../../session-logic";
+import { useStore } from "../../store";
+import { createThreadSelector } from "../../storeSelectors";
+import { retainThreadDetailSubscription } from "../../threadDetailSubscriptionRetention";
+import type { Thread } from "../../types";
+import { useWorkflowRunUiThreadState } from "../../workflowRunUiStore";
+import { enrichSubagentWorkEntries, resolveComposerStripWorkLogEntries } from "../ChatView.logic";
+import { createRelevantWorkLogThreadsSelector } from "../ChatView.selectors";
+import { deriveComposerSubagentStripItems } from "./ComposerSubagentStrip.logic";
+import { deriveWorkflowRunState, type WorkflowSubagentThreadRef } from "./WorkflowRunCard.logic";
+const EMPTY_ACTIVITIES: OrchestrationThreadActivity[] = [];
+interface ChatWorkLogInput {
+  activeThread: Thread | undefined;
+  latestTurnSettled: boolean;
+  latestTurnLive: boolean;
+}
+
+export function useChatWorkLog({
+  activeThread,
+  latestTurnSettled,
+  latestTurnLive,
+}: ChatWorkLogInput) {
+  const activeThreadId = activeThread?.id ?? null;
+  const activeLatestTurn = activeThread?.latestTurn ?? null;
+  const activeLatestTurnId = activeLatestTurn?.turnId ?? null;
+  const activeLatestTurnStartedAt = activeLatestTurn?.startedAt ?? null;
+  const activeLatestTurnState = activeLatestTurn?.state ?? null;
+  const activeLatestTurnCompletedAt = activeLatestTurn?.completedAt ?? null;
+  const threadActivities = activeThread?.activities ?? EMPTY_ACTIVITIES;
+  // User messages intentionally have no turn id; assistant messages are the stable
+  // bridge for deciding which historical work can fold into visible replies.
+  // Memoized on purpose: an inline Set would change identity every render and cascade
+  // through the memoized work-log/timeline chain into the virtualized list, which resets
+  // in a loop on unstable data.
+  const workLogVisibleTurnIds = useMemo(() => {
+    const turnIds = new Set<TurnId>();
+    for (const message of activeThread?.messages ?? []) {
+      if (message.turnId) {
+        turnIds.add(message.turnId);
+      }
+    }
+    if (activeLatestTurnId) {
+      turnIds.add(activeLatestTurnId);
+    }
+    return turnIds;
+  }, [activeLatestTurnId, activeThread?.messages]);
+  const rawWorkLogEntries = useMemo(
+    () =>
+      deriveWorkLogEntries(threadActivities, activeLatestTurnId ?? undefined, {
+        visibleTurnIds: workLogVisibleTurnIds,
+        activeTurnId: latestTurnLive ? activeLatestTurnId : null,
+        activeTurnStartedAt: activeLatestTurnStartedAt,
+        latestTurnState: activeLatestTurnState,
+        latestTurnCompletedAt: activeLatestTurnCompletedAt,
+      }),
+    [
+      activeLatestTurnCompletedAt,
+      activeLatestTurnId,
+      activeLatestTurnStartedAt,
+      activeLatestTurnState,
+      latestTurnLive,
+      threadActivities,
+      workLogVisibleTurnIds,
+    ],
+  );
+  const hasWorkLogSubagents = useMemo(
+    () => rawWorkLogEntries.some((entry) => (entry.subagents?.length ?? 0) > 0),
+    [rawWorkLogEntries],
+  );
+  const relevantWorkLogThreads = useStore(
+    useMemo(
+      () =>
+        createRelevantWorkLogThreadsSelector({
+          workEntries: rawWorkLogEntries,
+          parentThreadId: activeThread?.id ?? null,
+          enabled: hasWorkLogSubagents,
+        }),
+      [activeThread?.id, hasWorkLogSubagents, rawWorkLogEntries],
+    ),
+  );
+  const enrichedWorkLogEntries = useMemo(
+    () =>
+      hasWorkLogSubagents
+        ? enrichSubagentWorkEntries(
+            rawWorkLogEntries,
+            relevantWorkLogThreads,
+            activeThread?.id ?? null,
+          )
+        : rawWorkLogEntries,
+    [activeThread?.id, hasWorkLogSubagents, rawWorkLogEntries, relevantWorkLogThreads],
+  );
+  // Subagents are presented by the composer strip (and their own threads); the
+  // transcript drops the routed fan-out rows entirely. The enriched list above is
+  // still what feeds the strip-adjacent derivations that need receiver metadata.
+  const workLogEntries = useMemo(
+    () => omitRoutedSubagentWorkEntries(enrichedWorkLogEntries),
+    [enrichedWorkLogEntries],
+  );
+  // The strip's liveness (running/settled) reads the child thread's own session and
+  // tail activities, so retain a detail subscription while a subagent runs; settled
+  // subagents stay on whatever the store already holds.
+  const liveSubagentThreadIdsKey = useMemo(() => {
+    if (!hasWorkLogSubagents) {
+      return "";
+    }
+    const threadIds = new Set<string>();
+    for (const entry of enrichedWorkLogEntries) {
+      for (const subagent of entry.subagents ?? []) {
+        if (subagent.isActive && subagent.resolvedThreadId) {
+          threadIds.add(subagent.resolvedThreadId);
+        }
+      }
+    }
+    return [...threadIds].toSorted().join("\n");
+  }, [enrichedWorkLogEntries, hasWorkLogSubagents]);
+  useEffect(() => {
+    if (!liveSubagentThreadIdsKey) {
+      return;
+    }
+    const releases = liveSubagentThreadIdsKey
+      .split("\n")
+      .map((threadId) => retainThreadDetailSubscription(ThreadId.makeUnsafe(threadId)));
+    return () => {
+      for (const release of releases) {
+        release();
+      }
+    };
+  }, [liveSubagentThreadIdsKey]);
+  // Native-CLI parity: while a subagent thread is open, the strip derives from the
+  // PARENT thread's activities so all sibling subagents (plus a way back to the
+  // main thread) stay visible, with the open subagent marked as viewed.
+  const stripParentThreadId = activeThread?.parentThreadId ?? null;
+  const stripParentThread = useStore(
+    useMemo(() => createThreadSelector(stripParentThreadId), [stripParentThreadId]),
+  );
+  // Deep links can land on a subagent thread before the parent has a detail
+  // subscription; retain one so the parent's activities hydrate for the strip.
+  useEffect(() => {
+    if (!stripParentThreadId) {
+      return;
+    }
+    return retainThreadDetailSubscription(stripParentThreadId);
+  }, [stripParentThreadId]);
+  const stripSourceThreadId = stripParentThread?.id ?? activeThread?.id ?? null;
+  const stripSourceActivities = stripParentThread?.activities ?? threadActivities;
+  const stripSourceLatestTurnId = stripParentThread
+    ? (stripParentThread.latestTurn?.turnId ?? null)
+    : (activeLatestTurn?.turnId ?? null);
+  const stripSourceLatestTurnState = stripParentThread
+    ? (stripParentThread.latestTurn?.state ?? null)
+    : activeLatestTurnState;
+  const stripSourceLatestTurnStartedAt = stripParentThread
+    ? (stripParentThread.latestTurn?.startedAt ?? null)
+    : activeLatestTurnStartedAt;
+  const stripSourceLatestTurnCompletedAt = stripParentThread
+    ? (stripParentThread.latestTurn?.completedAt ?? null)
+    : activeLatestTurnCompletedAt;
+  const stripVisibleTurnIds = useMemo(() => {
+    if (!stripParentThread) {
+      return workLogVisibleTurnIds;
+    }
+    const turnIds = new Set<TurnId>();
+    for (const message of stripParentThread.messages) {
+      if (message.turnId) {
+        turnIds.add(message.turnId);
+      }
+    }
+    if (stripParentThread.latestTurn?.turnId) {
+      turnIds.add(stripParentThread.latestTurn.turnId);
+    }
+    return turnIds;
+  }, [stripParentThread, workLogVisibleTurnIds]);
+  const stripLiveTurnId = stripParentThread
+    ? isLatestTurnSettled(stripParentThread.latestTurn, stripParentThread.session ?? null)
+      ? null
+      : (stripParentThread.latestTurn?.turnId ?? null)
+    : latestTurnSettled
+      ? null
+      : (activeLatestTurn?.turnId ?? null);
+  // Composer-strip source: the strip needs the routed subagent entries the
+  // transcript drops. A top-level thread has already derived that exact source
+  // above; reuse it so every live activity does not scan and normalize the full
+  // history twice. Subagent views still derive from their distinct parent source.
+  const stripRawWorkLogEntries = useMemo(
+    () =>
+      resolveComposerStripWorkLogEntries({
+        hasDistinctParentSource: stripParentThread !== undefined,
+        activeWorkLogEntries: rawWorkLogEntries,
+        deriveParentWorkLogEntries: () =>
+          deriveWorkLogEntries(stripSourceActivities, stripSourceLatestTurnId ?? undefined, {
+            visibleTurnIds: stripVisibleTurnIds,
+            activeTurnId: stripLiveTurnId,
+            activeTurnStartedAt: stripSourceLatestTurnStartedAt,
+            latestTurnState: stripSourceLatestTurnState,
+            latestTurnCompletedAt: stripSourceLatestTurnCompletedAt,
+          }),
+      }),
+    [
+      rawWorkLogEntries,
+      stripLiveTurnId,
+      stripParentThread,
+      stripSourceActivities,
+      stripSourceLatestTurnCompletedAt,
+      stripSourceLatestTurnId,
+      stripSourceLatestTurnStartedAt,
+      stripSourceLatestTurnState,
+      stripVisibleTurnIds,
+    ],
+  );
+  const hasStripWorkLogSubagents = useMemo(
+    () => stripRawWorkLogEntries.some((entry) => (entry.subagents?.length ?? 0) > 0),
+    [stripRawWorkLogEntries],
+  );
+  const stripRelevantWorkLogThreads = useStore(
+    useMemo(
+      () =>
+        createRelevantWorkLogThreadsSelector({
+          workEntries: stripRawWorkLogEntries,
+          parentThreadId: stripSourceThreadId,
+          enabled: hasStripWorkLogSubagents,
+        }),
+      [stripSourceThreadId, hasStripWorkLogSubagents, stripRawWorkLogEntries],
+    ),
+  );
+  const stripWorkLogEntries = useMemo(
+    () =>
+      hasStripWorkLogSubagents
+        ? enrichSubagentWorkEntries(
+            stripRawWorkLogEntries,
+            stripRelevantWorkLogThreads,
+            stripSourceThreadId,
+          )
+        : stripRawWorkLogEntries,
+    [
+      stripSourceThreadId,
+      hasStripWorkLogSubagents,
+      stripRawWorkLogEntries,
+      stripRelevantWorkLogThreads,
+    ],
+  );
+
+  // Task tool_use_ids the provider confirmed as backgrounded via task_updated
+  // patches (last patch wins, so re-foregrounded tasks drop back out).
+  const backgroundedSubagentToolUseIds = useMemo(() => {
+    const toolUseIds = new Set<string>();
+    for (const activity of stripSourceActivities) {
+      if (activity.kind !== "task.updated") {
+        continue;
+      }
+      const payload =
+        activity.payload && typeof activity.payload === "object"
+          ? (activity.payload as Record<string, unknown>)
+          : null;
+      const toolUseId = typeof payload?.toolUseId === "string" ? payload.toolUseId : null;
+      if (!toolUseId || typeof payload?.isBackgrounded !== "boolean") {
+        continue;
+      }
+      if (payload.isBackgrounded) {
+        toolUseIds.add(toolUseId);
+      } else {
+        toolUseIds.delete(toolUseId);
+      }
+    }
+    return toolUseIds;
+  }, [stripSourceActivities]);
+  const composerSubagentStripItems = useMemo(
+    () =>
+      deriveComposerSubagentStripItems({
+        workEntries: stripWorkLogEntries,
+        liveTurnId: stripLiveTurnId,
+        backgroundedProviderThreadIds: backgroundedSubagentToolUseIds,
+        viewedThreadId: stripParentThread ? (activeThread?.id ?? null) : null,
+        parentRow: stripParentThread
+          ? { threadId: stripParentThread.id, label: stripParentThread.title ?? null }
+          : null,
+      }),
+    [
+      activeThread?.id,
+      backgroundedSubagentToolUseIds,
+      stripLiveTurnId,
+      stripParentThread,
+      stripWorkLogEntries,
+    ],
+  );
+  // Links workflow agent rows to their subagent child threads (and models) when the
+  // Task tool_use_id produced one; agents spawned without a tool call stay unlinked.
+  const workflowSubagentThreadsByToolUseId = useMemo(() => {
+    const refs = new Map<string, WorkflowSubagentThreadRef>();
+    for (const entry of enrichedWorkLogEntries) {
+      for (const subagent of entry.subagents ?? []) {
+        if (!subagent.providerThreadId) {
+          continue;
+        }
+        refs.set(subagent.providerThreadId, {
+          threadId: subagent.resolvedThreadId ?? subagent.threadId,
+          model: subagent.model,
+          effort: subagent.effort,
+        });
+      }
+    }
+    return refs;
+  }, [enrichedWorkLogEntries]);
+  // Persisted (per-thread) workflow run flags: pausedByUser tells the settled
+  // card apart from a plain stop; dismissed retires a settled card the run's
+  // activities would otherwise keep visible. Survive reloads via
+  // workflowRunUiStore instead of living in component state.
+  const workflowRunUiThreadState = useWorkflowRunUiThreadState(activeThreadId);
+  const pausedWorkflowTaskIds = useMemo(
+    () => new Set(workflowRunUiThreadState.pausedByUser),
+    [workflowRunUiThreadState.pausedByUser],
+  );
+  const dismissedWorkflowTaskIds = useMemo(
+    () => new Set(workflowRunUiThreadState.dismissed),
+    [workflowRunUiThreadState.dismissed],
+  );
+  const workflowRunState = useMemo(
+    () =>
+      deriveWorkflowRunState({
+        activities: threadActivities,
+        subagentThreadsByToolUseId: workflowSubagentThreadsByToolUseId,
+        pausedByUserTaskIds: pausedWorkflowTaskIds,
+        dismissedTaskIds: dismissedWorkflowTaskIds,
+      }),
+    [
+      threadActivities,
+      workflowSubagentThreadsByToolUseId,
+      pausedWorkflowTaskIds,
+      dismissedWorkflowTaskIds,
+    ],
+  );
+  return {
+    workLogEntries,
+    composerSubagentStripItems,
+    stripSourceThreadId,
+    workflowRunState,
+  };
+}

--- a/apps/web/src/components/chat/useChatWorkspaceSelection.ts
+++ b/apps/web/src/components/chat/useChatWorkspaceSelection.ts
@@ -1,0 +1,401 @@
+import {
+  type NativeApi,
+  type OrchestrationShellSnapshot,
+  type ProjectId,
+  type ProviderKind,
+  ThreadId,
+} from "@synara/contracts";
+import { workspaceRootsEqual } from "@synara/shared/threadWorkspace";
+import type { RefObject } from "react";
+import { useCallback } from "react";
+import { newCommandId } from "~/lib/utils";
+import { readNativeApi } from "~/nativeApi";
+import { type DraftThreadEnvMode, useComposerDraftStore } from "../../composerDraftStore";
+import { ensureHomeChatProject } from "../../lib/chatProjects";
+import {
+  PROJECT_CREATE_EXISTING_SYNC_ERROR,
+  PROJECT_CREATE_SYNC_ERROR,
+  createOrRecoverProjectFromPath,
+} from "../../lib/projectCreation";
+import { useProjectEnvironmentStore } from "../../projectEnvironmentStore";
+import { useStore } from "../../store";
+import type { Project, Thread } from "../../types";
+import { useWorkspacePathsStore } from "../../workspacePathsStore";
+import { type ComposerPromptEditorHandle } from "../ComposerPromptEditor";
+const LOCAL_PROJECT_DRAFT_CONTEXT = {
+  envMode: "local",
+  worktreePath: null,
+  branch: null,
+  lastKnownPr: null,
+} as const;
+const DRAFT_PROJECT_SYNC_MAX_ATTEMPTS = 6;
+const DRAFT_PROJECT_SYNC_DELAY_MS = 50;
+function waitForDraftProjectSyncDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+// Waits for a project to appear in the shell snapshot before a local draft points at it.
+async function waitForShellProjectById(
+  api: NativeApi,
+  projectId: ProjectId,
+): Promise<{
+  project: OrchestrationShellSnapshot["projects"][number] | null;
+  snapshot: OrchestrationShellSnapshot | null;
+}> {
+  let latestSnapshot: OrchestrationShellSnapshot | null = null;
+  for (let attempt = 1; attempt <= DRAFT_PROJECT_SYNC_MAX_ATTEMPTS; attempt += 1) {
+    const snapshot = await api.orchestration.getShellSnapshot().catch(() => null);
+    if (snapshot) {
+      latestSnapshot = snapshot;
+      const project = snapshot.projects.find((candidate) => candidate.id === projectId) ?? null;
+      if (project) {
+        return { project, snapshot };
+      }
+    }
+    if (attempt < DRAFT_PROJECT_SYNC_MAX_ATTEMPTS) {
+      await waitForDraftProjectSyncDelay(DRAFT_PROJECT_SYNC_DELAY_MS * attempt);
+    }
+  }
+  return { project: null, snapshot: latestSnapshot };
+}
+interface ChatWorkspaceSelectionInput {
+  threadId: ThreadId;
+  activeThread: Thread | undefined;
+  activeProject: Project | undefined;
+  activeRootBranch: string | null;
+  isServerThread: boolean;
+  isLocalDraftThread: boolean;
+  isHomeChatContainer: boolean;
+  isStudioContainer: boolean;
+  hasNativeUserMessages: boolean;
+  composerEditorRef: RefObject<ComposerPromptEditorHandle | null>;
+  scheduleComposerFocus: () => void;
+  defaultProvider: ProviderKind;
+}
+
+export function useChatWorkspaceSelection({
+  threadId,
+  activeThread,
+  activeProject,
+  activeRootBranch,
+  isServerThread,
+  isLocalDraftThread,
+  isHomeChatContainer,
+  isStudioContainer,
+  hasNativeUserMessages,
+  composerEditorRef,
+  scheduleComposerFocus,
+  defaultProvider,
+}: ChatWorkspaceSelectionInput) {
+  const syncServerShellSnapshot = useStore((store) => store.syncServerShellSnapshot);
+  const setStoreThreadWorkspace = useStore((store) => store.setThreadWorkspace);
+  const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
+  const moveDraftThreadToProject = useComposerDraftStore((store) => store.moveDraftThreadToProject);
+  const draftThread = useComposerDraftStore(
+    (store) => store.draftThreadsByThreadId[threadId] ?? null,
+  );
+  const homeDir = useWorkspacePathsStore((state) => state.homeDir);
+  const chatWorkspaceRoot = useWorkspacePathsStore((state) => state.chatWorkspaceRoot);
+  const onEnvModeChange = useCallback(
+    (mode: DraftThreadEnvMode) => {
+      if (activeProject) {
+        useProjectEnvironmentStore.getState().setProjectEnvMode(activeProject.id, mode);
+      }
+      const nextBranch =
+        mode === "worktree"
+          ? (activeThread?.branch ?? draftThread?.branch ?? activeRootBranch ?? null)
+          : (activeThread?.branch ?? draftThread?.branch ?? null);
+      if (isLocalDraftThread) {
+        setDraftThreadContext(threadId, {
+          envMode: mode,
+          ...(mode === "local" ? { worktreePath: null } : {}),
+          ...(nextBranch ? { branch: nextBranch } : {}),
+        });
+      }
+      if (isServerThread && activeThread && !hasNativeUserMessages && !activeThread.session) {
+        const api = readNativeApi();
+        if (api) {
+          void api.orchestration.dispatchCommand({
+            type: "thread.meta.update",
+            commandId: newCommandId(),
+            threadId,
+            envMode: mode,
+            ...(nextBranch ? { branch: nextBranch } : {}),
+            ...(mode === "local" ? { worktreePath: null } : {}),
+          });
+        }
+      }
+      scheduleComposerFocus();
+    },
+    [
+      activeProject,
+      activeThread,
+      activeRootBranch,
+      draftThread?.branch,
+      hasNativeUserMessages,
+      isLocalDraftThread,
+      isServerThread,
+      scheduleComposerFocus,
+      setDraftThreadContext,
+      threadId,
+    ],
+  );
+
+  const moveEmptyDraftToLocalProject = useCallback(
+    (
+      projectId: ProjectId,
+      options?: {
+        restoreComposerFocus?: boolean;
+      },
+    ) => {
+      // Project moves reset branch; the previous project's current branch may not exist here.
+      moveDraftThreadToProject(threadId, projectId, LOCAL_PROJECT_DRAFT_CONTEXT);
+      if (options?.restoreComposerFocus ?? true) {
+        scheduleComposerFocus();
+      }
+    },
+    [moveDraftThreadToProject, scheduleComposerFocus, threadId],
+  );
+
+  const handleResetWorkspaceToHome = useCallback(() => {
+    // The inline reset action prevents pointer-down from stealing editor focus. Avoid refocusing
+    // an already-focused editor: focusAtEnd would move its cursor and schedule a redundant frame.
+    // Picker-menu resets still restore focus because the editor is no longer active in that path.
+    const restoreComposerFocus = !composerEditorRef.current?.isFocused();
+    if (isLocalDraftThread) {
+      if (isStudioContainer) {
+        setDraftThreadContext(threadId, {
+          envMode: "local",
+          branch: null,
+          worktreePath: null,
+          workingDirectory: null,
+          lastKnownPr: null,
+        });
+        if (restoreComposerFocus) {
+          scheduleComposerFocus();
+        }
+        return;
+      }
+      if (!isHomeChatContainer) {
+        return (async () => {
+          if (!homeDir) {
+            throw new Error("Home folder is not available yet.");
+          }
+          const homeProjectId = await ensureHomeChatProject({ homeDir, chatWorkspaceRoot });
+          if (!homeProjectId) {
+            throw new Error("Unable to prepare a normal chat.");
+          }
+          const api = readNativeApi();
+          if (!api) {
+            throw new Error("App is still connecting. Try again in a moment.");
+          }
+          const hasHomeProjectInStore = useStore
+            .getState()
+            .projects.some((project) => project.id === homeProjectId);
+          if (!hasHomeProjectInStore) {
+            const { project, snapshot } = await waitForShellProjectById(api, homeProjectId);
+            if (!project || !snapshot) {
+              throw new Error(PROJECT_CREATE_SYNC_ERROR);
+            }
+            syncServerShellSnapshot(snapshot);
+          }
+          moveEmptyDraftToLocalProject(homeProjectId, { restoreComposerFocus });
+        })();
+      }
+      setDraftThreadContext(threadId, {
+        envMode: "local",
+        worktreePath: null,
+        workingDirectory: null,
+        branch: null,
+        lastKnownPr: null,
+      });
+      if (restoreComposerFocus) {
+        scheduleComposerFocus();
+      }
+      return;
+    }
+
+    if (activeThread) {
+      setStoreThreadWorkspace(activeThread.id, {
+        envMode: "local",
+        worktreePath: null,
+        ...(isStudioContainer ? { workingDirectory: null } : {}),
+      });
+      const api = readNativeApi();
+      if (api && !hasNativeUserMessages && !activeThread.session) {
+        void api.orchestration.dispatchCommand({
+          type: "thread.meta.update",
+          commandId: newCommandId(),
+          threadId: activeThread.id,
+          envMode: "local",
+          worktreePath: null,
+          ...(isStudioContainer ? { workingDirectory: null } : {}),
+        });
+      }
+    }
+    if (restoreComposerFocus) {
+      scheduleComposerFocus();
+    }
+  }, [
+    composerEditorRef,
+    activeThread,
+    chatWorkspaceRoot,
+    hasNativeUserMessages,
+    homeDir,
+    isHomeChatContainer,
+    isLocalDraftThread,
+    isStudioContainer,
+    moveEmptyDraftToLocalProject,
+    scheduleComposerFocus,
+    setDraftThreadContext,
+    setStoreThreadWorkspace,
+    syncServerShellSnapshot,
+    threadId,
+  ]);
+
+  const handleSelectWorkspaceRoot = useCallback(
+    (workspaceRoot: string) => {
+      if (isStudioContainer) {
+        if (isLocalDraftThread) {
+          setDraftThreadContext(threadId, {
+            envMode: "local",
+            branch: null,
+            worktreePath: null,
+            workingDirectory: workspaceRoot,
+          });
+        } else if (activeThread) {
+          setStoreThreadWorkspace(activeThread.id, {
+            envMode: "local",
+            branch: null,
+            worktreePath: null,
+            workingDirectory: workspaceRoot,
+          });
+          if (!hasNativeUserMessages && !activeThread.session) {
+            const api = readNativeApi();
+            if (api) {
+              void api.orchestration.dispatchCommand({
+                type: "thread.meta.update",
+                commandId: newCommandId(),
+                threadId: activeThread.id,
+                envMode: "local",
+                branch: null,
+                worktreePath: null,
+                workingDirectory: workspaceRoot,
+              });
+            }
+          }
+        }
+        scheduleComposerFocus();
+        return;
+      }
+      if (isLocalDraftThread) {
+        setDraftThreadContext(threadId, {
+          envMode: "worktree",
+          worktreePath: workspaceRoot,
+        });
+        scheduleComposerFocus();
+        return;
+      }
+
+      if (activeThread) {
+        setStoreThreadWorkspace(activeThread.id, {
+          envMode: "worktree",
+          worktreePath: workspaceRoot,
+        });
+      }
+      scheduleComposerFocus();
+    },
+    [
+      activeThread,
+      hasNativeUserMessages,
+      isLocalDraftThread,
+      isStudioContainer,
+      scheduleComposerFocus,
+      setDraftThreadContext,
+      setStoreThreadWorkspace,
+      threadId,
+    ],
+  );
+
+  const handleSelectProjectForEmptyDraft = useCallback(
+    (projectId: ProjectId) => {
+      if (!isLocalDraftThread) {
+        return;
+      }
+      const project = useStore
+        .getState()
+        .projects.find((candidate) => candidate.id === projectId && candidate.kind === "project");
+      if (!project) {
+        throw new Error("Selected project is not available.");
+      }
+      if (draftThread?.projectId === projectId) {
+        scheduleComposerFocus();
+        return;
+      }
+      moveEmptyDraftToLocalProject(projectId);
+    },
+    [
+      draftThread?.projectId,
+      isLocalDraftThread,
+      moveEmptyDraftToLocalProject,
+      scheduleComposerFocus,
+    ],
+  );
+
+  const handleCreateProjectFromPickerPath = useCallback(
+    async (workspaceRoot: string) => {
+      if (!isLocalDraftThread) {
+        return;
+      }
+      const api = readNativeApi();
+      if (!api) {
+        throw new Error("App is still connecting. Try again in a moment.");
+      }
+
+      const existingProject = useStore
+        .getState()
+        .projects.find(
+          (project) =>
+            project.kind === "project" && workspaceRootsEqual(project.cwd, workspaceRoot),
+        );
+      if (existingProject) {
+        handleSelectProjectForEmptyDraft(existingProject.id);
+        return;
+      }
+
+      const creationResult = await createOrRecoverProjectFromPath({
+        api,
+        workspaceRoot,
+        createIfMissing: false,
+        defaultProvider: defaultProvider,
+        loadSnapshot: () => api.orchestration.getShellSnapshot().catch(() => null),
+      });
+      if (creationResult.snapshot) {
+        syncServerShellSnapshot(creationResult.snapshot);
+      }
+      if (!creationResult.created && !creationResult.project) {
+        throw new Error(PROJECT_CREATE_EXISTING_SYNC_ERROR);
+      }
+      if (!creationResult.project) {
+        throw new Error(PROJECT_CREATE_SYNC_ERROR);
+      }
+      moveEmptyDraftToLocalProject(creationResult.project.id);
+    },
+    [
+      handleSelectProjectForEmptyDraft,
+      isLocalDraftThread,
+      moveEmptyDraftToLocalProject,
+      defaultProvider,
+      syncServerShellSnapshot,
+    ],
+  );
+  return {
+    onEnvModeChange,
+    handleResetWorkspaceToHome,
+    handleSelectWorkspaceRoot,
+    handleSelectProjectForEmptyDraft,
+    handleCreateProjectFromPickerPath,
+  };
+}

--- a/apps/web/src/components/chat/useComposerAttachmentPersistence.ts
+++ b/apps/web/src/components/chat/useComposerAttachmentPersistence.ts
@@ -1,0 +1,160 @@
+import { ThreadId } from "@synara/contracts";
+import { useEffect } from "react";
+import {
+  type ComposerImageAttachment,
+  type PersistedComposerImageAttachment,
+  useComposerDraftStore,
+} from "../../composerDraftStore";
+import { composerImageBlobKey, persistComposerImageBlob } from "../../lib/composerImageBlobStore";
+import { readFileAsDataUrl } from "../../lib/composerSend";
+
+// Shared by the live-composer and prompt-history attachment sync effects:
+// AppSnap images persist their bytes as IndexedDB blobs (reusing an existing
+// blob key when valid), everything else inlines a data URL. Falls back to the
+// already-persisted attachments for images whose serialization fails.
+async function stagePersistedComposerImageAttachments(input: {
+  threadId: ThreadId;
+  images: ReadonlyArray<ComposerImageAttachment>;
+  getPersistedAttachments: () => PersistedComposerImageAttachment[];
+}): Promise<PersistedComposerImageAttachment[]> {
+  try {
+    const existingPersistedById = new Map(
+      input.getPersistedAttachments().map((attachment) => [attachment.id, attachment]),
+    );
+    const stagedAttachmentById = new Map<string, PersistedComposerImageAttachment>();
+    await Promise.all(
+      input.images.map(async (image) => {
+        try {
+          if (image.source?.kind === "appsnap") {
+            const existingPersisted = existingPersistedById.get(image.id);
+            const expectedBlobKey = composerImageBlobKey(input.threadId, image.id);
+            const blobKey =
+              existingPersisted?.blobKey === expectedBlobKey
+                ? expectedBlobKey
+                : await persistComposerImageBlob({
+                    threadId: input.threadId,
+                    imageId: image.id,
+                    file: image.file,
+                  });
+            stagedAttachmentById.set(image.id, {
+              id: image.id,
+              name: image.name,
+              mimeType: image.mimeType,
+              sizeBytes: image.sizeBytes,
+              blobKey,
+              source: image.source,
+            });
+            return;
+          }
+          const dataUrl = await readFileAsDataUrl(image.file);
+          stagedAttachmentById.set(image.id, {
+            id: image.id,
+            name: image.name,
+            mimeType: image.mimeType,
+            sizeBytes: image.sizeBytes,
+            dataUrl,
+          });
+        } catch {
+          const existingPersisted = existingPersistedById.get(image.id);
+          if (existingPersisted) {
+            stagedAttachmentById.set(image.id, existingPersisted);
+          }
+        }
+      }),
+    );
+    return Array.from(stagedAttachmentById.values());
+  } catch {
+    const currentImageIds = new Set(input.images.map((image) => image.id));
+    return input
+      .getPersistedAttachments()
+      .filter((attachment) => currentImageIds.has(attachment.id));
+  }
+}
+interface ComposerAttachmentPersistenceInput {
+  threadId: ThreadId;
+  composerImages: readonly ComposerImageAttachment[];
+  composerPromptHistorySavedDraftImages: readonly ComposerImageAttachment[] | null;
+}
+
+export function useComposerAttachmentPersistence({
+  threadId,
+  composerImages,
+  composerPromptHistorySavedDraftImages,
+}: ComposerAttachmentPersistenceInput) {
+  const clearComposerDraftPersistedAttachments = useComposerDraftStore(
+    (store) => store.clearPersistedAttachments,
+  );
+  const syncComposerDraftPersistedAttachments = useComposerDraftStore(
+    (store) => store.syncPersistedAttachments,
+  );
+  const syncComposerDraftPromptHistorySavedDraftPersistedAttachments = useComposerDraftStore(
+    (store) => store.syncPromptHistorySavedDraftPersistedAttachments,
+  );
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      if (composerImages.length === 0) {
+        const hasDeferredBlobAttachment =
+          useComposerDraftStore
+            .getState()
+            .draftsByThreadId[threadId]?.persistedAttachments.some(
+              (attachment) => attachment.blobKey,
+            ) ?? false;
+        if (hasDeferredBlobAttachment) {
+          return;
+        }
+        clearComposerDraftPersistedAttachments(threadId);
+        return;
+      }
+      const staged = await stagePersistedComposerImageAttachments({
+        threadId,
+        images: composerImages,
+        getPersistedAttachments: () =>
+          useComposerDraftStore.getState().draftsByThreadId[threadId]?.persistedAttachments ?? [],
+      });
+      if (cancelled) {
+        return;
+      }
+      // Stage attachments in persisted draft state first so persist middleware can write them.
+      void syncComposerDraftPersistedAttachments(threadId, staged);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    clearComposerDraftPersistedAttachments,
+    composerImages,
+    syncComposerDraftPersistedAttachments,
+    threadId,
+  ]);
+
+  useEffect(() => {
+    if (
+      !composerPromptHistorySavedDraftImages ||
+      composerPromptHistorySavedDraftImages.length === 0
+    ) {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      const staged = await stagePersistedComposerImageAttachments({
+        threadId,
+        images: composerPromptHistorySavedDraftImages,
+        getPersistedAttachments: () =>
+          useComposerDraftStore.getState().draftsByThreadId[threadId]?.promptHistorySavedDraft
+            ?.persistedAttachments ?? [],
+      });
+      if (cancelled) {
+        return;
+      }
+      void syncComposerDraftPromptHistorySavedDraftPersistedAttachments(threadId, staged);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    composerPromptHistorySavedDraftImages,
+    syncComposerDraftPromptHistorySavedDraftPersistedAttachments,
+    threadId,
+  ]);
+}

--- a/apps/web/src/components/chat/useComposerDiscovery.ts
+++ b/apps/web/src/components/chat/useComposerDiscovery.ts
@@ -1,0 +1,212 @@
+import {
+  type ProjectEntry,
+  type ProviderKind,
+  type ProviderMentionReference,
+  type ProviderNativeCommandDescriptor,
+  type ProviderPluginDescriptor,
+  type ProviderSkillDescriptor,
+  type ProviderStartOptions,
+  ThreadId,
+} from "@synara/contracts";
+import { useDebouncedValue } from "@tanstack/react-pacer";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { isLocalFolderMentionQuery } from "~/lib/localFolderMentions";
+import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
+import {
+  providerCommandsQueryOptions,
+  providerComposerCapabilitiesQueryOptions,
+  providerPluginsQueryOptions,
+  providerSkillsQueryOptions,
+  supportsNativeSlashCommandDiscovery,
+  supportsPluginDiscovery,
+  supportsSkillDiscovery,
+  supportsThreadCompaction,
+} from "~/lib/providerDiscoveryReactQuery";
+import { type ComposerTrigger } from "../../composer-logic";
+import {
+  hasProviderNativeSlashCommand,
+  providerSupportsTextNativeReviewCommand,
+} from "../../composerSlashCommands";
+
+const EMPTY_PROJECT_ENTRIES: ProjectEntry[] = [];
+const EMPTY_PROVIDER_NATIVE_COMMANDS: ProviderNativeCommandDescriptor[] = [];
+const EMPTY_PROVIDER_SKILLS: ProviderSkillDescriptor[] = [];
+type ComposerPluginSuggestion = {
+  plugin: ProviderPluginDescriptor;
+  mention: ProviderMentionReference;
+};
+
+const EMPTY_COMPOSER_PLUGIN_SUGGESTIONS: ComposerPluginSuggestion[] = [];
+const COMPOSER_PATH_QUERY_DEBOUNCE_MS = 120;
+interface ComposerDiscoveryInput {
+  threadId: ThreadId;
+  selectedProvider: ProviderKind;
+  composerTrigger: ComposerTrigger | null;
+  composerCommandPicker: "fork-target" | "review-target" | null;
+  providerModelDiscoveryCwd: string | null;
+  providerOptionsForDispatch: ProviderStartOptions | undefined;
+  gitCwd: string | null;
+  piAgentDir: string;
+}
+
+export function useComposerDiscovery({
+  threadId,
+  selectedProvider,
+  composerTrigger,
+  composerCommandPicker,
+  providerModelDiscoveryCwd,
+  providerOptionsForDispatch,
+  gitCwd,
+  piAgentDir,
+}: ComposerDiscoveryInput) {
+  const composerTriggerKind = composerTrigger?.kind ?? null;
+  const mentionTriggerQuery = composerTrigger?.kind === "mention" ? composerTrigger.query : "";
+  const isMentionTrigger = composerTriggerKind === "mention";
+
+  const isLocalFolderBrowserOpen =
+    composerCommandPicker === null &&
+    isMentionTrigger &&
+    isLocalFolderMentionQuery(mentionTriggerQuery);
+  const isSkillTrigger = composerTriggerKind === "skill";
+  const [debouncedPathQuery, composerPathQueryDebouncer] = useDebouncedValue(
+    mentionTriggerQuery,
+    { wait: COMPOSER_PATH_QUERY_DEBOUNCE_MS },
+    (debouncerState) => ({ isPending: debouncerState.isPending }),
+  );
+  const effectiveMentionQuery = mentionTriggerQuery.length > 0 ? debouncedPathQuery : "";
+  const composerSkillCwd = providerModelDiscoveryCwd;
+  const providerComposerCapabilitiesQuery = useQuery(
+    providerComposerCapabilitiesQueryOptions(selectedProvider),
+  );
+  const providerCommandsQuery = useQuery(
+    providerCommandsQueryOptions({
+      provider: selectedProvider,
+      cwd: composerSkillCwd,
+      threadId,
+      binaryPath:
+        (selectedProvider === "opencode"
+          ? providerOptionsForDispatch?.opencode?.binaryPath
+          : selectedProvider === "devin"
+            ? providerOptionsForDispatch?.devin?.binaryPath
+            : null) ?? null,
+      serverUrl:
+        (selectedProvider === "opencode"
+          ? providerOptionsForDispatch?.opencode?.serverUrl
+          : null) ?? null,
+      experimentalWebSockets:
+        selectedProvider === "opencode"
+          ? providerOptionsForDispatch?.opencode?.experimentalWebSockets
+          : undefined,
+      agentDir: selectedProvider === "pi" ? piAgentDir || null : null,
+      enabled:
+        (composerTriggerKind === "slash-command" || composerTriggerKind === "slash-model") &&
+        supportsNativeSlashCommandDiscovery(providerComposerCapabilitiesQuery.data) &&
+        composerSkillCwd !== null,
+    }),
+  );
+  const canDiscoverProviderSkills =
+    selectedProvider === "pi" || supportsSkillDiscovery(providerComposerCapabilitiesQuery.data);
+  const providerSkillsQuery = useQuery(
+    providerSkillsQueryOptions({
+      provider: selectedProvider,
+      cwd: composerSkillCwd,
+      threadId,
+      agentDir: selectedProvider === "pi" ? piAgentDir || null : null,
+      enabled:
+        (isSkillTrigger || composerTriggerKind === "slash-command" || selectedProvider === "pi") &&
+        canDiscoverProviderSkills &&
+        composerSkillCwd !== null,
+    }),
+  );
+  const providerPluginsQuery = useQuery(
+    providerPluginsQueryOptions({
+      provider: selectedProvider,
+      cwd: composerSkillCwd,
+      threadId,
+      enabled:
+        supportsPluginDiscovery(providerComposerCapabilitiesQuery.data) &&
+        composerSkillCwd !== null,
+    }),
+  );
+  const workspaceEntriesQuery = useQuery(
+    projectSearchEntriesQueryOptions({
+      cwd: gitCwd,
+      query: effectiveMentionQuery,
+      enabled: isMentionTrigger && !isLocalFolderBrowserOpen,
+      limit: 80,
+    }),
+  );
+  const workspaceEntries = workspaceEntriesQuery.data?.entries ?? EMPTY_PROJECT_ENTRIES;
+
+  // Keep plugin suggestions referentially stable so prompt-sync effects do not loop on rerender.
+  const providerPlugins = useMemo(
+    () =>
+      providerPluginsQuery.data?.marketplaces.flatMap((marketplace) =>
+        marketplace.plugins.map((plugin) => ({
+          plugin,
+          mention: {
+            name: plugin.name,
+            path: `plugin://${plugin.name}@${marketplace.name}`,
+          } satisfies ProviderMentionReference,
+        })),
+      ) ?? EMPTY_COMPOSER_PLUGIN_SUGGESTIONS,
+    [providerPluginsQuery.data],
+  );
+  const providerNativeCommands =
+    providerCommandsQuery.data?.commands ?? EMPTY_PROVIDER_NATIVE_COMMANDS;
+  const providerNativeCommandNames = useMemo(
+    () => providerNativeCommands.map((command) => command.name),
+    [providerNativeCommands],
+  );
+  const effectiveComposerTrigger = useMemo(() => {
+    if (
+      composerTrigger?.kind === "slash-model" &&
+      hasProviderNativeSlashCommand(selectedProvider, providerNativeCommandNames, "model")
+    ) {
+      return {
+        ...composerTrigger,
+        kind: "slash-command" as const,
+        query: "model",
+      };
+    }
+    return composerTrigger;
+  }, [composerTrigger, providerNativeCommandNames, selectedProvider]);
+  const effectiveComposerTriggerKind = effectiveComposerTrigger?.kind ?? null;
+  const supportsTextNativeReviewCommand = useMemo(
+    () => providerSupportsTextNativeReviewCommand(selectedProvider, providerNativeCommands),
+    [providerNativeCommands, selectedProvider],
+  );
+  const providerSkills = providerSkillsQuery.data?.skills ?? EMPTY_PROVIDER_SKILLS;
+
+  const isComposerMenuLoading =
+    (composerTriggerKind === "mention" &&
+      ((mentionTriggerQuery.length > 0 && composerPathQueryDebouncer.state.isPending) ||
+        workspaceEntriesQuery.isLoading ||
+        workspaceEntriesQuery.isFetching ||
+        providerPluginsQuery.isLoading ||
+        providerPluginsQuery.isFetching)) ||
+    (composerTriggerKind === "slash-command" &&
+      (providerCommandsQuery.isLoading ||
+        providerCommandsQuery.isFetching ||
+        providerSkillsQuery.isLoading ||
+        providerSkillsQuery.isFetching)) ||
+    (composerTriggerKind === "skill" &&
+      (providerComposerCapabilitiesQuery.isLoading ||
+        providerComposerCapabilitiesQuery.isFetching ||
+        providerSkillsQuery.isLoading ||
+        providerSkillsQuery.isFetching));
+  return {
+    mentionTriggerQuery,
+    isLocalFolderBrowserOpen,
+    providerPlugins,
+    providerNativeCommands,
+    providerSkills,
+    workspaceEntries,
+    effectiveComposerTrigger,
+    effectiveComposerTriggerKind,
+    supportsTextNativeReviewCommand,
+    isComposerMenuLoading,
+    canCompactThread: supportsThreadCompaction(providerComposerCapabilitiesQuery.data),
+  };
+}

--- a/apps/web/src/components/chat/useComposerReferences.ts
+++ b/apps/web/src/components/chat/useComposerReferences.ts
@@ -1,0 +1,129 @@
+import {
+  type ProviderKind,
+  type ProviderMentionReference,
+  type ProviderSkillReference,
+  ThreadId,
+} from "@synara/contracts";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  filterPromptProviderMentionReferences,
+  filterPromptSkillReferences,
+  providerMentionReferencesEqual,
+  providerSkillReferencesEqual,
+} from "~/lib/composerMentions";
+import { useComposerDraftStore } from "../../composerDraftStore";
+
+interface ComposerReferencesInput {
+  threadId: ThreadId;
+  selectedProvider: ProviderKind;
+  prompt: string;
+  composerSkills: ProviderSkillReference[];
+  composerMentions: ProviderMentionReference[];
+}
+
+export function useComposerReferences({
+  threadId,
+  selectedProvider,
+  prompt,
+  composerSkills,
+  composerMentions,
+}: ComposerReferencesInput) {
+  const setComposerDraftSkills = useComposerDraftStore((store) => store.setSkills);
+  const setComposerDraftMentions = useComposerDraftStore((store) => store.setMentions);
+  const [selectedComposerSkills, setSelectedComposerSkills] = useState<ProviderSkillReference[]>(
+    () => composerSkills,
+  );
+  const [selectedComposerMentions, setSelectedComposerMentions] = useState<
+    ProviderMentionReference[]
+  >(() => composerMentions);
+  const selectedComposerSkillsRef = useRef<ProviderSkillReference[]>(selectedComposerSkills);
+  const selectedComposerMentionsRef = useRef<ProviderMentionReference[]>(selectedComposerMentions);
+  // The setters below stamp these refs synchronously; layout effects backstop
+  // external state changes before another browser event can read stale values.
+  useLayoutEffect(() => {
+    selectedComposerSkillsRef.current = selectedComposerSkills;
+  }, [selectedComposerSkills]);
+  useLayoutEffect(() => {
+    selectedComposerMentionsRef.current = selectedComposerMentions;
+  }, [selectedComposerMentions]);
+  const updateSelectedComposerSkills = useCallback(
+    (
+      next:
+        | ProviderSkillReference[]
+        | ((existing: ProviderSkillReference[]) => ProviderSkillReference[]),
+    ) => {
+      const existing = selectedComposerSkillsRef.current;
+      const resolved = typeof next === "function" ? next(existing) : next;
+      selectedComposerSkillsRef.current = resolved;
+      setSelectedComposerSkills(resolved);
+      setComposerDraftSkills(threadId, resolved);
+    },
+    [setComposerDraftSkills, threadId],
+  );
+  const updateSelectedComposerMentions = useCallback(
+    (
+      next:
+        | ProviderMentionReference[]
+        | ((existing: ProviderMentionReference[]) => ProviderMentionReference[]),
+    ) => {
+      const existing = selectedComposerMentionsRef.current;
+      const resolved = typeof next === "function" ? next(existing) : next;
+      selectedComposerMentionsRef.current = resolved;
+      setSelectedComposerMentions(resolved);
+      setComposerDraftMentions(threadId, resolved);
+    },
+    [setComposerDraftMentions, threadId],
+  );
+
+  const previousSelectedProviderRef = useRef<{
+    threadId: ThreadId;
+    provider: ProviderKind;
+  } | null>(null);
+
+  useLayoutEffect(() => {
+    updateSelectedComposerSkills(composerSkills);
+    updateSelectedComposerMentions(composerMentions);
+  }, [
+    composerMentions,
+    composerSkills,
+    threadId,
+    updateSelectedComposerMentions,
+    updateSelectedComposerSkills,
+  ]);
+
+  useEffect(() => {
+    updateSelectedComposerSkills((existing) => {
+      const nextSkills = filterPromptSkillReferences(prompt, existing, selectedProvider);
+      return providerSkillReferencesEqual(existing, nextSkills) ? existing : nextSkills;
+    });
+  }, [prompt, selectedProvider, updateSelectedComposerSkills]);
+
+  useEffect(() => {
+    updateSelectedComposerMentions((existing) => {
+      const nextMentions = filterPromptProviderMentionReferences(prompt, existing);
+      return providerMentionReferencesEqual(existing, nextMentions) ? existing : nextMentions;
+    });
+  }, [prompt, updateSelectedComposerMentions]);
+
+  // Provider references are provider-specific; keep draft restores from looking like manual switches.
+  useEffect(() => {
+    const previous = previousSelectedProviderRef.current;
+    previousSelectedProviderRef.current = {
+      threadId,
+      provider: selectedProvider,
+    };
+    if (!previous || previous.threadId !== threadId || previous.provider === selectedProvider) {
+      return;
+    }
+    updateSelectedComposerSkills([]);
+    updateSelectedComposerMentions([]);
+  }, [selectedProvider, threadId, updateSelectedComposerMentions, updateSelectedComposerSkills]);
+  return {
+    selectedComposerSkills,
+    selectedComposerMentions,
+    selectedComposerSkillsRef,
+    selectedComposerMentionsRef,
+    updateSelectedComposerSkills,
+    updateSelectedComposerMentions,
+  };
+}

--- a/apps/web/src/components/chatHotPath.compiler.test.ts
+++ b/apps/web/src/components/chatHotPath.compiler.test.ts
@@ -22,52 +22,141 @@
 // Layer: Web build-integrity test
 // Depends on: babel-plugin-react-compiler (same plugin the Vite build uses).
 
-import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { transformSync } from "@babel/core";
 import { describe, expect, it } from "vitest";
 
-interface CompilerEvent {
-  readonly kind: string;
-  readonly fnName?: string | null | undefined;
-  readonly detail?: { readonly reason?: string; readonly description?: string } | undefined;
-}
-
-// Mirrors ChatMarkdown.compiler.test.ts. Both harnesses should move to a shared
-// helper module once one can be added alongside these tests.
-function compileEvents(filePath: string): CompilerEvent[] {
-  const events: CompilerEvent[] = [];
-  transformSync(readFileSync(filePath, "utf8"), {
-    filename: filePath,
-    configFile: false,
-    babelrc: false,
-    parserOpts: { plugins: ["typescript", "jsx"] },
-    plugins: [
-      [
-        "babel-plugin-react-compiler",
-        {
-          panicThreshold: "none",
-          logger: {
-            logEvent: (_fn: unknown, event: CompilerEvent) => {
-              events.push(event);
-            },
-          },
-        },
-      ],
-    ],
-  });
-  return events;
-}
+import { compileReactModule } from "../test/reactCompiler";
 
 interface HotPathModule {
   readonly relativePath: string;
+  readonly requiredFunction?: string;
   // Exact multiset of bailout reasons that are deliberate and reviewed. Anything
   // else — including a second copy of an allowed reason — fails the test.
   readonly allowedBailoutReasons: readonly string[];
 }
 
 const HOT_PATH_MODULES: readonly HotPathModule[] = [
-  { relativePath: "ChatView.tsx", allowedBailoutReasons: [] },
+  { relativePath: "ChatView.tsx", requiredFunction: "ChatView", allowedBailoutReasons: [] },
+  {
+    relativePath: "chat/useChatTranscriptScroll.ts",
+    requiredFunction: "useChatTranscriptScroll",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useChatTimelineMessages.ts",
+    requiredFunction: "useChatTimelineMessages",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useChatWorkLog.ts",
+    requiredFunction: "useChatWorkLog",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useChatWorkspaceSelection.ts",
+    requiredFunction: "useChatWorkspaceSelection",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useChatProjectScripts.ts",
+    requiredFunction: "useChatProjectScripts",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useComposerAttachmentPersistence.ts",
+    requiredFunction: "useComposerAttachmentPersistence",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/ChatComposerFooter.tsx",
+    requiredFunction: "ChatComposerFooter",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useComposerDiscovery.ts",
+    requiredFunction: "useComposerDiscovery",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useComposerReferences.ts",
+    requiredFunction: "useComposerReferences",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/WorkflowRunCard.tsx",
+    requiredFunction: "WorkflowRunCard",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useChatProviderModels.ts",
+    requiredFunction: "useChatProviderModels",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useChatProviderStatus.ts",
+    requiredFunction: "useChatProviderStatus",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useChatRuntimeModes.ts",
+    requiredFunction: "useChatRuntimeModes",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useChatPendingInteractions.ts",
+    requiredFunction: "useChatPendingInteractions",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useChatComposerDraft.ts",
+    requiredFunction: "useChatComposerDraft",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useChatLocalDispatch.ts",
+    requiredFunction: "useChatLocalDispatch",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useChatAutomationCreation.ts",
+    requiredFunction: "useChatAutomationCreation",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useChatComposerEditing.ts",
+    requiredFunction: "useChatComposerEditing",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useChatComposerCommands.ts",
+    requiredFunction: "useChatComposerCommands",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useChatTurnSubmission.ts",
+    requiredFunction: "useChatTurnSubmission",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useChatTurnFollowUps.ts",
+    requiredFunction: "useChatTurnFollowUps",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useChatKeyboardShortcuts.ts",
+    requiredFunction: "useChatKeyboardShortcuts",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useChatQueuedTurns.ts",
+    requiredFunction: "useChatQueuedTurns",
+    allowedBailoutReasons: [],
+  },
+  {
+    relativePath: "chat/useChatTurnExecution.ts",
+    requiredFunction: "useChatTurnExecution",
+    allowedBailoutReasons: [],
+  },
   { relativePath: "Sidebar.tsx", allowedBailoutReasons: [] },
   {
     relativePath: "chat/MessagesTimeline.tsx",
@@ -98,7 +187,7 @@ const HOT_PATH_MODULES: readonly HotPathModule[] = [
 ];
 
 /**
- * These are among the largest modules in the app — ChatView.tsx alone is ~11k lines, and a cold
+ * These are among the largest modules in the app — a cold
  * Babel compile of it was measured at 66s while the rest of the workspace suite competed for CPU.
  * The budget only exists to stop a hang, so it is set far above the observed worst case rather
  * than near it; a tight bound here fails the suite for machine load, not for a real regression.
@@ -110,13 +199,24 @@ describe("chat hot-path React Compiler coverage", () => {
     it(
       `compiles ${module.relativePath} without unexpected bailouts`,
       () => {
-        const events = compileEvents(join(import.meta.dirname, module.relativePath));
+        const events = compileReactModule(join(import.meta.dirname, module.relativePath));
         const bailoutReasons = events
           .filter((event) => event.kind === "CompileError")
           .map((event) => event.detail?.reason ?? event.detail?.description ?? "unknown")
-          .sort();
+          .toSorted();
 
-        expect(bailoutReasons).toEqual([...module.allowedBailoutReasons].sort());
+        // Pipeline failures (including stack overflows) do not emit CompileError.
+        // A successful helper must not mask failure to compile the main component.
+        expect(events.filter((event) => event.kind === "PipelineError")).toEqual([]);
+        expect(bailoutReasons).toEqual(module.allowedBailoutReasons.toSorted());
+        if (module.requiredFunction) {
+          expect(
+            events.some(
+              (event) =>
+                event.kind === "CompileSuccess" && event.fnName === module.requiredFunction,
+            ),
+          ).toBe(true);
+        }
         expect(events.some((event) => event.kind === "CompileSuccess")).toBe(true);
       },
       COMPILE_TIMEOUT_MS,

--- a/apps/web/src/hooks/useLocalStorage.browser.tsx
+++ b/apps/web/src/hooks/useLocalStorage.browser.tsx
@@ -1,11 +1,12 @@
 // FILE: useLocalStorage.browser.tsx
-// Purpose: Verifies cross-window localStorage clear events reset subscribed hook state.
+// Purpose: Verifies fresh schema-validated storage reads and cross-window hook synchronization.
 
 import * as Schema from "effect/Schema";
+import { flushSync } from "react-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook } from "vitest-browser-react";
 
-import { useLocalStorage } from "~/hooks/useLocalStorage";
+import { getLocalStorageItem, setLocalStorageItem, useLocalStorage } from "~/hooks/useLocalStorage";
 
 const STORAGE_KEY = "synara:test:use-local-storage-clear";
 
@@ -18,6 +19,68 @@ afterEach(() => {
 });
 
 describe("useLocalStorage cross-window synchronization", () => {
+  it("keeps each schema's encode/decode transformations when a storage key is shared", () => {
+    const numeric = Schema.NumberFromString.check(Schema.isFinite());
+    setLocalStorageItem(STORAGE_KEY, 42, numeric);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('"42"');
+    expect(getLocalStorageItem(STORAGE_KEY, numeric)).toBe(42);
+    expect(getLocalStorageItem(STORAGE_KEY, Schema.String)).toBe("42");
+
+    setLocalStorageItem(STORAGE_KEY, "updated", Schema.String);
+    expect(getLocalStorageItem(STORAGE_KEY, Schema.String)).toBe("updated");
+    expect(() => getLocalStorageItem(STORAGE_KEY, numeric)).toThrow();
+  });
+
+  it("reads and validates current storage rather than reusing decoded objects", () => {
+    const schema = Schema.Struct({ count: Schema.Number });
+    setLocalStorageItem(STORAGE_KEY, { count: 1 }, schema);
+    const first = getLocalStorageItem(STORAGE_KEY, schema);
+    const second = getLocalStorageItem(STORAGE_KEY, schema);
+    expect(second).toEqual({ count: 1 });
+    expect(second).not.toBe(first);
+
+    window.localStorage.setItem(STORAGE_KEY, '{"count":2}');
+    expect(getLocalStorageItem(STORAGE_KEY, schema)).toEqual({ count: 2 });
+    window.localStorage.setItem(STORAGE_KEY, '{"count":"invalid"}');
+    expect(() => getLocalStorageItem(STORAGE_KEY, schema)).toThrow();
+    window.localStorage.removeItem(STORAGE_KEY);
+    expect(getLocalStorageItem(STORAGE_KEY, schema)).toBeNull();
+  });
+
+  it("synchronizes same-window subscribers after an updater writes through a shared codec", async () => {
+    const first = await renderHook(() => useLocalStorage(STORAGE_KEY, 0, Schema.NumberFromString));
+    const second = await renderHook(() => useLocalStorage(STORAGE_KEY, 0, Schema.NumberFromString));
+    try {
+      flushSync(() => first.result.current[1]((previous) => previous + 1));
+      await vi.waitFor(() => expect(second.result.current[0]).toBe(1));
+      flushSync(() => second.result.current[1]((previous) => previous + 1));
+      await vi.waitFor(() => expect(first.result.current[0]).toBe(2));
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBe('"2"');
+    } finally {
+      await first.unmount();
+      await second.unmount();
+    }
+  });
+
+  it("falls back on corrupt cross-window data and recovers on the next valid value", async () => {
+    setLocalStorageItem(STORAGE_KEY, "initial", Schema.String);
+    const hook = await renderHook(() => useLocalStorage(STORAGE_KEY, "fallback", Schema.String));
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      for (const invalid of ['{"broken":', "123"]) {
+        window.localStorage.setItem(STORAGE_KEY, invalid);
+        window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
+        await vi.waitFor(() => expect(hook.result.current[0]).toBe("fallback"));
+      }
+      window.localStorage.setItem(STORAGE_KEY, '"recovered"');
+      window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
+      await vi.waitFor(() => expect(hook.result.current[0]).toBe("recovered"));
+    } finally {
+      error.mockRestore();
+      await hook.unmount();
+    }
+  });
+
   it("returns to its fallback after another window clears localStorage", async () => {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify("persisted"));
     const hook = await renderHook(() => useLocalStorage(STORAGE_KEY, "fallback", Schema.String));

--- a/apps/web/src/hooks/useLocalStorage.ts
+++ b/apps/web/src/hooks/useLocalStorage.ts
@@ -19,11 +19,25 @@ const isomorphicLocalStorage: Storage =
         };
       })();
 
+// Reuse the JSON schema (and Effect's compiled parser) across subscribers.
+// Cache only schema machinery: every read still fetches and validates the current value.
+const jsonSchemasByCodec = new WeakMap<Schema.Top, Schema.Codec<unknown, string>>();
+
+function getJsonSchema<T, E>(schema: Schema.Codec<T, E>): Schema.Codec<T, string> {
+  let jsonSchema = jsonSchemasByCodec.get(schema);
+  if (!jsonSchema) {
+    jsonSchema = Schema.fromJsonString(schema);
+    jsonSchemasByCodec.set(schema, jsonSchema);
+  }
+  // The schema identity ties the cached decoded type to the caller's T.
+  return jsonSchema as Schema.Codec<T, string>;
+}
+
 const decode = <T, E>(schema: Schema.Codec<T, E>, value: string) =>
-  Schema.decodeSync(Schema.fromJsonString(schema))(value);
+  Schema.decodeSync(getJsonSchema(schema))(value);
 
 const encode = <T, E>(schema: Schema.Codec<T, E>, value: T) =>
-  Schema.encodeSync(Schema.fromJsonString(schema))(value);
+  Schema.encodeSync(getJsonSchema(schema))(value);
 
 export const getLocalStorageItem = <T, E>(key: string, schema: Schema.Codec<T, E>): T | null => {
   const item = isomorphicLocalStorage.getItem(key);

--- a/apps/web/src/test/reactCompiler.ts
+++ b/apps/web/src/test/reactCompiler.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { transformSync } from "@babel/core";
+
+export interface CompilerEvent {
+  readonly kind: string;
+  readonly fnName?: string | null;
+  readonly detail?: { readonly reason?: string; readonly description?: string };
+  readonly data?: unknown;
+}
+
+export function compileReactModule(filePath: string): CompilerEvent[] {
+  const events: CompilerEvent[] = [];
+  transformSync(readFileSync(filePath, "utf8"), {
+    filename: filePath,
+    configFile: false,
+    babelrc: false,
+    parserOpts: { plugins: ["typescript", "jsx"] },
+    plugins: [
+      [
+        "babel-plugin-react-compiler",
+        {
+          panicThreshold: "none",
+          logger: {
+            logEvent: (_filename: unknown, event: CompilerEvent) => events.push(event),
+          },
+        },
+      ],
+    ],
+  });
+  return events;
+}


### PR DESCRIPTION
## What Changed

Split the 12,932-line `ChatView.tsx` into modules with separate responsibilities and remove repeated settings-schema construction from the chat opening path. `ChatView.tsx` is now 5,868 lines (55% smaller), with 30 extracted runtime modules covering composer state, send preparation/execution, queues, follow-ups, provider/workspace state, transcript scrolling, and keyboard shortcuts.

The extraction preserves draft restoration, optimistic sends, queue claim/drain ordering, workspace promotion, and live-text scroll ownership. Workflow elapsed-time updates now live in `WorkflowRunCard`: ten one-second ticks cause zero parent renders instead of ten, while the card still updates and stops its timer when settled.

The shared local-storage helper reuses JSON schemas through a WeakMap keyed by codec identity. Every read still reads, parses, and validates the current stored value; decoded values are not cached. Added regression coverage checks codec separation, fresh reads, same-window synchronization, and invalid-value fallback/recovery.

## Why

The monolithic component made unrelated responsibilities difficult to maintain and silently exceeded React Compiler's stack depth. The old test could pass when a helper compiled even if the main component failed. A shared compiler harness now rejects pipeline errors and requires the named component/hook to compile, with 38 hot-path module checks. Duplicate test setup and unused imports/actions were also removed.

Profiling the refactored route identified repeated `Schema.fromJsonString` construction across storage subscribers. Reusing that machinery removes a measured opening cost without changing persistence behavior.

### Performance evidence

Fresh A/B measurements compare the refactored chat **before and after the storage optimization**, with six repetitions per version and fixture, warmed modules, identical fixtures, and alternating before/after/after/before batches.

| Warm full-route mount | Before median (range) | After median (range) | Reduction |
| --- | ---: | ---: | ---: |
| Short: 10 messages, 20 activities | 570.5 ms (495.9–620.1) | 374.5 ms (332.4–429.5) | 34.4% |
| Large: 81 messages, 1,609 activities | 595.3 ms (513.1–647.2) | 326.3 ms (315.0–395.7) | 45.2% |

These are Chromium development-build measurements on one unthrottled macOS machine, using a fresh router, real application CSS, and mocked RPC. They include render/hydration and explicit animation-frame waits. They do not measure switching chats within an already-mounted shell, packaged Electron startup, or AI/provider response latency.

The extraction alone did not improve opening latency and increased the large-fixture React work over 30 mixed updates from 518.8 to 585.7 ms in a separate comparison. The later storage A/B reduced that workload from 586.4 to 534.5 ms; these separate runs are not a paired original-to-final benchmark. File extraction also adds explicit types and wiring: combined source grew by 28%. Pre-cache production builds increased total gzipped JavaScript by 0.26% and the chat route plus static imports by 0.95%; the large-chunk warning remains. Most extracted hooks still share ChatView's render lifecycle.

## Verification

- `bun fmt`, `bun lint`, and `bun typecheck` passed. Lint retains 559 existing warnings and zero errors.
- Focused unit/compiler suite: **494 passed across 17 files**.
- Chat browser coverage: **139 passed**, with 12 Linux-specific geometry cases skipped on macOS.
- Final storage browser suite: **5 passed**. A test-only finite-number expectation was corrected after confirming the original helper also accepts NaN; focused formatting/lint and web typecheck passed afterward.
- Both original and refactored production builds passed before the final storage-only change; that helper change was covered by the checks above but was not rebuilt separately.
- The browser suite's existing ResizeObserver notification was reproduced on the original baseline; the affected streaming-follow cases pass on both versions.
- Before publication, the changed source hashes and final storage patch were checked against the validated artifacts, and `git diff --check` passed.

## Checklist

- [x] Explained the refactor boundaries, behavior, and performance tradeoffs.
- [x] Included regression coverage and measured performance results with their limits.
- [x] No visual redesign or new animation behavior; screenshots/video are not applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with stricter compiler pipeline assertions; no runtime behavior changes.
> 
> **Overview**
> The **ChatMarkdown** React Compiler regression test now uses the shared **`compileReactModule`** harness from `apps/web/src/test/reactCompiler.ts` instead of inlining its own Babel transform and event logger.
> 
> It also **fails on `PipelineError` events**, in line with the chat hot-path compiler suite, so a broken compile pipeline cannot slip through while `CompileError` checks still pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21f7af0206ba144f588a87211602b11cb9ce9415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->