### PR TITLE
Add opt-in provider handoffs within the current conversation

### DIFF
--- a/apps/marketing/content/docs/workflows/handoffs.mdx
+++ b/apps/marketing/content/docs/workflows/handoffs.mdx
@@ -5,6 +5,22 @@ description: Continue the same Synara task and working environment with another 
 
 A provider handoff changes which provider continues one Synara task. Use it when the objective and environment should remain the same but another runtime is better suited to the next phase or useful as an independent second opinion.
 
+## Continue in the current conversation
+
+Turn on **Settings → Chat behavior → Continue handoffs in this chat** to keep the same Synara conversation when changing providers. The setting is off by default; while it is off, the existing handoff flow creates a destination conversation.
+
+With continuous handoff enabled, Synara:
+
+- waits for the active turn and provider interactions to settle
+- replaces the provider session without changing the thread or workspace
+- sends the receiving provider a bounded recap on its first turn
+- records each completed transition in the thread activity history
+- shows the provider path in the chat header, including a return marker when the path comes back to an earlier provider
+
+While a switch is pending, Synara disables the composer and rejects new turns at the server boundary. The composer unlocks only after a durable completion or failure record, so a fast follow-up cannot accidentally reach the previous provider. Providers such as Pi that do not have a static default use the first model returned by their configured runtime discovery when no prior or project selection exists.
+
+There is no handoff-count limit. The header compacts long paths to recent transitions, and Synara bounds each receiving-provider recap so a long-running conversation does not grow the next prompt without limit. Every completed transition remains in the durable event history and follows the normal activity-projection retention policy.
+
 ## Handoff or new task
 
 | Choose           | When                                                                                                 |

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
@@ -554,6 +554,7 @@ const makeOrchestrationEngine = Effect.gen(function* () {
       case "thread.approval.respond":
       case "thread.user-input.respond":
       case "thread.sidechat.expire":
+      case "thread.provider.handoff":
         return loadThreadDetailForDecider(command, commandReadModel, command.threadId);
       case "thread.message.assistant.complete":
         // Read the exact message, including a resumed message older than the

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -1204,6 +1204,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         ) AS ranks
         JOIN projection_thread_activities AS ranked USING (thread_id, activity_id)
         WHERE activity_rank <= ${MAX_SNAPSHOT_THREAD_ACTIVITIES}
+          OR kind IN ('provider.handoff.requested', 'provider.handoff.completed', 'provider.handoff.failed')
           OR (
             kind IN ('approval.requested', 'user-input.requested')
             AND json_extract(payload_json, '$.requestId') IS NOT NULL
@@ -1272,7 +1273,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
       `,
   });
 
-  const listCheckpointRevertLifecycleActivityRows = SqlSchema.findAll({
+  const listCommandLifecycleActivityRows = SqlSchema.findAll({
     Request: Schema.Void,
     Result: ProjectionThreadActivityDbRowSchema,
     execute: () =>
@@ -1292,7 +1293,9 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             thread_id,
             activity_id,
             ROW_NUMBER() OVER (
-              PARTITION BY thread_id
+              PARTITION BY thread_id,
+                CASE WHEN kind IN ('provider.handoff.requested', 'provider.handoff.completed', 'provider.handoff.failed')
+                  THEN 'provider-handoff' ELSE 'checkpoint-revert' END
               ORDER BY
                 CASE WHEN sequence IS NULL THEN 0 ELSE 1 END DESC,
                 sequence DESC,
@@ -1303,7 +1306,10 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           WHERE kind IN (
             'checkpoint.revert.started',
             'checkpoint.revert.succeeded',
-            'checkpoint.revert.failed'
+            'checkpoint.revert.failed',
+            'provider.handoff.requested',
+            'provider.handoff.completed',
+            'provider.handoff.failed'
           )
         ) AS ranks
         JOIN projection_thread_activities AS ranked USING (thread_id, activity_id)
@@ -1847,6 +1853,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                 AND (SELECT has_newer_turn FROM cutoff_turn_state)
               )
             )
+            OR kind IN ('provider.handoff.requested', 'provider.handoff.completed', 'provider.handoff.failed')
             OR (
               kind IN ('approval.requested', 'user-input.requested')
               AND json_extract(payload_json, '$.requestId') IS NOT NULL
@@ -2311,7 +2318,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             projectRows,
             threadRows,
             proposedPlanRows,
-            checkpointRevertActivityRows,
+            commandLifecycleActivityRows,
             sessionRows,
             latestTurnRows,
             stateRows,
@@ -2360,11 +2367,11 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                 ),
               ),
             ),
-            listCheckpointRevertLifecycleActivityRows(undefined).pipe(
+            listCommandLifecycleActivityRows(undefined).pipe(
               Effect.mapError(
                 toPersistenceSqlOrDecodeError(
-                  "ProjectionSnapshotQuery.getCommandReadModel:listCheckpointRevertActivities:query",
-                  "ProjectionSnapshotQuery.getCommandReadModel:listCheckpointRevertActivities:decodeRows",
+                  "ProjectionSnapshotQuery.getCommandReadModel:listCommandLifecycleActivities:query",
+                  "ProjectionSnapshotQuery.getCommandReadModel:listCommandLifecycleActivities:decodeRows",
                 ),
               ),
             ),
@@ -2395,15 +2402,15 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           ]);
 
           const proposedPlans = collectProjectedProposedPlans(proposedPlanRows);
-          const checkpointRevertActivities = collectProjectedActivities(
-            checkpointRevertActivityRows,
+          const commandLifecycleActivities = collectProjectedActivities(
+            commandLifecycleActivityRows,
           );
           const sessions = collectProjectedSessions(sessionRows);
           const latestTurns = collectProjectedLatestTurns(latestTurnRows);
 
           let updatedAt = collectBaseUpdatedAt({ spaceRows, projectRows, threadRows, stateRows });
           updatedAt = maxOptionalIso(updatedAt, proposedPlans.updatedAt);
-          updatedAt = maxOptionalIso(updatedAt, checkpointRevertActivities.updatedAt);
+          updatedAt = maxOptionalIso(updatedAt, commandLifecycleActivities.updatedAt);
           updatedAt = maxOptionalIso(updatedAt, sessions.updatedAt);
           updatedAt = maxOptionalIso(updatedAt, latestTurns.updatedAt);
 
@@ -2415,7 +2422,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
               latestTurn: latestTurns.byThread.get(row.threadId) ?? null,
               messages: [],
               proposedPlans: proposedPlans.byThread.get(row.threadId) ?? [],
-              activities: checkpointRevertActivities.byThread.get(row.threadId) ?? [],
+              activities: commandLifecycleActivities.byThread.get(row.threadId) ?? [],
               pendingInteractions: [],
               checkpoints: [],
               session: sessions.byThread.get(row.threadId) ?? null,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1069,95 +1069,175 @@ describe("ProviderCommandReactor", () => {
     );
   }
 
-  it("switches an established thread provider and primes a bounded transcript recap", async () => {
+  it.each([
+    "grok",
+    "claudeAgent",
+    "cursor",
+    "devin",
+    "antigravity",
+    "droid",
+    "opencode",
+    "pi",
+  ] as const)(
+    "switches to %s and retains the recap until a completed turn",
+    async (targetProvider) => {
+      const harness = await createHarness({
+        serverSettings: { enableContinuousProviderHandoff: true },
+        confirmNativeResume: () => false,
+      });
+      const threadId = ThreadId.makeUnsafe("thread-1");
+      const createdAt = new Date().toISOString();
+
+      await dispatchHarnessUserTurn(harness, {
+        messageId: "provider-handoff-context",
+        text: "The release train is amber.",
+        createdAt,
+      });
+      await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+      harness.setRuntimeSessionTurnState({ threadId, status: "ready" });
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.session.set",
+          commandId: CommandId.makeUnsafe("cmd-provider-handoff-source-ready"),
+          threadId,
+          session: {
+            threadId,
+            status: "ready",
+            providerName: "codex",
+            runtimeMode: "approval-required",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: new Date().toISOString(),
+          },
+          createdAt: new Date().toISOString(),
+        }),
+      );
+      await waitFor(async () => (await readHarnessThread(harness))?.session?.status === "ready");
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.provider.handoff",
+          commandId: CommandId.makeUnsafe("cmd-provider-handoff-to-grok"),
+          threadId,
+          expectedSourceProvider: "codex",
+          targetModelSelection: { provider: targetProvider, model: "grok-code" },
+          createdAt: new Date().toISOString(),
+        }),
+      );
+
+      await waitFor(async () => {
+        const current = await readHarnessThread(harness);
+        return (
+          current?.modelSelection.provider === targetProvider &&
+          current.activities.some((activity) => activity.kind === "provider.handoff.completed")
+        );
+      });
+      const switchedThread = await readHarnessThread(harness);
+      expect(switchedThread?.session?.providerName).toBe(targetProvider);
+      expect(switchedThread?.activities).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: "provider.handoff.completed",
+            payload: expect.objectContaining({
+              handoffCommandId: "cmd-provider-handoff-to-grok",
+              recapMode: "bounded-transcript",
+            }),
+          }),
+        ]),
+      );
+      expect(harness.pendingPriorTranscriptBootstraps.has(threadId)).toBe(true);
+      expect(harness.startSessionWithOutcome).toHaveBeenLastCalledWith(
+        threadId,
+        expect.objectContaining({
+          provider: targetProvider,
+          modelSelection: expect.objectContaining({ provider: targetProvider, model: "grok-code" }),
+        }),
+        { registerPriorTranscriptBootstrapOnFreshStart: true },
+      );
+
+      // The lightweight service double records restarts additively, unlike the
+      // real ProviderService's stop-first replacement. Remove its old source row
+      // before the follow-up so the remainder exercises the target session.
+      await Effect.runPromise(harness.stopRuntimeSession({ threadId }));
+
+      await dispatchHarnessUserTurn(harness, {
+        messageId: "provider-handoff-target-turn",
+        text: "What color is the release train?",
+        createdAt: new Date().toISOString(),
+      });
+      await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+      const targetInput = harness.sendTurn.mock.calls[1]?.[0] as { readonly input?: string };
+      expect(targetInput.input).toContain("<thread_context>");
+      expect(targetInput.input).toContain("The release train is amber.");
+      expect(targetInput.input).toContain("What color is the release train?");
+      expect(harness.pendingPriorTranscriptBootstraps.has(threadId)).toBe(true);
+      await emitHarnessTurnTerminal(harness, {
+        provider: targetProvider,
+        eventId: "provider-handoff-target-completed",
+        type: "completed",
+      });
+      await waitFor(() => !harness.pendingPriorTranscriptBootstraps.has(threadId));
+    },
+  );
+
+  it("starts a fresh target session when handing off a stopped fork", async () => {
+    const threadId = ThreadId.makeUnsafe("handoff-stopped-fork");
     const harness = await createHarness({
       serverSettings: { enableContinuousProviderHandoff: true },
-      confirmNativeResume: () => false,
+      forkThreadResult: { threadId, resumeCursor: { nativeFork: true } },
     });
-    const threadId = ThreadId.makeUnsafe("thread-1");
     const createdAt = new Date().toISOString();
-
-    await dispatchHarnessUserTurn(harness, {
-      messageId: "provider-handoff-context",
-      text: "The release train is amber.",
-      createdAt,
-    });
-    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
-    harness.setRuntimeSessionTurnState({ threadId, status: "ready" });
     await Effect.runPromise(
       harness.engine.dispatch({
-        type: "thread.session.set",
-        commandId: CommandId.makeUnsafe("cmd-provider-handoff-source-ready"),
+        type: "thread.fork.create",
+        commandId: CommandId.makeUnsafe("create-handoff-stopped-fork"),
         threadId,
-        session: {
-          threadId,
-          status: "ready",
-          providerName: "codex",
-          runtimeMode: "approval-required",
-          activeTurnId: null,
-          lastError: null,
-          updatedAt: new Date().toISOString(),
-        },
-        createdAt: new Date().toISOString(),
+        sourceThreadId: ThreadId.makeUnsafe("thread-1"),
+        projectId: asProjectId("project-1"),
+        title: "Fork to hand off",
+        modelSelection: { provider: "codex", model: "gpt-5-codex" },
+        runtimeMode: "approval-required",
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        envMode: "local",
+        branch: null,
+        worktreePath: null,
+        importedMessages: [
+          {
+            messageId: asMessageId("fork-handoff-context"),
+            role: "user",
+            text: "The release train is amber.",
+            createdAt,
+            updatedAt: createdAt,
+          },
+        ],
+        createdAt,
       }),
     );
-    await waitFor(async () => (await readHarnessThread(harness))?.session?.status === "ready");
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.stop",
+        commandId: CommandId.makeUnsafe("stop-fork-before-handoff"),
+        threadId,
+        createdAt,
+      }),
+    );
+    await waitFor(
+      async () => (await readHarnessThread(harness, threadId))?.session?.status === "stopped",
+    );
     await Effect.runPromise(
       harness.engine.dispatch({
         type: "thread.provider.handoff",
-        commandId: CommandId.makeUnsafe("cmd-provider-handoff-to-grok"),
+        commandId: CommandId.makeUnsafe("handoff-stopped-fork"),
         threadId,
         expectedSourceProvider: "codex",
         targetModelSelection: { provider: "grok", model: "grok-code" },
-        createdAt: new Date().toISOString(),
+        createdAt,
       }),
     );
-
-    await waitFor(async () => {
-      const current = await readHarnessThread(harness);
-      return (
-        current?.modelSelection.provider === "grok" &&
-        current.activities.some((activity) => activity.kind === "provider.handoff.completed")
-      );
-    });
-    const switchedThread = await readHarnessThread(harness);
-    expect(switchedThread?.session?.providerName).toBe("grok");
-    expect(switchedThread?.activities).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          kind: "provider.handoff.completed",
-          payload: expect.objectContaining({
-            handoffCommandId: "cmd-provider-handoff-to-grok",
-            recapMode: "bounded-transcript",
-          }),
-        }),
-      ]),
+    await waitFor(
+      async () => (await readHarnessThread(harness, threadId))?.modelSelection.provider === "grok",
     );
+    expect(harness.forkThread).not.toHaveBeenCalled();
     expect(harness.pendingPriorTranscriptBootstraps.has(threadId)).toBe(true);
-    expect(harness.startSessionWithOutcome).toHaveBeenLastCalledWith(
-      threadId,
-      expect.objectContaining({
-        provider: "grok",
-        modelSelection: expect.objectContaining({ provider: "grok", model: "grok-code" }),
-      }),
-      { registerPriorTranscriptBootstrapOnFreshStart: true },
-    );
-
-    // The lightweight service double records restarts additively, unlike the
-    // real ProviderService's stop-first replacement. Remove its old source row
-    // before the follow-up so the remainder exercises the target session.
-    await Effect.runPromise(harness.stopRuntimeSession({ threadId }));
-
-    await dispatchHarnessUserTurn(harness, {
-      messageId: "provider-handoff-target-turn",
-      text: "What color is the release train?",
-      createdAt: new Date().toISOString(),
-    });
-    await waitFor(() => harness.sendTurn.mock.calls.length === 2);
-    const targetInput = harness.sendTurn.mock.calls[1]?.[0] as { readonly input?: string };
-    expect(targetInput.input).toContain("<thread_context>");
-    expect(targetInput.input).toContain("The release train is amber.");
-    expect(targetInput.input).toContain("What color is the release train?");
   });
 
   it("keeps the provider unchanged when continuous handoff is disabled", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1069,6 +1069,376 @@ describe("ProviderCommandReactor", () => {
     );
   }
 
+  it("switches an established thread provider and primes a bounded transcript recap", async () => {
+    const harness = await createHarness({
+      serverSettings: { enableContinuousProviderHandoff: true },
+      confirmNativeResume: () => false,
+    });
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const createdAt = new Date().toISOString();
+
+    await dispatchHarnessUserTurn(harness, {
+      messageId: "provider-handoff-context",
+      text: "The release train is amber.",
+      createdAt,
+    });
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    harness.setRuntimeSessionTurnState({ threadId, status: "ready" });
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-provider-handoff-source-ready"),
+        threadId,
+        session: {
+          threadId,
+          status: "ready",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: new Date().toISOString(),
+        },
+        createdAt: new Date().toISOString(),
+      }),
+    );
+    await waitFor(async () => (await readHarnessThread(harness))?.session?.status === "ready");
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.provider.handoff",
+        commandId: CommandId.makeUnsafe("cmd-provider-handoff-to-grok"),
+        threadId,
+        expectedSourceProvider: "codex",
+        targetModelSelection: { provider: "grok", model: "grok-code" },
+        createdAt: new Date().toISOString(),
+      }),
+    );
+
+    await waitFor(async () => {
+      const current = await readHarnessThread(harness);
+      return (
+        current?.modelSelection.provider === "grok" &&
+        current.activities.some((activity) => activity.kind === "provider.handoff.completed")
+      );
+    });
+    const switchedThread = await readHarnessThread(harness);
+    expect(switchedThread?.session?.providerName).toBe("grok");
+    expect(switchedThread?.activities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "provider.handoff.completed",
+          payload: expect.objectContaining({
+            handoffCommandId: "cmd-provider-handoff-to-grok",
+            recapMode: "bounded-transcript",
+          }),
+        }),
+      ]),
+    );
+    expect(harness.pendingPriorTranscriptBootstraps.has(threadId)).toBe(true);
+    expect(harness.startSessionWithOutcome).toHaveBeenLastCalledWith(
+      threadId,
+      expect.objectContaining({
+        provider: "grok",
+        modelSelection: expect.objectContaining({ provider: "grok", model: "grok-code" }),
+      }),
+      { registerPriorTranscriptBootstrapOnFreshStart: true },
+    );
+
+    // The lightweight service double records restarts additively, unlike the
+    // real ProviderService's stop-first replacement. Remove its old source row
+    // before the follow-up so the remainder exercises the target session.
+    await Effect.runPromise(harness.stopRuntimeSession({ threadId }));
+
+    await dispatchHarnessUserTurn(harness, {
+      messageId: "provider-handoff-target-turn",
+      text: "What color is the release train?",
+      createdAt: new Date().toISOString(),
+    });
+    await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+    const targetInput = harness.sendTurn.mock.calls[1]?.[0] as { readonly input?: string };
+    expect(targetInput.input).toContain("<thread_context>");
+    expect(targetInput.input).toContain("The release train is amber.");
+    expect(targetInput.input).toContain("What color is the release train?");
+  });
+
+  it("keeps the provider unchanged when continuous handoff is disabled", async () => {
+    const harness = await createHarness();
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    await seedRenameConversation(harness, "Keep this provider unchanged");
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.provider.handoff",
+        commandId: CommandId.makeUnsafe("cmd-provider-handoff-disabled"),
+        threadId,
+        expectedSourceProvider: "codex",
+        targetModelSelection: { provider: "grok", model: "grok-code" },
+        createdAt: new Date().toISOString(),
+      }),
+    );
+
+    await waitFor(async () =>
+      Boolean(
+        (await readHarnessThread(harness))?.activities.some(
+          (activity) => activity.kind === "provider.handoff.failed",
+        ),
+      ),
+    );
+    const failedThread = await readHarnessThread(harness);
+    expect(failedThread?.modelSelection.provider).toBe("codex");
+    expect(
+      failedThread?.activities.find((activity) => activity.kind === "provider.handoff.failed")
+        ?.payload,
+    ).toMatchObject({ handoffCommandId: "cmd-provider-handoff-disabled" });
+    expect(harness.startSessionWithOutcome).not.toHaveBeenCalled();
+  });
+
+  it("rechecks activity before a queued provider handoff reaches the runtime", async () => {
+    const harness = await createHarness({
+      startReactor: false,
+      serverSettings: { enableContinuousProviderHandoff: true },
+    });
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    await seedRenameConversation(harness, "Do not interrupt a newer active turn");
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.provider.handoff",
+        commandId: CommandId.makeUnsafe("cmd-provider-handoff-before-race"),
+        threadId,
+        expectedSourceProvider: "codex",
+        targetModelSelection: { provider: "grok", model: "grok-code" },
+        createdAt: new Date().toISOString(),
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-provider-handoff-race-running"),
+        threadId,
+        session: {
+          threadId,
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: asTurnId("turn-provider-handoff-race"),
+          lastError: null,
+          updatedAt: new Date().toISOString(),
+        },
+        createdAt: new Date().toISOString(),
+      }),
+    );
+
+    await harness.startReactor();
+    await waitFor(async () =>
+      Boolean(
+        (await readHarnessThread(harness))?.activities.some(
+          (activity) =>
+            activity.kind === "provider.handoff.failed" &&
+            activity.summary === "Provider handoff was blocked",
+        ),
+      ),
+    );
+    expect((await readHarnessThread(harness))?.modelSelection.provider).toBe("codex");
+    expect(harness.startSessionWithOutcome).not.toHaveBeenCalled();
+  });
+
+  it("keeps a queued message on the source provider and closes the conflicting handoff", async () => {
+    const harness = await createHarness({
+      serverSettings: { enableContinuousProviderHandoff: true },
+    });
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    await seedRenameConversation(harness, "Run queued work before switching providers");
+    await seedQueuedTurnBehindLiveTurn(harness, {
+      liveTurnId: asTurnId("turn-before-provider-handoff"),
+      messageId: asMessageId("message-queued-before-provider-handoff"),
+      text: "finish this on the source provider",
+    });
+
+    const now = new Date().toISOString();
+    harness.setRuntimeSessionTurnState({ threadId, status: "ready" });
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-source-ready-before-provider-handoff"),
+        threadId,
+        session: {
+          threadId,
+          status: "ready",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+    await waitFor(async () => (await readHarnessThread(harness))?.session?.status === "ready");
+    harness.startSessionWithOutcome.mockClear();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.provider.handoff",
+        commandId: CommandId.makeUnsafe("cmd-handoff-with-queued-message"),
+        threadId,
+        expectedSourceProvider: "codex",
+        targetModelSelection: { provider: "grok", model: "grok-code" },
+        createdAt: new Date().toISOString(),
+      }),
+    );
+
+    await waitFor(async () =>
+      Boolean(
+        (await readHarnessThread(harness))?.activities.some(
+          (activity) =>
+            activity.kind === "provider.handoff.failed" &&
+            (activity.payload as Record<string, unknown> | null)?.handoffCommandId ===
+              "cmd-handoff-with-queued-message",
+        ),
+      ),
+    );
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    expect((await readHarnessThread(harness))?.modelSelection.provider).toBe("codex");
+    expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({
+      input: "finish this on the source provider",
+    });
+    expect(harness.startSessionWithOutcome).not.toHaveBeenCalledWith(
+      threadId,
+      expect.objectContaining({ provider: "grok" }),
+      expect.anything(),
+    );
+  });
+
+  it("quarantines a handoff when replacement failure also fails provider restoration", async () => {
+    const harness = await createHarness({
+      serverSettings: { enableContinuousProviderHandoff: true },
+    });
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    await seedRenameConversation(harness, "Surface failed provider restoration");
+    const replacementFailure = new ProviderAdapterProcessError({
+      provider: "grok",
+      threadId,
+      reason: "startup-failed",
+      detail: "Replacement provider startup failed.",
+    });
+    const restorationFailure = new ProviderAdapterProcessError({
+      provider: "codex",
+      threadId,
+      detail: "Previous provider restoration failed.",
+    });
+    harness.startSessionWithOutcome.mockImplementationOnce(() =>
+      Effect.fail(replacementFailure).pipe(Effect.onExit(() => Effect.fail(restorationFailure))),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.provider.handoff",
+        commandId: CommandId.makeUnsafe("cmd-provider-handoff-restoration-fails"),
+        threadId,
+        expectedSourceProvider: "codex",
+        targetModelSelection: { provider: "grok", model: "grok-code" },
+        createdAt: new Date().toISOString(),
+      }),
+    );
+
+    await waitFor(async () => {
+      const thread = await readHarnessThread(harness);
+      return (
+        thread?.session?.status === "error" &&
+        thread.activities.some(
+          (activity) =>
+            activity.kind === "provider.handoff.failed" &&
+            (activity.payload as Record<string, unknown> | null)?.settlementStatus === "uncertain",
+        )
+      );
+    });
+    const events = await Effect.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((items) => Array.from(items)),
+      ),
+    );
+    const handoffEvent = events.find(
+      (event) =>
+        event.commandId === "cmd-provider-handoff-restoration-fails" &&
+        event.type === "thread.provider-handoff-requested",
+    );
+    expect(handoffEvent).toBeDefined();
+    await waitFor(async () => {
+      const delivery = await Effect.runPromise(
+        harness.deliveryRepository.getDelivery({
+          consumerName: PROVIDER_COMMAND_REACTOR_CONSUMER,
+          eventSequence: handoffEvent!.sequence,
+        }),
+      );
+      return Option.isSome(delivery) && delivery.value.state === "uncertain";
+    });
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.provider.handoff",
+        commandId: CommandId.makeUnsafe("cmd-provider-handoff-after-quarantine"),
+        threadId,
+        expectedSourceProvider: "codex",
+        targetModelSelection: { provider: "claudeAgent", model: "claude-sonnet" },
+        createdAt: new Date().toISOString(),
+      }),
+    );
+    await waitFor(async () =>
+      Boolean(
+        (await readHarnessThread(harness))?.activities.some(
+          (activity) =>
+            activity.kind === "provider.handoff.failed" &&
+            (activity.payload as Record<string, unknown> | null)?.handoffCommandId ===
+              "cmd-provider-handoff-after-quarantine",
+        ),
+      ),
+    );
+    expect(harness.startSessionWithOutcome).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a second provider switch while the first is durably pending", async () => {
+    const harness = await createHarness({
+      startReactor: false,
+      serverSettings: { enableContinuousProviderHandoff: true },
+    });
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    await seedRenameConversation(harness, "Keep duplicate handoffs idempotent");
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.provider.handoff",
+        commandId: CommandId.makeUnsafe("cmd-provider-handoff-duplicate-first"),
+        threadId,
+        expectedSourceProvider: "codex",
+        targetModelSelection: { provider: "grok", model: "grok-code" },
+        createdAt: new Date().toISOString(),
+      }),
+    );
+    await expect(
+      Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.provider.handoff",
+          commandId: CommandId.makeUnsafe("cmd-provider-handoff-duplicate-second"),
+          threadId,
+          expectedSourceProvider: "codex",
+          targetModelSelection: { provider: "grok", model: "grok-code" },
+          createdAt: new Date().toISOString(),
+        }),
+      ),
+    ).rejects.toThrow("still switching to 'grok'");
+
+    await harness.startReactor();
+    await waitFor(async () => {
+      const thread = await readHarnessThread(harness);
+      return thread?.modelSelection.provider === "grok";
+    });
+    expect(harness.startSessionWithOutcome).toHaveBeenCalledTimes(1);
+    expect(
+      (await readHarnessThread(harness))?.activities.filter(
+        (activity) => activity.kind === "provider.handoff.completed",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("regenerates a title from durable conversation context without steering an active turn", async () => {
     const harness = await createHarness();
     await seedRenameConversation(harness);

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1671,6 +1671,7 @@ const make = Effect.gen(function* () {
       );
     }
     const shouldRegisterContextBootstrap =
+      options?.providerHandoffSource !== undefined ||
       !suppressContextBootstrapOnNextStartThreadIds.has(threadId);
 
     const desiredRuntimeMode = options?.runtimeMode ?? thread.runtimeMode;
@@ -1908,7 +1909,11 @@ const make = Effect.gen(function* () {
     }
 
     let bootstrapTranscriptIfResumeFails = false;
-    if (providerService.forkThread && thread.forkSourceThreadId) {
+    if (
+      options?.providerHandoffSource === undefined &&
+      providerService.forkThread &&
+      thread.forkSourceThreadId
+    ) {
       const forked = yield* providerService.forkThread({
         ...providerSessionOptions,
         sourceThreadId: thread.forkSourceThreadId,
@@ -2003,10 +2008,7 @@ const make = Effect.gen(function* () {
     if (startOutcome.priorTranscriptBootstrapPending) {
       if (shouldRegisterContextBootstrap) {
         freshSessionContextBootstrapThreadIds.add(threadId);
-      } else if (
-        (preferredProvider === "opencode" || preferredProvider === "devin") &&
-        providerService.completePriorTranscriptBootstrap
-      ) {
+      } else if (providerService.completePriorTranscriptBootstrap) {
         // An explicit stop intentionally discards pending synthetic context.
         // If its best-effort persistence cleanup was interrupted, finish that
         // cleanup before starting the fresh session instead of resurrecting it.
@@ -2516,11 +2518,14 @@ const make = Effect.gen(function* () {
         activeSession?.provider === "droid" &&
         (sidechatBootstrapText !== null || priorTranscriptBootstrapText !== null);
       const tracksDurableContextAcceptance =
-        (selectedProvider === "opencode" || selectedProvider === "devin") &&
-        ((hasPendingFreshSessionTranscriptBootstrap &&
-          (priorTranscriptBootstrapRetiresOnAcceptedTurn ||
-            specializedBootstrapCompletesFreshSessionContext)) ||
-          (hasPendingRollbackTranscriptBootstrap && priorTranscriptBootstrapRetiresOnAcceptedTurn));
+        (hasPendingFreshSessionTranscriptBootstrap &&
+          (priorTranscriptBootstrapText !== null ||
+            specializedBootstrapCompletesFreshSessionContext ||
+            ((selectedProvider === "opencode" || selectedProvider === "devin") &&
+              priorTranscriptBootstrapRetiresOnAcceptedTurn))) ||
+        ((selectedProvider === "opencode" || selectedProvider === "devin") &&
+          hasPendingRollbackTranscriptBootstrap &&
+          priorTranscriptBootstrapRetiresOnAcceptedTurn);
       // Only Codex awaits a provider turn/start acknowledgement. The other
       // adapters enqueue/fork prompts or launch a process before acceptance;
       // their matching terminal success confirms that recovery was consumed.
@@ -2744,12 +2749,11 @@ const make = Effect.gen(function* () {
       let durableCompletionSucceeded = true;
       if (
         hasPendingFreshSessionTranscriptBootstrap &&
-        (selectedProvider === "opencode" || selectedProvider === "devin") &&
         providerService.completePriorTranscriptBootstrap
       ) {
         durableCompletionSucceeded = yield* persistPriorTranscriptBootstrapCompletion(
           input.threadId,
-          selectedProvider,
+          selectedProvider as ProviderKind,
         );
       }
       if (durableCompletionSucceeded) {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -11,6 +11,7 @@ import {
   MessageId,
   type OrchestrationEvent,
   type OrchestrationRegenerateThreadTitleResult,
+  PROVIDER_DISPLAY_NAMES,
   PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
   type ProviderMentionReference,
   type ProviderInteractionMode,
@@ -61,6 +62,10 @@ import {
   formatProviderDeliveryBlockDetail,
   PROVIDER_DELIVERY_BLOCK_SUMMARY,
 } from "@synara/shared/providerDeliveryBlock";
+import {
+  PROVIDER_HANDOFF_FAILED_ACTIVITY_KIND,
+  toProviderHandoffActivityModelSelection,
+} from "@synara/shared/providerHandoff";
 import { buildStalePendingRequestFailureDetail } from "@synara/shared/threadSummary";
 import { resolveThreadWorkspaceState } from "@synara/shared/threadEnvironment";
 
@@ -148,6 +153,11 @@ import { deriveTurnStartSession } from "../turnStartSession.ts";
 import { TurnCheckpointCoordinator } from "../Services/TurnCheckpointCoordinator.ts";
 import { resolveProviderSessionThread as resolveProviderSessionThreadFromProjection } from "../providerSessionThread.ts";
 import { isExpiredSidechat } from "../sidechatLifecycle.ts";
+import {
+  checkpointRevertInProgressDetail,
+  threadHasCheckpointRevertInProgress,
+  threadHasInFlightTurn,
+} from "../commandInvariants.ts";
 
 type ProviderQueueDrainEvent = Extract<
   ProviderRuntimeEvent,
@@ -174,7 +184,7 @@ type ProviderAttemptOutcome =
   | { readonly _tag: "uncertain"; readonly detail: string };
 
 export function classifyProviderAttemptOutcome(
-  exit: Exit.Exit<void, unknown>,
+  exit: Exit.Exit<unknown, unknown>,
 ): ProviderAttemptOutcome {
   if (Exit.isSuccess(exit)) return { _tag: "accepted" };
   const detail = Cause.pretty(exit.cause);
@@ -1255,6 +1265,43 @@ const make = Effect.gen(function* () {
       createdAt: input.createdAt,
     });
 
+  const appendProviderHandoffFailureActivity = (
+    event: Extract<ProviderIntentEvent, { type: "thread.provider-handoff-requested" }>,
+    input: {
+      readonly summary: string;
+      readonly detail: string;
+      readonly settlementStatus?: "retryable" | "uncertain";
+    },
+  ) => {
+    const handoffCommandId = event.commandId ?? event.eventId;
+    return orchestrationEngine.dispatch({
+      type: "thread.activity.append",
+      commandId: CommandId.makeUnsafe(`server:provider-handoff-failure:${event.eventId}`),
+      threadId: event.payload.threadId,
+      activity: {
+        id: EventId.makeUnsafe(`provider-handoff-failed:${event.eventId}`),
+        tone: "error",
+        kind: PROVIDER_HANDOFF_FAILED_ACTIVITY_KIND,
+        summary: input.summary,
+        payload: {
+          handoffCommandId,
+          sourceModelSelection: toProviderHandoffActivityModelSelection(
+            event.payload.sourceModelSelection,
+          ),
+          targetModelSelection: toProviderHandoffActivityModelSelection(
+            event.payload.targetModelSelection,
+          ),
+          handoffEventId: event.eventId,
+          detail: input.detail,
+          ...(input.settlementStatus ? { settlementStatus: input.settlementStatus } : {}),
+        },
+        turnId: null,
+        createdAt: event.payload.createdAt,
+      },
+      createdAt: event.payload.createdAt,
+    });
+  };
+
   const setThreadSession = (input: {
     readonly threadId: ThreadId;
     readonly session: OrchestrationSession;
@@ -1614,6 +1661,7 @@ const make = Effect.gen(function* () {
       readonly providerOptions?: ProviderStartOptions;
       readonly runtimeMode?: RuntimeMode;
       readonly registerPriorTranscriptBootstrapOnFreshStart?: boolean;
+      readonly providerHandoffSource?: ProviderKind;
     },
   ) {
     const thread = yield* resolveThread(threadId);
@@ -1654,10 +1702,16 @@ const make = Effect.gen(function* () {
       currentProvider !== undefined && (activeSession !== undefined || thread.latestTurn !== null)
         ? currentProvider
         : undefined;
+    const providerHandoffAuthorized =
+      establishedProvider !== undefined &&
+      requestedModelSelection !== undefined &&
+      requestedModelSelection.provider !== establishedProvider &&
+      options?.providerHandoffSource === establishedProvider;
     if (
       establishedProvider !== undefined &&
       requestedModelSelection !== undefined &&
-      requestedModelSelection.provider !== establishedProvider
+      requestedModelSelection.provider !== establishedProvider &&
+      !providerHandoffAuthorized
     ) {
       return yield* new ProviderAdapterValidationError({
         provider: establishedProvider,
@@ -1666,7 +1720,7 @@ const make = Effect.gen(function* () {
       });
     }
     const preferredProvider: ProviderKind =
-      establishedProvider ??
+      (providerHandoffAuthorized ? requestedModelSelection?.provider : establishedProvider) ??
       requestedModelSelection?.provider ??
       currentProvider ??
       thread.modelSelection.provider;
@@ -1817,8 +1871,14 @@ const make = Effect.gen(function* () {
         shouldRestartForModelSelectionChange,
         hasResumeCursor: resumeCursor !== undefined,
       });
-      const restartedOutcome = yield* startProviderSessionWithOutcome(resumeCursor);
+      const restartedOutcome = yield* startProviderSessionWithOutcome(
+        resumeCursor,
+        options?.registerPriorTranscriptBootstrapOnFreshStart === true,
+      );
       const restartedSession = restartedOutcome.session;
+      if (shouldRegisterContextBootstrap && restartedOutcome.priorTranscriptBootstrapPending) {
+        freshSessionContextBootstrapThreadIds.add(threadId);
+      }
       if (
         shouldRegisterContextBootstrap &&
         currentProvider === "droid" &&
@@ -4798,6 +4858,130 @@ const make = Effect.gen(function* () {
             ),
           );
           return;
+        case "thread.provider-handoff-requested": {
+          const thread = yield* resolveThread(event.payload.threadId);
+          if (!thread) {
+            return;
+          }
+
+          const handoffCommandId = event.commandId ?? event.eventId;
+          const completionActivityId = EventId.makeUnsafe(`provider-handoff:${event.eventId}`);
+          const failureActivityId = EventId.makeUnsafe(`provider-handoff-failed:${event.eventId}`);
+          const existingFailureActivity = thread.activities.find(
+            (activity) => activity.id === failureActivityId,
+          );
+          if (existingFailureActivity) {
+            const failurePayload =
+              typeof existingFailureActivity.payload === "object" &&
+              existingFailureActivity.payload !== null
+                ? (existingFailureActivity.payload as Record<string, unknown>)
+                : null;
+            if (failurePayload?.settlementStatus === "uncertain") {
+              return yield* Effect.die(
+                new Error(
+                  typeof failurePayload.detail === "string"
+                    ? failurePayload.detail
+                    : "Provider handoff previously reached an uncertain terminal state.",
+                ),
+              );
+            }
+            return;
+          }
+
+          const settings = yield* serverSettings.getSettings;
+          if (!settings.enableContinuousProviderHandoff) {
+            yield* appendProviderHandoffFailureActivity(event, {
+              summary: "Provider handoff is turned off",
+              detail:
+                "Enable 'Continue handoffs in this chat' in Settings before switching providers.",
+            });
+            return;
+          }
+
+          const sourceProvider = event.payload.sourceModelSelection.provider;
+          const targetProvider = event.payload.targetModelSelection.provider;
+          if (
+            thread.modelSelection.provider !== sourceProvider &&
+            thread.modelSelection.provider !== targetProvider
+          ) {
+            yield* appendProviderHandoffFailureActivity(event, {
+              summary: "Provider handoff is stale",
+              detail: `This handoff expected '${sourceProvider}', but the thread now uses '${thread.modelSelection.provider}'.`,
+            });
+            return;
+          }
+          if (thread.modelSelection.provider === targetProvider) {
+            if (thread.activities.some((activity) => activity.id === completionActivityId)) {
+              return;
+            }
+            yield* appendProviderHandoffFailureActivity(event, {
+              summary: "Provider handoff was superseded",
+              detail: `The thread already switched to '${targetProvider}' through another handoff request.`,
+            });
+            return;
+          }
+          if (
+            thread.modelSelection.provider === sourceProvider &&
+            (threadHasInFlightTurn(thread) ||
+              thread.hasPendingApprovals === true ||
+              thread.hasPendingUserInput === true)
+          ) {
+            yield* appendProviderHandoffFailureActivity(event, {
+              summary: "Provider handoff was blocked",
+              detail:
+                "The thread became active or received a pending provider interaction before the handoff started. Retry after it settles.",
+            });
+            return;
+          }
+          if (threadHasCheckpointRevertInProgress(thread)) {
+            yield* appendProviderHandoffFailureActivity(event, {
+              summary: "Provider handoff was blocked",
+              detail: checkpointRevertInProgressDetail(event.payload.threadId),
+            });
+            return;
+          }
+          if (yield* hasPendingQueuedTurnForSession(event.payload.threadId)) {
+            yield* appendProviderHandoffFailureActivity(event, {
+              summary: "Provider handoff was blocked",
+              detail:
+                "The thread has a queued message that must run before switching providers. Retry the handoff after the queue settles.",
+            });
+            yield* drainQueuedTurnsForSession(event.payload.threadId);
+            return;
+          }
+
+          const handoffExit = yield* Effect.exit(
+            ensureSessionForThread(event.payload.threadId, event.payload.createdAt, {
+              modelSelection: event.payload.targetModelSelection,
+              runtimeMode: thread.runtimeMode,
+              registerPriorTranscriptBootstrapOnFreshStart: true,
+              providerHandoffSource: sourceProvider,
+            }),
+          );
+          if (Exit.isFailure(handoffExit)) {
+            const outcome = classifyProviderAttemptOutcome(handoffExit);
+            if (outcome._tag === "rejected") {
+              yield* appendProviderHandoffFailureActivity(event, {
+                summary: `Could not continue with ${PROVIDER_DISPLAY_NAMES[targetProvider]}`,
+                detail: outcome.detail,
+              });
+              return;
+            }
+            return yield* Effect.failCause(handoffExit.cause);
+          }
+
+          yield* orchestrationEngine.dispatch({
+            type: "thread.provider.handoff.complete",
+            commandId: CommandId.makeUnsafe(`server:provider-handoff-complete:${event.eventId}`),
+            threadId: event.payload.threadId,
+            handoffCommandId: CommandId.makeUnsafe(handoffCommandId),
+            handoffEventId: event.eventId,
+            sourceModelSelection: event.payload.sourceModelSelection,
+            targetModelSelection: event.payload.targetModelSelection,
+            createdAt: event.payload.createdAt,
+          });
+          return;
+        }
         case "thread.session-stop-requested":
           yield* processSessionStopRequested(event);
           return;
@@ -4944,6 +5128,22 @@ const make = Effect.gen(function* () {
         state: input.state,
         detail: input.detail,
       });
+      if (input.event.type === "thread.provider-handoff-requested") {
+        const targetProvider = input.event.payload.targetModelSelection.provider;
+        yield* appendProviderHandoffFailureActivity(input.event, {
+          summary: `Could not continue with ${PROVIDER_DISPLAY_NAMES[targetProvider]}`,
+          detail: input.detail,
+          // If the process dies between this activity and delivery settlement,
+          // replay must re-enter quarantine instead of treating the recorded
+          // failure as a successful provider switch.
+          settlementStatus: "uncertain",
+        });
+        yield* setThreadSessionError({
+          threadId: input.event.payload.threadId,
+          detail: `Provider handoff could not be settled safely. ${input.detail}`,
+          createdAt: new Date().toISOString(),
+        });
+      }
       const settled = yield* deliveryRepository.markTerminalFailure({
         consumerName: PROVIDER_COMMAND_REACTOR_CONSUMER,
         eventSequence: input.event.sequence,
@@ -5014,6 +5214,28 @@ const make = Effect.gen(function* () {
               threadId: event.payload.threadId,
               cause: Cause.pretty(cause),
             }),
+          ),
+        );
+      } else if (event.type === "thread.provider-handoff-requested") {
+        yield* Effect.gen(function* () {
+          const blocker = yield* deliveryRepository.firstBlockingDeliveryForThread({
+            consumerName: PROVIDER_COMMAND_REACTOR_CONSUMER,
+            threadId: event.payload.threadId,
+          });
+          const blockerDetail =
+            Option.isSome(blocker) && blocker.value.lastError !== null
+              ? blocker.value.lastError
+              : "an earlier provider command failed";
+          yield* appendProviderHandoffFailureActivity(event, {
+            summary: PROVIDER_DELIVERY_BLOCK_SUMMARY,
+            detail: `The provider handoff was not started. Blocking failure: ${blockerDetail}`,
+          });
+        }).pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning("failed to close a quarantined provider handoff", {
+              threadId: event.payload.threadId,
+              cause: Cause.pretty(cause),
+            }).pipe(Effect.andThen(Effect.failCause(cause))),
           ),
         );
       }

--- a/apps/server/src/orchestration/Layers/pinnedMessagesRoundTrip.test.ts
+++ b/apps/server/src/orchestration/Layers/pinnedMessagesRoundTrip.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import {
   CommandId,
+  EventId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   MessageId,
   ProjectId,
@@ -310,14 +311,81 @@ describe("continuous provider handoff round-trip", () => {
         ),
       ).resolves.toMatchObject({ sequence: expect.any(Number) });
 
+      // Work logs must not evict a pending transition or the permanent provider path.
+      for (let index = 0; index < 2_010; index += 1) {
+        await system.run(
+          system.engine.dispatch({
+            type: "thread.activity.append",
+            commandId: CommandId.makeUnsafe(`handoff-noise-${index}`),
+            threadId,
+            activity: {
+              id: EventId.makeUnsafe(`handoff-noise-${index}`),
+              kind: "tool.completed",
+              tone: "tool",
+              summary: "Tool completed",
+              payload: {},
+              turnId: null,
+              createdAt,
+            },
+            createdAt,
+          }),
+        );
+      }
+      await system.dispose();
+      system = await createSystem(dbPath);
       const detail = Option.getOrNull(await system.run(system.query.getThreadDetailById(threadId)));
-      expect(detail?.activities.at(-1)).toMatchObject({
+      expect(
+        detail?.activities.find((activity) => activity.kind === "provider.handoff.requested"),
+      ).toMatchObject({
         kind: "provider.handoff.requested",
         payload: {
           sourceModelSelection: { provider: "codex" },
           targetModelSelection: { provider: "grok" },
         },
       });
+      const snapshot = await system.run(system.query.getSnapshot());
+      expect(
+        snapshot.threads[0]?.activities.some(
+          (activity) => activity.kind === "provider.handoff.requested",
+        ),
+      ).toBe(true);
+      await expect(
+        system.run(
+          system.engine.dispatch({
+            type: "thread.provider.handoff",
+            commandId: CommandId.makeUnsafe("duplicate-after-capped-restart"),
+            threadId,
+            expectedSourceProvider: "codex",
+            targetModelSelection: { provider: "grok", model: "grok-code" },
+            createdAt,
+          }),
+        ),
+      ).rejects.toThrow("still switching");
+      await system.run(
+        system.engine.dispatch({
+          type: "thread.provider.handoff.complete",
+          commandId: CommandId.makeUnsafe("complete-after-capped-restart"),
+          threadId,
+          handoffCommandId: CommandId.makeUnsafe("cmd-provider-handoff-after-restart"),
+          handoffEventId: EventId.makeUnsafe("handoff-after-capped-restart"),
+          sourceModelSelection: { provider: "codex", model: "gpt-5-codex" },
+          targetModelSelection: { provider: "grok", model: "grok-code" },
+          createdAt,
+        }),
+      );
+      await system.dispose();
+      system = await createSystem(dbPath);
+      const completed = Option.getOrThrow(
+        await system.run(system.query.getThreadDetailById(threadId)),
+      );
+      expect(completed.id).toBe(threadId);
+      expect(completed.modelSelection.provider).toBe("grok");
+      expect(completed.messages).toHaveLength(1);
+      expect(
+        completed.activities
+          .filter((activity) => activity.kind.startsWith("provider.handoff."))
+          .map((activity) => activity.kind),
+      ).toEqual(["provider.handoff.requested", "provider.handoff.completed"]);
     } finally {
       await system.dispose();
       fs.rmSync(stateDir, { recursive: true, force: true });

--- a/apps/server/src/orchestration/Layers/pinnedMessagesRoundTrip.test.ts
+++ b/apps/server/src/orchestration/Layers/pinnedMessagesRoundTrip.test.ts
@@ -239,3 +239,88 @@ describe("thread annotations round-trip", () => {
     }
   });
 });
+
+describe("continuous provider handoff round-trip", () => {
+  it("hydrates completed messages for handoff validation after a server restart", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "synara-handoff-roundtrip-"));
+    const dbPath = path.join(stateDir, "state.sqlite");
+    let system = await createSystem(dbPath);
+    const createdAt = "2026-09-10T00:00:00.000Z";
+    const projectId = ProjectId.makeUnsafe("project-provider-handoff");
+    const threadId = ThreadId.makeUnsafe("thread-provider-handoff");
+
+    try {
+      await system.run(
+        system.engine.dispatch({
+          type: "project.create",
+          commandId: CommandId.makeUnsafe("cmd-provider-handoff-project"),
+          projectId,
+          title: "Provider handoff",
+          workspaceRoot: "/tmp/provider-handoff",
+          defaultModelSelection: { provider: "codex", model: "gpt-5-codex" },
+          createdAt,
+        }),
+      );
+      await system.run(
+        system.engine.dispatch({
+          type: "thread.create",
+          commandId: CommandId.makeUnsafe("cmd-provider-handoff-thread"),
+          threadId,
+          projectId,
+          title: "Provider handoff thread",
+          modelSelection: { provider: "codex", model: "gpt-5-codex" },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          branch: null,
+          worktreePath: null,
+          createdAt,
+        }),
+      );
+      await system.run(
+        system.engine.dispatch({
+          type: "thread.messages.import",
+          commandId: CommandId.makeUnsafe("cmd-provider-handoff-import"),
+          threadId,
+          messages: [
+            {
+              messageId: MessageId.makeUnsafe("message-provider-handoff"),
+              role: "user",
+              text: "Continue this conversation with another provider.",
+              createdAt,
+              updatedAt: createdAt,
+            },
+          ],
+          createdAt,
+        }),
+      );
+
+      await system.dispose();
+      system = await createSystem(dbPath);
+
+      await expect(
+        system.run(
+          system.engine.dispatch({
+            type: "thread.provider.handoff",
+            commandId: CommandId.makeUnsafe("cmd-provider-handoff-after-restart"),
+            threadId,
+            expectedSourceProvider: "codex",
+            targetModelSelection: { provider: "grok", model: "grok-code" },
+            createdAt: "2026-09-10T00:01:00.000Z",
+          }),
+        ),
+      ).resolves.toMatchObject({ sequence: expect.any(Number) });
+
+      const detail = Option.getOrNull(await system.run(system.query.getThreadDetailById(threadId)));
+      expect(detail?.activities.at(-1)).toMatchObject({
+        kind: "provider.handoff.requested",
+        payload: {
+          sourceModelSelection: { provider: "codex" },
+          targetModelSelection: { provider: "grok" },
+        },
+      });
+    } finally {
+      await system.dispose();
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/server/src/orchestration/decider.providerHandoff.test.ts
+++ b/apps/server/src/orchestration/decider.providerHandoff.test.ts
@@ -1,0 +1,352 @@
+import {
+  CommandId,
+  EventId,
+  MessageId,
+  ProjectId,
+  ThreadId,
+  type OrchestrationReadModel,
+  type OrchestrationThread,
+} from "@synara/contracts";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { decideOrchestrationCommand } from "./decider.ts";
+
+const NOW = "2026-09-10T10:00:00.000Z";
+const THREAD_ID = ThreadId.makeUnsafe("thread-provider-handoff");
+
+function makeThread(overrides: Partial<OrchestrationThread> = {}): OrchestrationThread {
+  return {
+    id: THREAD_ID,
+    projectId: ProjectId.makeUnsafe("project-provider-handoff"),
+    title: "Continuous provider handoff",
+    modelSelection: { provider: "claudeAgent", model: "claude-sonnet" },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    envMode: "local",
+    branch: null,
+    worktreePath: null,
+    workingDirectory: null,
+    associatedWorktreePath: null,
+    associatedWorktreeBranch: null,
+    associatedWorktreeRef: null,
+    createBranchFlowCompleted: false,
+    isPinned: false,
+    parentThreadId: null,
+    creationSource: null,
+    sourceThreadId: null,
+    sourceTurnId: null,
+    gatewayOperationId: null,
+    gatewayOperationIndex: null,
+    subagentAgentId: null,
+    subagentNickname: null,
+    subagentRole: null,
+    forkSourceThreadId: null,
+    sidechatSourceThreadId: null,
+    sidechatLastActivityAt: null,
+    sidechatExpiredAt: null,
+    lastKnownPr: null,
+    latestTurn: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    deletedAt: null,
+    archivedAt: null,
+    settledAt: null,
+    handoff: null,
+    messages: [
+      {
+        id: MessageId.makeUnsafe("handoff-message"),
+        role: "user",
+        text: "Continue with another provider",
+        turnId: null,
+        streaming: false,
+        source: "native",
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ],
+    proposedPlans: [],
+    activities: [],
+    checkpoints: [],
+    session: null,
+    ...overrides,
+  };
+}
+
+function makeReadModel(overrides: Partial<OrchestrationThread> = {}): OrchestrationReadModel {
+  return {
+    snapshotSequence: 1,
+    updatedAt: NOW,
+    spaces: [],
+    projects: [],
+    threads: [makeThread(overrides)],
+  };
+}
+
+function command(expectedSourceProvider: "claudeAgent" | "codex" = "claudeAgent") {
+  return {
+    type: "thread.provider.handoff" as const,
+    commandId: CommandId.makeUnsafe("command-provider-handoff"),
+    threadId: THREAD_ID,
+    expectedSourceProvider,
+    targetModelSelection: { provider: "grok" as const, model: "grok-code" },
+    createdAt: NOW,
+  };
+}
+
+describe("decider continuous provider handoff", () => {
+  it("records a durable pending activity before the provider handoff intent", async () => {
+    const events = await Effect.runPromise(
+      decideOrchestrationCommand({ command: command(), readModel: makeReadModel() }),
+    );
+
+    expect(Array.isArray(events)).toBe(true);
+    if (!Array.isArray(events)) return;
+    expect(events.map((event) => event.type)).toEqual([
+      "thread.activity-appended",
+      "thread.provider-handoff-requested",
+    ]);
+    expect(events[0]?.payload).toMatchObject({
+      activity: {
+        kind: "provider.handoff.requested",
+        payload: {
+          handoffCommandId: "command-provider-handoff",
+          targetModelSelection: { provider: "grok" },
+        },
+      },
+    });
+    expect(events[1]?.payload).toMatchObject({
+      threadId: THREAD_ID,
+      sourceModelSelection: { provider: "claudeAgent" },
+      targetModelSelection: { provider: "grok" },
+    });
+  });
+
+  it("rejects a message admitted immediately after a pending handoff", async () => {
+    const pendingActivity = {
+      id: EventId.makeUnsafe("provider-handoff-requested:command-provider-handoff"),
+      tone: "info" as const,
+      kind: "provider.handoff.requested",
+      summary: "Switching to Grok",
+      payload: {
+        handoffCommandId: "command-provider-handoff",
+        sourceModelSelection: { provider: "claudeAgent", model: "claude-sonnet" },
+        targetModelSelection: { provider: "grok", model: "grok-code" },
+      },
+      turnId: null,
+      createdAt: NOW,
+    };
+
+    await expect(
+      Effect.runPromise(
+        decideOrchestrationCommand({
+          command: {
+            type: "thread.turn.start",
+            commandId: CommandId.makeUnsafe("command-turn-during-handoff"),
+            threadId: THREAD_ID,
+            message: {
+              messageId: MessageId.makeUnsafe("message-turn-during-handoff"),
+              role: "user",
+              text: "Did the provider switch yet?",
+              attachments: [],
+            },
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            createdAt: NOW,
+          },
+          readModel: makeReadModel({ activities: [pendingActivity] }),
+        }),
+      ),
+    ).rejects.toThrow("still switching to 'grok'");
+  });
+
+  it("rejects queued-turn promotion and checkpoint revert while a handoff is pending", async () => {
+    const pendingActivity = {
+      id: EventId.makeUnsafe("provider-handoff-requested:command-provider-handoff"),
+      tone: "info" as const,
+      kind: "provider.handoff.requested",
+      summary: "Switching to Grok",
+      payload: {
+        handoffCommandId: "command-provider-handoff",
+        sourceModelSelection: { provider: "claudeAgent", model: "claude-sonnet" },
+        targetModelSelection: { provider: "grok", model: "grok-code" },
+      },
+      turnId: null,
+      createdAt: NOW,
+    };
+    const readModel = makeReadModel({ activities: [pendingActivity] });
+
+    await expect(
+      Effect.runPromise(
+        decideOrchestrationCommand({
+          command: {
+            type: "thread.turn.dispatch-queued",
+            commandId: CommandId.makeUnsafe("command-promote-during-handoff"),
+            threadId: THREAD_ID,
+            messageId: MessageId.makeUnsafe("queued-message-during-handoff"),
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            createdAt: NOW,
+          },
+          readModel,
+        }),
+      ),
+    ).rejects.toThrow("still switching to 'grok'");
+
+    await expect(
+      Effect.runPromise(
+        decideOrchestrationCommand({
+          command: {
+            type: "thread.checkpoint.revert",
+            commandId: CommandId.makeUnsafe("command-revert-during-handoff"),
+            threadId: THREAD_ID,
+            turnCount: 1,
+            scope: "thread",
+            createdAt: NOW,
+          },
+          readModel,
+        }),
+      ),
+    ).rejects.toThrow("still switching to 'grok'");
+  });
+
+  it("rejects a handoff while a checkpoint revert is pending", async () => {
+    await expect(
+      Effect.runPromise(
+        decideOrchestrationCommand({
+          command: command(),
+          readModel: makeReadModel({
+            activities: [
+              {
+                id: EventId.makeUnsafe("checkpoint-revert-started"),
+                tone: "info",
+                kind: "checkpoint.revert.started",
+                summary: "Reverting checkpoint",
+                payload: { turnCount: 1, scope: "thread" },
+                turnId: null,
+                createdAt: NOW,
+              },
+            ],
+          }),
+        }),
+      ),
+    ).rejects.toThrow("checkpoint revert in progress");
+  });
+
+  it("completes a handoff by updating the provider before closing the pending activity", async () => {
+    const events = await Effect.runPromise(
+      decideOrchestrationCommand({
+        command: {
+          type: "thread.provider.handoff.complete",
+          commandId: CommandId.makeUnsafe("server:complete-provider-handoff"),
+          threadId: THREAD_ID,
+          handoffCommandId: CommandId.makeUnsafe("command-provider-handoff"),
+          handoffEventId: EventId.makeUnsafe("event-provider-handoff"),
+          sourceModelSelection: { provider: "claudeAgent", model: "claude-sonnet" },
+          targetModelSelection: { provider: "grok", model: "grok-code" },
+          createdAt: NOW,
+        },
+        readModel: makeReadModel({
+          activities: [
+            {
+              id: EventId.makeUnsafe("provider-handoff-requested:command-provider-handoff"),
+              tone: "info",
+              kind: "provider.handoff.requested",
+              summary: "Switching to Grok",
+              payload: {
+                handoffCommandId: "command-provider-handoff",
+                sourceModelSelection: { provider: "claudeAgent", model: "claude-sonnet" },
+                targetModelSelection: { provider: "grok", model: "grok-code" },
+              },
+              turnId: null,
+              createdAt: NOW,
+            },
+          ],
+        }),
+      }),
+    );
+
+    expect(Array.isArray(events)).toBe(true);
+    if (!Array.isArray(events)) return;
+    expect(events.map((event) => event.type)).toEqual([
+      "thread.meta-updated",
+      "thread.activity-appended",
+    ]);
+    expect(events[0]?.payload).toMatchObject({
+      modelSelection: { provider: "grok", model: "grok-code" },
+    });
+    expect(events[1]?.payload).toMatchObject({
+      activity: {
+        kind: "provider.handoff.completed",
+        payload: { handoffCommandId: "command-provider-handoff" },
+      },
+    });
+  });
+
+  it("rejects a stale source provider", async () => {
+    await expect(
+      Effect.runPromise(
+        decideOrchestrationCommand({ command: command("codex"), readModel: makeReadModel() }),
+      ),
+    ).rejects.toThrow("not expected source 'codex'");
+  });
+
+  it("rejects a handoff while a turn is running", async () => {
+    await expect(
+      Effect.runPromise(
+        decideOrchestrationCommand({
+          command: command(),
+          readModel: makeReadModel({
+            session: {
+              threadId: THREAD_ID,
+              status: "running",
+              providerName: "claudeAgent",
+              runtimeMode: "full-access",
+              activeTurnId: null,
+              lastError: null,
+              updatedAt: NOW,
+            },
+          }),
+        }),
+      ),
+    ).rejects.toThrow("has an active turn");
+  });
+
+  it("rejects a handoff with unresolved provider interaction", async () => {
+    await expect(
+      Effect.runPromise(
+        decideOrchestrationCommand({
+          command: command(),
+          readModel: makeReadModel({ hasPendingApprovals: true }),
+        }),
+      ),
+    ).rejects.toThrow("pending provider interaction");
+  });
+
+  it("rejects a second handoff while the first is pending", async () => {
+    await expect(
+      Effect.runPromise(
+        decideOrchestrationCommand({
+          command: command(),
+          readModel: makeReadModel({
+            activities: [
+              {
+                id: EventId.makeUnsafe("provider-handoff-requested:first"),
+                tone: "info",
+                kind: "provider.handoff.requested",
+                summary: "Switching to Codex",
+                payload: {
+                  handoffCommandId: "first",
+                  sourceModelSelection: { provider: "claudeAgent", model: "claude-sonnet" },
+                  targetModelSelection: { provider: "codex", model: "gpt-5.5" },
+                },
+                turnId: null,
+                createdAt: NOW,
+              },
+            ],
+          }),
+        }),
+      ),
+    ).rejects.toThrow("still switching to 'codex'");
+  });
+});

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -10,6 +10,7 @@ import {
   EventId,
   MAX_PINNED_PROJECTS,
   PINNED_MESSAGES_MAX_COUNT,
+  PROVIDER_DISPLAY_NAMES,
   RESERVED_VOID_SPACE_ID,
   SPACES_MAX_COUNT,
   THREAD_GOAL_ACHIEVEMENTS_MAX_COUNT,
@@ -23,6 +24,11 @@ import {
 import { collectSubagentDescendants } from "@synara/shared/threadHierarchy";
 import { autoRuntimeModeSelectionIssue } from "@synara/shared/runtimeMode";
 import { providerSupportsNativeTurnSteering } from "@synara/shared/providerMetadata";
+import {
+  PROVIDER_HANDOFF_REQUESTED_ACTIVITY_KIND,
+  resolvePendingProviderHandoff,
+  toProviderHandoffActivityModelSelection,
+} from "@synara/shared/providerHandoff";
 import {
   collectTailTurnIds,
   resolveTailUserMessageEditTarget,
@@ -107,6 +113,21 @@ function validateAutoRuntimeMode(
         new OrchestrationCommandInvariantError({
           commandType: command.type,
           detail: issue,
+        }),
+      );
+}
+
+function validateNoPendingProviderHandoff(
+  command: Pick<OrchestrationCommand, "type">,
+  thread: Pick<OrchestrationThread, "id" | "activities">,
+) {
+  const pending = resolvePendingProviderHandoff(thread.activities);
+  return pending === null
+    ? Effect.void
+    : Effect.fail(
+        new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `Thread '${thread.id}' is still switching to '${pending.targetModelSelection.provider}'. Wait for the provider handoff to finish.`,
         }),
       );
 }
@@ -1458,6 +1479,9 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         threadId: command.threadId,
       });
+      if (command.modelSelection !== undefined) {
+        yield* validateNoPendingProviderHandoff(command, thread);
+      }
       const project = readModel.projects.find((candidate) => candidate.id === thread.projectId);
       // Provider-native threads: see thread.create — the selection mirrors the
       // provider's own subagent, so the Auto-mode capability check doesn't apply.
@@ -1621,6 +1645,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         threadId: command.threadId,
       });
+      yield* validateNoPendingProviderHandoff(command, thread);
       yield* validateAutoRuntimeMode(command, thread.modelSelection, command.runtimeMode);
       const occurredAt = nowIso();
       return {
@@ -1670,6 +1695,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         threadId: command.threadId,
       });
       yield* validateSidechatExecutionAvailable(command, targetThread);
+      yield* validateNoPendingProviderHandoff(command, targetThread);
       if (command.resumePrecondition !== undefined) {
         // Quit-resume continuations are only valid while the thread is exactly as
         // it was recorded; checked here so it holds inside the serialized dispatch.
@@ -1831,6 +1857,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         threadId: command.threadId,
       });
       yield* validateSidechatExecutionAvailable(command, thread);
+      yield* validateNoPendingProviderHandoff(command, thread);
       if (threadHasCheckpointRevertInProgress(thread)) {
         return yield* new OrchestrationCommandInvariantError({
           commandType: command.type,
@@ -2041,6 +2068,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         threadId: command.threadId,
       });
+      yield* validateNoPendingProviderHandoff(command, thread);
       if (threadHasInFlightTurn(thread)) {
         return yield* new OrchestrationCommandInvariantError({
           commandType: command.type,
@@ -2101,6 +2129,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         threadId: command.threadId,
       });
+      yield* validateNoPendingProviderHandoff(command, thread);
       if (threadHasCheckpointRevertInProgress(thread)) {
         return yield* new OrchestrationCommandInvariantError({
           commandType: command.type,
@@ -2144,6 +2173,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         threadId: command.threadId,
       });
       yield* validateSidechatExecutionAvailable(command, thread);
+      yield* validateNoPendingProviderHandoff(command, thread);
       if (threadHasCheckpointRevertInProgress(thread)) {
         return yield* new OrchestrationCommandInvariantError({
           commandType: command.type,
@@ -2246,6 +2276,179 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       };
     }
 
+    case "thread.provider.handoff": {
+      const thread = yield* requireThread({
+        readModel,
+        command,
+        threadId: command.threadId,
+      });
+      yield* requireThreadNotArchived({
+        readModel,
+        command,
+        threadId: command.threadId,
+      });
+      yield* validateSidechatExecutionAvailable(command, thread);
+      yield* validateNoPendingProviderHandoff(command, thread);
+      yield* validateAutoRuntimeMode(command, command.targetModelSelection, thread.runtimeMode);
+
+      if (threadHasCheckpointRevertInProgress(thread)) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: checkpointRevertInProgressDetail(command.threadId),
+        });
+      }
+
+      if (thread.modelSelection.provider !== command.expectedSourceProvider) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `Thread '${command.threadId}' is currently assigned to '${thread.modelSelection.provider}', not expected source '${command.expectedSourceProvider}'.`,
+        });
+      }
+      if (command.targetModelSelection.provider === command.expectedSourceProvider) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `Thread '${command.threadId}' is already assigned to provider '${command.expectedSourceProvider}'.`,
+        });
+      }
+      if (threadHasInFlightTurn(thread)) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `Thread '${command.threadId}' has an active turn. Wait for it to finish or interrupt it before switching providers.`,
+        });
+      }
+      if (thread.hasPendingApprovals || thread.hasPendingUserInput) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `Thread '${command.threadId}' has a pending provider interaction that must be resolved before switching providers.`,
+        });
+      }
+      if (
+        !thread.messages.some(
+          (message) =>
+            !message.streaming && (message.role === "user" || message.role === "assistant"),
+        )
+      ) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `Thread '${command.threadId}' must contain at least one completed chat message before switching providers.`,
+        });
+      }
+
+      const requestedActivityEvent: Omit<OrchestrationEvent, "sequence"> = {
+        ...withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        }),
+        type: "thread.activity-appended",
+        payload: {
+          threadId: command.threadId,
+          activity: {
+            id: EventId.makeUnsafe(`provider-handoff-requested:${command.commandId}`),
+            tone: "info",
+            kind: PROVIDER_HANDOFF_REQUESTED_ACTIVITY_KIND,
+            summary: `Switching to ${PROVIDER_DISPLAY_NAMES[command.targetModelSelection.provider]}`,
+            payload: {
+              handoffCommandId: command.commandId,
+              sourceModelSelection: toProviderHandoffActivityModelSelection(thread.modelSelection),
+              targetModelSelection: toProviderHandoffActivityModelSelection(
+                command.targetModelSelection,
+              ),
+            },
+            turnId: null,
+            createdAt: command.createdAt,
+          },
+        },
+      };
+      const requestedEvent: Omit<OrchestrationEvent, "sequence"> = {
+        ...withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        }),
+        causationEventId: requestedActivityEvent.eventId,
+        type: "thread.provider-handoff-requested",
+        payload: {
+          threadId: command.threadId,
+          sourceModelSelection: thread.modelSelection,
+          targetModelSelection: command.targetModelSelection,
+          createdAt: command.createdAt,
+        },
+      };
+      return [requestedActivityEvent, requestedEvent];
+    }
+
+    case "thread.provider.handoff.complete": {
+      const thread = yield* requireThread({
+        readModel,
+        command,
+        threadId: command.threadId,
+      });
+      const pending = resolvePendingProviderHandoff(thread.activities);
+      if (pending?.handoffCommandId !== command.handoffCommandId) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `Thread '${command.threadId}' no longer has provider handoff '${command.handoffCommandId}' pending.`,
+        });
+      }
+      if (thread.modelSelection.provider !== command.sourceModelSelection.provider) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `Thread '${command.threadId}' changed providers before handoff '${command.handoffCommandId}' completed.`,
+        });
+      }
+
+      const metaUpdatedEvent: Omit<OrchestrationEvent, "sequence"> = {
+        ...withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        }),
+        type: "thread.meta-updated",
+        payload: {
+          threadId: command.threadId,
+          modelSelection: command.targetModelSelection,
+          updatedAt: command.createdAt,
+        },
+      };
+      const completedActivityEvent: Omit<OrchestrationEvent, "sequence"> = {
+        ...withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        }),
+        causationEventId: metaUpdatedEvent.eventId,
+        type: "thread.activity-appended",
+        payload: {
+          threadId: command.threadId,
+          activity: {
+            id: EventId.makeUnsafe(`provider-handoff:${command.handoffEventId}`),
+            tone: "info",
+            kind: "provider.handoff.completed",
+            summary: `Continued with ${PROVIDER_DISPLAY_NAMES[command.targetModelSelection.provider]}`,
+            payload: {
+              handoffCommandId: command.handoffCommandId,
+              sourceModelSelection: toProviderHandoffActivityModelSelection(
+                command.sourceModelSelection,
+              ),
+              targetModelSelection: toProviderHandoffActivityModelSelection(
+                command.targetModelSelection,
+              ),
+              handoffEventId: command.handoffEventId,
+              recapMode: "bounded-transcript",
+            },
+            turnId: null,
+            createdAt: command.createdAt,
+          },
+        },
+      };
+      return [metaUpdatedEvent, completedActivityEvent];
+    }
+
     case "thread.goal.continue": {
       const thread = yield* requireThread({
         readModel,
@@ -2253,6 +2456,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         threadId: command.threadId,
       });
       yield* validateSidechatExecutionAvailable(command, thread);
+      yield* validateNoPendingProviderHandoff(command, thread);
       return {
         ...withEventBase({
           aggregateKind: "thread",

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -1,3 +1,4 @@
+import { retainProviderHandoffHistory } from "@synara/shared/providerHandoff";
 import type { OrchestrationEvent, OrchestrationReadModel, ThreadId } from "@synara/contracts";
 import {
   OrchestrationCheckpointSummary,
@@ -262,7 +263,7 @@ function upsertThreadActivity(
   if (existingIndex >= 0 && compareThreadActivities(activities[existingIndex]!, activity) === 0) {
     const next = [...activities];
     next[existingIndex] = activity;
-    return next.slice(-MAX_THREAD_ACTIVITIES);
+    return retainProviderHandoffHistory(next, MAX_THREAD_ACTIVITIES);
   }
 
   const withoutExisting =
@@ -271,7 +272,7 @@ function upsertThreadActivity(
       : [...activities.slice(0, existingIndex), ...activities.slice(existingIndex + 1)];
   const last = withoutExisting.at(-1);
   if (!last || compareThreadActivities(last, activity) <= 0) {
-    return [...withoutExisting, activity].slice(-MAX_THREAD_ACTIVITIES);
+    return retainProviderHandoffHistory([...withoutExisting, activity], MAX_THREAD_ACTIVITIES);
   }
 
   let low = 0;
@@ -284,8 +285,9 @@ function upsertThreadActivity(
       high = middle;
     }
   }
-  return [...withoutExisting.slice(0, low), activity, ...withoutExisting.slice(low)].slice(
-    -MAX_THREAD_ACTIVITIES,
+  return retainProviderHandoffHistory(
+    [...withoutExisting.slice(0, low), activity, ...withoutExisting.slice(low)],
+    MAX_THREAD_ACTIVITIES,
   );
 }
 

--- a/apps/server/src/orchestration/providerIntentClassification.test.ts
+++ b/apps/server/src/orchestration/providerIntentClassification.test.ts
@@ -31,4 +31,32 @@ describe("providerIntentClassification", () => {
     expect(isClaimedProviderIntent(event)).toBe(true);
     expect(isReplaySafeClaimedProviderIntent(event)).toBe(true);
   });
+
+  it("treats continuous provider handoff as a claimed side effect", () => {
+    const threadId = ThreadId.makeUnsafe("thread-provider-intent-handoff");
+    const event = {
+      sequence: 2,
+      eventId: EventId.makeUnsafe("event-provider-intent-handoff"),
+      aggregateKind: "thread",
+      aggregateId: threadId,
+      type: "thread.provider-handoff-requested",
+      occurredAt: "2026-09-10T10:00:00.000Z",
+      commandId: null,
+      causationEventId: null,
+      correlationId: null,
+      metadata: {},
+      payload: {
+        threadId,
+        sourceModelSelection: { provider: "claudeAgent", model: "claude-sonnet" },
+        targetModelSelection: { provider: "grok", model: "grok-code" },
+        createdAt: "2026-09-10T10:00:00.000Z",
+      },
+    } as OrchestrationEvent;
+
+    expect(isProviderIntentEvent(event)).toBe(true);
+    if (!isProviderIntentEvent(event)) return;
+    expect(isProviderSideEffectIntent(event)).toBe(true);
+    expect(isClaimedProviderIntent(event)).toBe(true);
+    expect(isReplaySafeClaimedProviderIntent(event)).toBe(true);
+  });
 });

--- a/apps/server/src/orchestration/providerIntentClassification.ts
+++ b/apps/server/src/orchestration/providerIntentClassification.ts
@@ -21,6 +21,7 @@ export type ProviderIntentEvent = Extract<
       | "thread.user-input-response-requested"
       | "thread.conversation-rollback-requested"
       | "thread.message-edit-resend-requested"
+      | "thread.provider-handoff-requested"
       | "thread.session-stop-requested";
   }
 >;
@@ -43,6 +44,7 @@ const PROVIDER_INTENT_EVENT_TYPES = new Set<ProviderIntentEvent["type"]>([
   "thread.user-input-response-requested",
   "thread.conversation-rollback-requested",
   "thread.message-edit-resend-requested",
+  "thread.provider-handoff-requested",
   "thread.session-stop-requested",
 ]);
 
@@ -57,6 +59,10 @@ export const isProviderIntentEvent = (event: OrchestrationEvent): event is Provi
 export const isReplaySafeClaimedProviderIntent = (event: ProviderIntentEvent): boolean =>
   event.type === "thread.created" ||
   event.type === "thread.archived" ||
+  // Provider handoff is a durable mini-saga: request/completion/failure activity
+  // ids and projection commands are deterministic, and the provider switch is
+  // serialized by ProviderService with rollback on rejected replacement.
+  event.type === "thread.provider-handoff-requested" ||
   // The claimed handler only performs the idempotent durable enqueue. Queue
   // draining runs after the delivery settles, so replay never repeats provider
   // dispatch as part of this claim.

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -43,6 +43,14 @@ import {
 } from "./appSettings";
 
 describe("server-backed provider enablement", () => {
+  it("keeps continuous provider handoff opt-in and persists explicit changes", () => {
+    expect(AppSettingsSchema.makeUnsafe({}).enableContinuousProviderHandoff).toBe(false);
+    expect(DEFAULT_SERVER_SETTINGS_VIEW.enableContinuousProviderHandoff).toBe(false);
+    expect(
+      appSettingsPatchToServerSettingsPatch({ enableContinuousProviderHandoff: true }),
+    ).toEqual({ enableContinuousProviderHandoff: true });
+  });
+
   it("reads disabled providers from the server settings view", () => {
     expect(
       getServerDisabledProviders({

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -328,6 +328,7 @@ export const AppSettingsSchema = Schema.Struct({
   // Started threads: show reasoning effort as a stepped slider card in the composer's
   // model menu instead of radio rows. New chats keep the split model/effort pickers.
   composerEffortSlider: Schema.Boolean.pipe(withDefaults(() => true)),
+  enableContinuousProviderHandoff: Schema.Boolean.pipe(withDefaults(() => false)),
   autoOpenDevicePane: Schema.Boolean.pipe(withDefaults(() => true)),
   enableProviderUpdateChecks: Schema.Boolean.pipe(withDefaults(() => true)),
   enableNativeFontSmoothing: Schema.Boolean.pipe(withDefaults(getDefaultNativeFontSmoothing)),
@@ -682,6 +683,7 @@ function serverSettingsToAppSettings(settings: ServerSettingsView): Partial<AppS
     devinBinaryPath: settings.providers.devin.binaryPath,
     defaultThreadEnvMode: settings.defaultThreadEnvMode,
     enableAssistantStreaming: settings.enableAssistantStreaming,
+    enableContinuousProviderHandoff: settings.enableContinuousProviderHandoff,
     enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
     antigravityBinaryPath: settings.providers.antigravity.binaryPath,
     grokBinaryPath: settings.providers.grok.binaryPath,
@@ -776,6 +778,9 @@ export function appSettingsPatchToServerSettingsPatch(
 
   if (hasOwn(patch, "enableAssistantStreaming")) {
     serverPatch.enableAssistantStreaming = Boolean(patch.enableAssistantStreaming);
+  }
+  if (hasOwn(patch, "enableContinuousProviderHandoff")) {
+    serverPatch.enableContinuousProviderHandoff = Boolean(patch.enableContinuousProviderHandoff);
   }
   if (hasOwn(patch, "enableProviderUpdateChecks")) {
     serverPatch.enableProviderUpdateChecks = Boolean(patch.enableProviderUpdateChecks);
@@ -939,6 +944,7 @@ function buildInitialServerSettingsMigrationPatch(settings: AppSettings): Server
     "cursorBinaryPath",
     "defaultThreadEnvMode",
     "enableAssistantStreaming",
+    "enableContinuousProviderHandoff",
     "enableProviderUpdateChecks",
     "devinBinaryPath",
     "antigravityBinaryPath",

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -144,6 +144,8 @@ import {
 import {
   canCreateThreadHandoff,
   resolveAvailableHandoffTargetProviders,
+  resolvePendingProviderHandoff,
+  resolveProviderHandoffTrail,
   resolveThreadHandoffBadgeLabel,
 } from "../lib/threadHandoff";
 import { buildDraftThreadRenameCreateInput, dispatchThreadRename } from "../lib/threadRename";
@@ -231,7 +233,7 @@ import { SynaraLogo } from "./SynaraLogo";
 import TerminalWorkspaceTabs from "./TerminalWorkspaceTabs";
 import { ThreadWorktreeHandoffDialog } from "./ThreadWorktreeHandoffDialog";
 import { ChatComposerFooter } from "./chat/ChatComposerFooter";
-import { ChatHeader } from "./chat/ChatHeader";
+import { ChatHeader, type ProviderHandoffMode } from "./chat/ChatHeader";
 import { ChatSurfaceHeader } from "./chat/ChatSurfaceHeader";
 import { ChatTranscriptPane } from "./chat/ChatTranscriptPane";
 import { ComposerActiveTaskListCard } from "./chat/ComposerActiveTaskListCard";
@@ -517,7 +519,7 @@ export default function ChatView({
   const navigate = useNavigate();
   const { handleNewThread } = useHandleNewThread();
   const { handleNewChat } = useHandleNewChat();
-  const { createThreadHandoff } = useThreadHandoff();
+  const { createThreadHandoff, continueThreadWithProvider } = useThreadHandoff();
   const rawSearch = useDiffRouteSearch();
   const activeSplitView = useSplitViewStore(
     useMemo(() => selectSplitView(rawSearch.splitViewId ?? null), [rawSearch.splitViewId]),
@@ -861,6 +863,10 @@ export default function ChatView({
   const activeLatestTurnId = activeLatestTurn?.turnId ?? null;
   const activeLatestTurnState = activeLatestTurn?.state ?? null;
   const threadActivities = activeThread?.activities ?? EMPTY_ACTIVITIES;
+  const pendingProviderHandoff = useMemo(
+    () => resolvePendingProviderHandoff(threadActivities),
+    [threadActivities],
+  );
   const hasLiveTurnTail = hasLiveTurnTailWork({
     latestTurn: activeLatestTurn,
     messages: activeThread?.messages ?? EMPTY_MESSAGES,
@@ -1518,7 +1524,8 @@ export default function ChatView({
   const activeTurnInProgress = activeTurnLayoutLive || keepSettledActiveTurnLayout;
   const isComposerApprovalState = activePendingApproval !== null;
   const isSidechatExpired = Boolean(activeThread?.sidechatExpiredAt);
-  const isComposerEditorDisabled = isConnecting || isComposerApprovalState || isSidechatExpired;
+  const isComposerEditorDisabled =
+    isConnecting || isComposerApprovalState || isSidechatExpired || pendingProviderHandoff !== null;
   const canCollapsePastedTextToDraft = shouldEnableComposerPastedTextCollapse({
     isComposerApprovalState,
     hasPendingUserInput: pendingUserInputs.length > 0,
@@ -2054,6 +2061,10 @@ export default function ChatView({
   const handoffBadgeTargetProvider = activeThread?.handoff
     ? activeThread.modelSelection.provider
     : null;
+  const providerHandoffTrail = useMemo(
+    () => resolveProviderHandoffTrail(threadActivities),
+    [threadActivities],
+  );
   const handoffTargetProviders = useMemo(
     () =>
       activeThread
@@ -2065,7 +2076,13 @@ export default function ChatView({
         : [],
     [activeThread, providerStatuses, serverSettingsQuery.data?.providers],
   );
-  const handoffActionLabel = activeThread ? "Hand off thread" : "Create handoff thread";
+  const handoffActionLabel = pendingProviderHandoff
+    ? `Switching to ${PROVIDER_DISPLAY_NAMES[pendingProviderHandoff.targetModelSelection.provider]}`
+    : settings.enableContinuousProviderHandoff
+      ? "Hand off to another provider"
+      : activeThread
+        ? "Hand off thread"
+        : "Create handoff thread";
   const activeProviderStatus = useMemo(
     () => findProviderStatus(providerStatuses, selectedProvider),
     [selectedProvider, providerStatuses],
@@ -3609,25 +3626,40 @@ export default function ChatView({
   );
 
   const onCreateHandoffThread = useCallback(
-    async (targetProvider: ProviderKind) => {
+    async (targetProvider: ProviderKind, mode: ProviderHandoffMode) => {
       if (!activeThread || handoffDisabled) {
         return;
       }
 
+      const shouldContinueInThread =
+        mode === "continue" && settings.enableContinuousProviderHandoff;
+      const handoffPromise = shouldContinueInThread
+        ? continueThreadWithProvider(activeThread, targetProvider)
+        : createThreadHandoff(activeThread, targetProvider);
+      const errorTitle = shouldContinueInThread
+        ? "Could not switch providers"
+        : "Could not create handoff thread";
+      const fallbackErrorDescription = shouldContinueInThread
+        ? "An error occurred while switching providers."
+        : "An error occurred while creating the handoff thread.";
+
       try {
-        await createThreadHandoff(activeThread, targetProvider);
+        await handoffPromise;
       } catch (error) {
         toastManager.add({
           type: "error",
-          title: "Could not create handoff thread",
-          description:
-            error instanceof Error
-              ? error.message
-              : "An error occurred while creating the handoff thread.",
+          title: errorTitle,
+          description: error instanceof Error ? error.message : fallbackErrorDescription,
         });
       }
     },
-    [activeThread, createThreadHandoff, handoffDisabled],
+    [
+      activeThread,
+      continueThreadWithProvider,
+      createThreadHandoff,
+      handoffDisabled,
+      settings.enableContinuousProviderHandoff,
+    ],
   );
 
   const clearComposerInput = useCallback(
@@ -5049,9 +5081,10 @@ export default function ChatView({
                 COMPOSER_INPUT_SHELL_CLASS_NAME,
                 composerProviderState.composerFrameClassName,
                 composerMenuOpen && !isComposerApprovalState && "overflow-visible",
-                isSidechatExpired && "pointer-events-none opacity-60",
+                (isSidechatExpired || pendingProviderHandoff !== null) &&
+                  "pointer-events-none opacity-60",
               )}
-              aria-disabled={isSidechatExpired}
+              aria-disabled={isComposerEditorDisabled}
             >
               <div
                 className={cn(
@@ -5270,7 +5303,7 @@ export default function ChatView({
                     submission={{
                       phase,
                       busy: isSendBusy,
-                      connecting: isConnecting,
+                      connecting: isConnecting || pendingProviderHandoff !== null,
                       expired: isSidechatExpired,
                       preparingImages: isPreparingComposerImages,
                       preparingWorktree: isPreparingWorktree,
@@ -5363,10 +5396,13 @@ export default function ChatView({
           diffToggleShortcutLabel={diffPanelShortcutLabel}
           handoffBadgeLabel={handoffBadgeLabel}
           handoffActionLabel={handoffActionLabel}
+          handoffPending={pendingProviderHandoff !== null}
           handoffDisabled={handoffDisabled}
           handoffActionTargetProviders={handoffTargetProviders}
           handoffBadgeSourceProvider={handoffBadgeSourceProvider}
           handoffBadgeTargetProvider={handoffBadgeTargetProvider}
+          providerHandoffTrail={providerHandoffTrail}
+          continuousHandoffEnabled={settings.enableContinuousProviderHandoff}
           gitCwd={threadWorkspaceCwd}
           diffTotals={repoDiffTotals}
           showGitActions={showGitActions && !isEditorRail}

--- a/apps/web/src/components/chat/ChatHandoffMenu.browser.tsx
+++ b/apps/web/src/components/chat/ChatHandoffMenu.browser.tsx
@@ -1,0 +1,112 @@
+import "../../index.css";
+
+import { page, userEvent } from "vitest/browser";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { TooltipProvider } from "../ui/tooltip";
+import { ChatHandoffMenu } from "./ChatHandoffMenu";
+import { ProviderHandoffTrail } from "./ProviderHandoffTrail";
+
+beforeEach(async () => {
+  await page.viewport(1000, 800);
+});
+
+const defaults = {
+  compact: false,
+  handoffActionLabel: "Hand off",
+  handoffPending: false,
+  handoffDisabled: false,
+  handoffActionTargetProviders: ["claudeAgent", "grok"] as const,
+};
+
+async function renderMenu(enabled: boolean) {
+  const onCreateHandoff = vi.fn();
+  await render(
+    <TooltipProvider>
+      <ChatHandoffMenu
+        {...defaults}
+        continuousHandoffEnabled={enabled}
+        onCreateHandoff={onCreateHandoff}
+      />
+    </TooltipProvider>,
+  );
+  await page.getByRole("button", { name: "Hand off", exact: true }).click();
+  return onCreateHandoff;
+}
+
+describe("provider handoff menu", () => {
+  it("keeps direct new-conversation handoffs when the setting is off", async () => {
+    const onCreateHandoff = await renderMenu(false);
+    await expect.element(page.getByRole("menuitem", { name: "Claude", exact: true })).toBeVisible();
+    expect(document.body.textContent).not.toContain("Continue here");
+    await page.getByRole("menuitem", { name: "Claude", exact: true }).click();
+    expect(onCreateHandoff).toHaveBeenCalledWith("claudeAgent", "new-thread");
+  });
+
+  it.each(["Continue here", "New conversation"] as const)(
+    "selects the %s outcome",
+    async (outcome) => {
+      const onCreateHandoff = await renderMenu(true);
+      await page.getByRole("menuitem", { name: outcome, exact: true }).click();
+      await page.getByRole("menuitem", { name: "Grok", exact: true }).click();
+      expect(onCreateHandoff).toHaveBeenCalledWith(
+        "grok",
+        outcome === "Continue here" ? "continue" : "new-thread",
+      );
+      await expect.element(page.getByRole("menu")).not.toBeInTheDocument();
+    },
+  );
+
+  it("dismisses with Escape without dispatching", async () => {
+    const onCreateHandoff = await renderMenu(true);
+    await userEvent.keyboard("{Escape}");
+    await expect.element(page.getByRole("menu")).not.toBeInTheDocument();
+    expect(onCreateHandoff).not.toHaveBeenCalled();
+  });
+
+  it("disables handoffs while a switch is pending", async () => {
+    await render(
+      <TooltipProvider>
+        <ChatHandoffMenu
+          {...defaults}
+          handoffPending
+          handoffDisabled
+          continuousHandoffEnabled
+          onCreateHandoff={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+    await expect
+      .element(page.getByRole("button", { name: "Hand off", exact: true }))
+      .toBeDisabled();
+  });
+});
+
+it("exposes the entire compressed provider route on keyboard focus", async () => {
+  const trail = Array.from({ length: 15 }, (_, index) => ({
+    provider: index % 2 === 0 ? ("codex" as const) : ("claudeAgent" as const),
+    isReturn: index > 1,
+  }));
+  await render(
+    <TooltipProvider delay={0}>
+      <ProviderHandoffTrail
+        trail={trail}
+        compact
+        fallbackLabel={null}
+        fallbackSourceProvider={null}
+        fallbackTargetProvider={null}
+      />
+    </TooltipProvider>,
+  );
+  const trigger = document.querySelector<HTMLElement>('[data-slot="tooltip-trigger"]');
+  expect(trigger?.tabIndex).toBe(0);
+  await userEvent.tab();
+  await expect.element(page.getByText("Provider path", { exact: true })).toBeVisible();
+  const routeText =
+    page.getByText("Provider path", { exact: true }).element().parentElement?.textContent ?? "";
+  expect(routeText.match(/Codex/g)).toHaveLength(8);
+  expect(routeText.match(/Claude/g)).toHaveLength(7);
+  expect(trigger?.getAttribute("aria-label")).toContain("returned to Codex");
+  await userEvent.keyboard("{Escape}");
+  await expect.element(page.getByText("Provider path", { exact: true })).not.toBeInTheDocument();
+});

--- a/apps/web/src/components/chat/ChatHandoffMenu.tsx
+++ b/apps/web/src/components/chat/ChatHandoffMenu.tsx
@@ -1,0 +1,96 @@
+import { PROVIDER_DISPLAY_NAMES, type ProviderKind } from "@synara/contracts";
+import { HandoffIcon, LoaderCircleIcon, MessageCircleIcon } from "~/lib/icons";
+import { ProviderIcon } from "../ProviderIcon";
+import { Menu, MenuItem, MenuSub, MenuSubTrigger, MenuTrigger } from "../ui/menu";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { ComposerPickerMenuPopup, ComposerPickerMenuSubPopup } from "./ComposerPickerMenuPopup";
+import { ChatHeaderButton } from "./chatHeaderControls";
+
+export type ProviderHandoffMode = "continue" | "new-thread";
+
+export function ChatHandoffMenu({
+  compact,
+  handoffActionLabel,
+  handoffPending,
+  handoffDisabled,
+  handoffActionTargetProviders,
+  continuousHandoffEnabled,
+  onCreateHandoff,
+}: {
+  compact: boolean;
+  handoffActionLabel: string;
+  handoffPending: boolean;
+  handoffDisabled: boolean;
+  handoffActionTargetProviders: ReadonlyArray<ProviderKind>;
+  continuousHandoffEnabled: boolean;
+  onCreateHandoff: (provider: ProviderKind, mode: ProviderHandoffMode) => void;
+}) {
+  const renderHandoffTargetItems = (mode: ProviderHandoffMode) =>
+    handoffActionTargetProviders.map((provider) => (
+      <MenuItem key={provider} onClick={() => onCreateHandoff(provider, mode)}>
+        {/* opacity-100 opts brand icons out of the option row's 80% icon dim. */}
+        <ProviderIcon provider={provider} className="size-3.5 shrink-0 opacity-100" />
+        <span>{PROVIDER_DISPLAY_NAMES[provider]}</span>
+      </MenuItem>
+    ));
+
+  return (
+    <Menu modal={false}>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <MenuTrigger
+              render={
+                <ChatHeaderButton
+                  type="button"
+                  tone="outline"
+                  className={compact ? "gap-1" : "gap-1.5"}
+                  aria-label={handoffActionLabel}
+                  disabled={handoffDisabled || handoffActionTargetProviders.length === 0}
+                />
+              }
+            >
+              {handoffPending ? (
+                <LoaderCircleIcon className="size-[1em] shrink-0 animate-spin opacity-80" />
+              ) : (
+                <HandoffIcon className="size-[1em] shrink-0 opacity-80" />
+              )}
+              {!compact ? (
+                <span className="truncate font-normal">
+                  {handoffPending ? "Switching…" : "Hand off"}
+                </span>
+              ) : null}
+            </MenuTrigger>
+          }
+        />
+        <TooltipPopup side="bottom">{handoffActionLabel}</TooltipPopup>
+      </Tooltip>
+      <ComposerPickerMenuPopup align="end" side="bottom" className="w-52 min-w-52">
+        {continuousHandoffEnabled ? (
+          <>
+            <MenuSub>
+              <MenuSubTrigger>
+                <MessageCircleIcon className="size-3.5 shrink-0" />
+                <span>Continue here</span>
+              </MenuSubTrigger>
+              <ComposerPickerMenuSubPopup className="w-48 min-w-48">
+                {renderHandoffTargetItems("continue")}
+              </ComposerPickerMenuSubPopup>
+            </MenuSub>
+            <MenuSub>
+              <MenuSubTrigger>
+                <HandoffIcon className="size-3.5 shrink-0" />
+                <span>New conversation</span>
+              </MenuSubTrigger>
+              <ComposerPickerMenuSubPopup className="w-48 min-w-48">
+                {renderHandoffTargetItems("new-thread")}
+              </ComposerPickerMenuSubPopup>
+            </MenuSub>
+          </>
+        ) : (
+          renderHandoffTargetItems("new-thread")
+        )}
+      </ComposerPickerMenuPopup>
+    </Menu>
+  );
+}

--- a/apps/web/src/components/chat/ChatHeader.test.ts
+++ b/apps/web/src/components/chat/ChatHeader.test.ts
@@ -6,6 +6,10 @@
 import { describe, expect, it } from "vitest";
 
 import { resolveChatHeaderThreadIconKind } from "./ChatHeader";
+import {
+  describeProviderHandoffTrail,
+  resolveProviderHandoffTrailPresentation,
+} from "./ProviderHandoffTrail";
 
 describe("resolveChatHeaderThreadIconKind", () => {
   it("uses the terminal icon for terminal-first threads", () => {
@@ -18,5 +22,30 @@ describe("resolveChatHeaderThreadIconKind", () => {
 
   it("hides provider branding for untouched new chat threads", () => {
     expect(resolveChatHeaderThreadIconKind("chat", "New thread")).toBe("none");
+  });
+});
+
+describe("provider handoff trail presentation", () => {
+  const trail = [
+    { provider: "claudeAgent" as const, isReturn: false },
+    { provider: "antigravity" as const, isReturn: false },
+    { provider: "codex" as const, isReturn: false },
+    { provider: "grok" as const, isReturn: false },
+    { provider: "claudeAgent" as const, isReturn: true },
+    { provider: "droid" as const, isReturn: false },
+  ];
+
+  it("keeps the origin and latest providers while compressing long paths", () => {
+    expect(resolveProviderHandoffTrailPresentation(trail)).toEqual({
+      first: trail[0],
+      trailing: trail.slice(-3),
+      hiddenCount: 2,
+    });
+  });
+
+  it("describes forward moves and returns explicitly", () => {
+    expect(describeProviderHandoffTrail(trail.slice(0, 5))).toBe(
+      "Started with Claude, continued with Antigravity, continued with Codex, continued with Grok, returned to Claude",
+    );
   });
 });

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -20,10 +20,10 @@ import { TbExchange } from "react-icons/tb";
 import type { ThreadPrimarySurface } from "../../types";
 import GitActionsControl from "../GitActionsControl";
 import {
-  ArrowRightIcon,
   CheckIcon,
   HandoffIcon,
   HistoryIcon,
+  LoaderCircleIcon,
   MessageCircleIcon,
   PanelRightCloseIcon,
   PlusIcon,
@@ -41,8 +41,8 @@ import {
 import { DiffStat } from "../ui/diff-stat";
 import { IconButton } from "../ui/icon-button";
 import { Badge } from "../ui/badge";
-import { Menu, MenuItem, MenuTrigger } from "../ui/menu";
-import { ComposerPickerMenuPopup } from "./ComposerPickerMenuPopup";
+import { Menu, MenuItem, MenuSub, MenuSubTrigger, MenuTrigger } from "../ui/menu";
+import { ComposerPickerMenuPopup, ComposerPickerMenuSubPopup } from "./ComposerPickerMenuPopup";
 import { OpenInPicker } from "./OpenInPicker";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { SidebarHeaderNavigationControls } from "../SidebarHeaderNavigationControls";
@@ -64,6 +64,7 @@ import type { RepoDiffTotals } from "~/hooks/useRepoDiffTotals";
 import { ProviderIcon } from "../ProviderIcon";
 import { ProviderUsageMenuControl } from "../ProviderUsageMenuControl";
 import { EnvironmentToggle, type EnvironmentToggleState } from "./environment/EnvironmentToggle";
+import { ProviderHandoffTrail } from "./ProviderHandoffTrail";
 
 /**
  * Width (px) below which collapsible header controls drop their text labels and
@@ -98,10 +99,16 @@ interface ChatHeaderProps {
   diffToggleShortcutLabel: string | null;
   handoffBadgeLabel: string | null;
   handoffActionLabel: string;
+  handoffPending?: boolean;
   handoffDisabled: boolean;
   handoffActionTargetProviders: ReadonlyArray<ProviderKind>;
   handoffBadgeSourceProvider: ProviderKind | null;
   handoffBadgeTargetProvider: ProviderKind | null;
+  providerHandoffTrail: ReadonlyArray<{
+    readonly provider: ProviderKind;
+    readonly isReturn: boolean;
+  }>;
+  continuousHandoffEnabled: boolean;
   gitCwd: string | null;
   diffTotals: RepoDiffTotals;
   showGitActions?: boolean;
@@ -145,11 +152,13 @@ interface ChatHeaderProps {
   onDeleteProjectScript: (scriptId: string) => Promise<void>;
   onToggleDiff: () => void;
   onRegisterCommitAndPushTrigger?: (trigger: (() => void) | null) => void;
-  onCreateHandoff: (targetProvider: ProviderKind) => void;
+  onCreateHandoff: (targetProvider: ProviderKind, mode: ProviderHandoffMode) => void;
   onNavigateToThread: (threadId: ThreadId) => void;
   onRenameThread: () => void;
   onCloseThreadPane?: () => void;
 }
+
+export type ProviderHandoffMode = "continue" | "new-thread";
 
 const EDITOR_CHAT_HISTORY_LIMIT = 30;
 
@@ -521,10 +530,13 @@ export function ChatHeader({
   diffToggleShortcutLabel,
   handoffBadgeLabel,
   handoffActionLabel,
+  handoffPending = false,
   handoffDisabled,
   handoffActionTargetProviders,
   handoffBadgeSourceProvider,
   handoffBadgeTargetProvider,
+  providerHandoffTrail,
+  continuousHandoffEnabled,
   gitCwd,
   diffTotals,
   showGitActions: showGitActionsProp,
@@ -588,6 +600,7 @@ export function ChatHeader({
   const inlineChatLayoutAction = chatLayoutAction?.kind === "maximize" ? chatLayoutAction : null;
   const threadIconKind = resolveChatHeaderThreadIconKind(activeThreadEntryPoint, activeThreadTitle);
   const showSidechatTitleChip = isSidechat && compact;
+  const showProviderHandoffTrail = providerHandoffTrail.length > 1 || handoffBadgeLabel !== null;
 
   useEffect(() => {
     const el = headerRef.current;
@@ -609,6 +622,14 @@ export function ChatHeader({
       />
     );
   };
+  const renderHandoffTargetItems = (mode: ProviderHandoffMode) =>
+    handoffActionTargetProviders.map((provider) => (
+      <MenuItem key={provider} onClick={() => onCreateHandoff(provider, mode)}>
+        {/* opacity-100 opts brand icons out of the option row's 80% icon dim. */}
+        {renderProviderIcon(provider, "size-3.5 shrink-0 opacity-100")}
+        <span>{PROVIDER_DISPLAY_NAMES[provider]}</span>
+      </MenuItem>
+    ));
 
   // Single-chat surfaces use this as a true right-dock visibility toggle. Hosts
   // without a multi-pane dock (split/editor surfaces) keep the legacy diff-only
@@ -713,7 +734,10 @@ export function ChatHeader({
               >
                 {threadIconKind === "none" ? null : (
                   <span
-                    className="inline-flex size-3.5 shrink-0 items-center justify-center"
+                    className={cn(
+                      "inline-flex size-3.5 shrink-0 items-center justify-center",
+                      showProviderHandoffTrail && "sm:hidden",
+                    )}
                     title={
                       threadIconKind === "terminal"
                         ? "Terminal"
@@ -768,26 +792,14 @@ export function ChatHeader({
                   onNavigateToThread={onNavigateToThread}
                 />
               ) : null}
-              {!hideHandoffControls && handoffBadgeLabel ? (
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <Badge
-                        variant="outline"
-                        className="hidden !h-6 shrink-0 items-center justify-center gap-1 rounded-md px-1.5 text-[10px] sm:inline-flex"
-                      >
-                        <span className="inline-flex size-4 shrink-0 items-center justify-center">
-                          {renderProviderIcon(handoffBadgeSourceProvider, "size-3")}
-                        </span>
-                        <ArrowRightIcon className="size-2.5 shrink-0 opacity-45" />
-                        <span className="inline-flex size-4 shrink-0 items-center justify-center">
-                          {renderProviderIcon(handoffBadgeTargetProvider, "size-3")}
-                        </span>
-                      </Badge>
-                    }
-                  />
-                  <TooltipPopup side="bottom">{handoffBadgeLabel}</TooltipPopup>
-                </Tooltip>
+              {!hideHandoffControls ? (
+                <ProviderHandoffTrail
+                  trail={providerHandoffTrail}
+                  compact={compact}
+                  fallbackLabel={handoffBadgeLabel}
+                  fallbackSourceProvider={handoffBadgeSourceProvider}
+                  fallbackTargetProvider={handoffBadgeTargetProvider}
+                />
               ) : null}
             </div>
           </div>
@@ -813,21 +825,46 @@ export function ChatHeader({
                       />
                     }
                   >
-                    <HandoffIcon className="size-[1em] shrink-0 opacity-80" />
-                    {!compact ? <span className="truncate font-normal">Hand off</span> : null}
+                    {handoffPending ? (
+                      <LoaderCircleIcon className="size-[1em] shrink-0 animate-spin opacity-80" />
+                    ) : (
+                      <HandoffIcon className="size-[1em] shrink-0 opacity-80" />
+                    )}
+                    {!compact ? (
+                      <span className="truncate font-normal">
+                        {handoffPending ? "Switching…" : "Hand off"}
+                      </span>
+                    ) : null}
                   </MenuTrigger>
                 }
               />
               <TooltipPopup side="bottom">{handoffActionLabel}</TooltipPopup>
             </Tooltip>
-            <ComposerPickerMenuPopup align="end" side="bottom" className="w-48 min-w-48">
-              {handoffActionTargetProviders.map((provider) => (
-                <MenuItem key={provider} onClick={() => onCreateHandoff(provider)}>
-                  {/* opacity-100 opts brand icons out of the option row's 80% icon dim. */}
-                  {renderProviderIcon(provider, "size-3.5 shrink-0 opacity-100")}
-                  <span>Handoff to {PROVIDER_DISPLAY_NAMES[provider]}</span>
-                </MenuItem>
-              ))}
+            <ComposerPickerMenuPopup align="end" side="bottom" className="w-52 min-w-52">
+              {continuousHandoffEnabled ? (
+                <>
+                  <MenuSub>
+                    <MenuSubTrigger>
+                      <MessageCircleIcon className="size-3.5 shrink-0" />
+                      <span>Continue here</span>
+                    </MenuSubTrigger>
+                    <ComposerPickerMenuSubPopup className="w-48 min-w-48">
+                      {renderHandoffTargetItems("continue")}
+                    </ComposerPickerMenuSubPopup>
+                  </MenuSub>
+                  <MenuSub>
+                    <MenuSubTrigger>
+                      <HandoffIcon className="size-3.5 shrink-0" />
+                      <span>New conversation</span>
+                    </MenuSubTrigger>
+                    <ComposerPickerMenuSubPopup className="w-48 min-w-48">
+                      {renderHandoffTargetItems("new-thread")}
+                    </ComposerPickerMenuSubPopup>
+                  </MenuSub>
+                </>
+              ) : (
+                renderHandoffTargetItems("new-thread")
+              )}
             </ComposerPickerMenuPopup>
           </Menu>
         ) : null}

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -21,9 +21,7 @@ import type { ThreadPrimarySurface } from "../../types";
 import GitActionsControl from "../GitActionsControl";
 import {
   CheckIcon,
-  HandoffIcon,
   HistoryIcon,
-  LoaderCircleIcon,
   MessageCircleIcon,
   PanelRightCloseIcon,
   PlusIcon,
@@ -33,16 +31,14 @@ import {
 import { formatRelativeTime } from "~/lib/relativeTime";
 import {
   CHAT_HEADER_TOGGLE_CLASS_NAME,
-  ChatHeaderButton,
   ChatHeaderIconButton,
   SurfaceChipIcon,
   SurfaceTabChip,
 } from "./chatHeaderControls";
 import { DiffStat } from "../ui/diff-stat";
 import { IconButton } from "../ui/icon-button";
-import { Badge } from "../ui/badge";
-import { Menu, MenuItem, MenuSub, MenuSubTrigger, MenuTrigger } from "../ui/menu";
-import { ComposerPickerMenuPopup, ComposerPickerMenuSubPopup } from "./ComposerPickerMenuPopup";
+import { Menu, MenuItem, MenuTrigger } from "../ui/menu";
+import { ComposerPickerMenuPopup } from "./ComposerPickerMenuPopup";
 import { OpenInPicker } from "./OpenInPicker";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { SidebarHeaderNavigationControls } from "../SidebarHeaderNavigationControls";
@@ -64,6 +60,7 @@ import type { RepoDiffTotals } from "~/hooks/useRepoDiffTotals";
 import { ProviderIcon } from "../ProviderIcon";
 import { ProviderUsageMenuControl } from "../ProviderUsageMenuControl";
 import { EnvironmentToggle, type EnvironmentToggleState } from "./environment/EnvironmentToggle";
+import { ChatHandoffMenu, type ProviderHandoffMode } from "./ChatHandoffMenu";
 import { ProviderHandoffTrail } from "./ProviderHandoffTrail";
 
 /**
@@ -158,7 +155,7 @@ interface ChatHeaderProps {
   onCloseThreadPane?: () => void;
 }
 
-export type ProviderHandoffMode = "continue" | "new-thread";
+export type { ProviderHandoffMode } from "./ChatHandoffMenu";
 
 const EDITOR_CHAT_HISTORY_LIMIT = 30;
 
@@ -622,14 +619,6 @@ export function ChatHeader({
       />
     );
   };
-  const renderHandoffTargetItems = (mode: ProviderHandoffMode) =>
-    handoffActionTargetProviders.map((provider) => (
-      <MenuItem key={provider} onClick={() => onCreateHandoff(provider, mode)}>
-        {/* opacity-100 opts brand icons out of the option row's 80% icon dim. */}
-        {renderProviderIcon(provider, "size-3.5 shrink-0 opacity-100")}
-        <span>{PROVIDER_DISPLAY_NAMES[provider]}</span>
-      </MenuItem>
-    ));
 
   // Single-chat surfaces use this as a true right-dock visibility toggle. Hosts
   // without a multi-pane dock (split/editor surfaces) keep the legacy diff-only
@@ -810,63 +799,15 @@ export function ChatHeader({
           <ProviderUsageMenuControl provider={activeProvider} />
         ) : null}
         {!minimalChrome && !hideHandoffControls ? (
-          <Menu modal={false}>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <MenuTrigger
-                    render={
-                      <ChatHeaderButton
-                        type="button"
-                        tone="outline"
-                        className={compact ? "gap-1" : "gap-1.5"}
-                        aria-label={handoffActionLabel}
-                        disabled={handoffDisabled || handoffActionTargetProviders.length === 0}
-                      />
-                    }
-                  >
-                    {handoffPending ? (
-                      <LoaderCircleIcon className="size-[1em] shrink-0 animate-spin opacity-80" />
-                    ) : (
-                      <HandoffIcon className="size-[1em] shrink-0 opacity-80" />
-                    )}
-                    {!compact ? (
-                      <span className="truncate font-normal">
-                        {handoffPending ? "Switching…" : "Hand off"}
-                      </span>
-                    ) : null}
-                  </MenuTrigger>
-                }
-              />
-              <TooltipPopup side="bottom">{handoffActionLabel}</TooltipPopup>
-            </Tooltip>
-            <ComposerPickerMenuPopup align="end" side="bottom" className="w-52 min-w-52">
-              {continuousHandoffEnabled ? (
-                <>
-                  <MenuSub>
-                    <MenuSubTrigger>
-                      <MessageCircleIcon className="size-3.5 shrink-0" />
-                      <span>Continue here</span>
-                    </MenuSubTrigger>
-                    <ComposerPickerMenuSubPopup className="w-48 min-w-48">
-                      {renderHandoffTargetItems("continue")}
-                    </ComposerPickerMenuSubPopup>
-                  </MenuSub>
-                  <MenuSub>
-                    <MenuSubTrigger>
-                      <HandoffIcon className="size-3.5 shrink-0" />
-                      <span>New conversation</span>
-                    </MenuSubTrigger>
-                    <ComposerPickerMenuSubPopup className="w-48 min-w-48">
-                      {renderHandoffTargetItems("new-thread")}
-                    </ComposerPickerMenuSubPopup>
-                  </MenuSub>
-                </>
-              ) : (
-                renderHandoffTargetItems("new-thread")
-              )}
-            </ComposerPickerMenuPopup>
-          </Menu>
+          <ChatHandoffMenu
+            compact={compact}
+            handoffActionLabel={handoffActionLabel}
+            handoffPending={handoffPending}
+            handoffDisabled={handoffDisabled}
+            handoffActionTargetProviders={handoffActionTargetProviders}
+            continuousHandoffEnabled={continuousHandoffEnabled}
+            onCreateHandoff={onCreateHandoff}
+          />
         ) : null}
         {!minimalChrome && activeProjectScripts ? (
           <ProjectScriptsControl

--- a/apps/web/src/components/chat/ProviderHandoffTrail.tsx
+++ b/apps/web/src/components/chat/ProviderHandoffTrail.tsx
@@ -1,0 +1,226 @@
+// FILE: ProviderHandoffTrail.tsx
+// Purpose: Shows the provider path for continuous, in-thread handoffs.
+// Layer: Chat shell header
+// Depends on: shared provider branding and tooltip primitives
+
+import { PROVIDER_DISPLAY_NAMES, type ProviderKind } from "@synara/contracts";
+import React from "react";
+
+import { ArrowRightIcon, Undo2Icon } from "~/lib/icons";
+import { cn } from "~/lib/utils";
+import { ProviderIcon } from "../ProviderIcon";
+import { Badge } from "../ui/badge";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+
+export interface ProviderHandoffTrailEntry {
+  readonly provider: ProviderKind;
+  readonly isReturn: boolean;
+}
+
+export interface ProviderHandoffTrailPresentation {
+  readonly first: ProviderHandoffTrailEntry | null;
+  readonly trailing: ReadonlyArray<ProviderHandoffTrailEntry>;
+  readonly hiddenCount: number;
+}
+
+const HEADER_TRAIL_LIMIT = 5;
+const HEADER_TRAILING_COUNT = 3;
+const TOOLTIP_TRAIL_LIMIT = 12;
+
+export function resolveProviderHandoffTrailPresentation(
+  trail: ReadonlyArray<ProviderHandoffTrailEntry>,
+): ProviderHandoffTrailPresentation {
+  if (trail.length <= HEADER_TRAIL_LIMIT) {
+    return { first: null, trailing: trail, hiddenCount: 0 };
+  }
+
+  const first = trail[0] ?? null;
+  const trailing = trail.slice(-HEADER_TRAILING_COUNT);
+  return {
+    first,
+    trailing,
+    hiddenCount: trail.length - trailing.length - (first ? 1 : 0),
+  };
+}
+
+export function describeProviderHandoffTrail(
+  trail: ReadonlyArray<ProviderHandoffTrailEntry>,
+): string {
+  if (trail.length === 0) return "";
+
+  return trail
+    .map((entry, index) => {
+      const providerName = PROVIDER_DISPLAY_NAMES[entry.provider];
+      if (index === 0) return `Started with ${providerName}`;
+      return `${entry.isReturn ? "returned to" : "continued with"} ${providerName}`;
+    })
+    .join(", ");
+}
+
+function TrailConnector({ isReturn }: { readonly isReturn: boolean }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "inline-flex size-3.5 shrink-0 items-center justify-center",
+        isReturn ? "text-[var(--color-text-accent)]" : "text-muted-foreground/55",
+      )}
+      title={isReturn ? "Returned to an earlier provider" : "Continued with another provider"}
+    >
+      {isReturn ? <Undo2Icon className="size-3" /> : <ArrowRightIcon className="size-3" />}
+    </span>
+  );
+}
+
+function ProviderStep({
+  entry,
+  current,
+  showCurrentLabel,
+}: {
+  readonly entry: ProviderHandoffTrailEntry;
+  readonly current: boolean;
+  readonly showCurrentLabel: boolean;
+}) {
+  const providerName = PROVIDER_DISPLAY_NAMES[entry.provider];
+
+  return (
+    <span
+      className={cn(
+        "inline-flex h-4 shrink-0 items-center justify-center gap-1 rounded-[4px]",
+        current ? "px-0.5" : "w-4",
+      )}
+      title={current ? `Current provider: ${providerName}` : providerName}
+    >
+      <ProviderIcon provider={entry.provider} tone="header" className="size-3 shrink-0" />
+      {current && showCurrentLabel ? (
+        <>
+          <span className="max-w-20 truncate font-medium text-foreground">{providerName}</span>
+          <span className="text-[9px] font-normal text-muted-foreground">Current</span>
+        </>
+      ) : null}
+    </span>
+  );
+}
+
+function HeaderTrail({
+  trail,
+  compact,
+}: {
+  readonly trail: ReadonlyArray<ProviderHandoffTrailEntry>;
+  readonly compact: boolean;
+}) {
+  const presentation = resolveProviderHandoffTrailPresentation(trail);
+  const currentEntry = trail.at(-1);
+  if (!currentEntry) return null;
+
+  return (
+    <>
+      {presentation.first ? (
+        <>
+          <ProviderStep entry={presentation.first} current={false} showCurrentLabel={false} />
+          <TrailConnector isReturn={false} />
+          <span
+            className="inline-flex h-4 min-w-5 shrink-0 items-center justify-center px-0.5 text-[9px] font-medium tabular-nums text-muted-foreground"
+            title={`${presentation.hiddenCount} hidden provider changes`}
+          >
+            +{presentation.hiddenCount}
+          </span>
+          <TrailConnector isReturn={false} />
+        </>
+      ) : null}
+      {presentation.trailing.map((entry, index) => {
+        const isCurrent = entry === currentEntry;
+        return (
+          <React.Fragment key={`${index}:${entry.provider}`}>
+            {index > 0 ? <TrailConnector isReturn={entry.isReturn} /> : null}
+            <ProviderStep entry={entry} current={isCurrent} showCurrentLabel={!compact} />
+          </React.Fragment>
+        );
+      })}
+    </>
+  );
+}
+
+function TooltipTrail({ trail }: { readonly trail: ReadonlyArray<ProviderHandoffTrailEntry> }) {
+  const visibleTrail = trail.slice(-TOOLTIP_TRAIL_LIMIT);
+  const hiddenCount = trail.length - visibleTrail.length;
+
+  return (
+    <div className="max-w-96 py-1">
+      <div className="font-medium text-foreground">Provider path</div>
+      <div className="mt-1.5 flex flex-wrap items-center gap-1" dir="ltr">
+        {hiddenCount > 0 ? (
+          <span className="text-muted-foreground">{hiddenCount} earlier ·</span>
+        ) : null}
+        {visibleTrail.map((entry, index) => (
+          <React.Fragment key={`${index}:${entry.provider}`}>
+            {index > 0 ? <TrailConnector isReturn={entry.isReturn} /> : null}
+            <span
+              className={cn(
+                "inline-flex items-center gap-1 rounded-[4px] px-1 py-0.5",
+                index === visibleTrail.length - 1
+                  ? "bg-[var(--color-bg-accent)] text-foreground"
+                  : "text-muted-foreground",
+              )}
+            >
+              <ProviderIcon provider={entry.provider} tone="header" className="size-3" />
+              {PROVIDER_DISPLAY_NAMES[entry.provider]}
+            </span>
+          </React.Fragment>
+        ))}
+      </div>
+      <div className="mt-1.5 text-muted-foreground">Context stayed in this conversation.</div>
+    </div>
+  );
+}
+
+export function ProviderHandoffTrail({
+  trail,
+  compact,
+  fallbackLabel,
+  fallbackSourceProvider,
+  fallbackTargetProvider,
+}: {
+  readonly trail: ReadonlyArray<ProviderHandoffTrailEntry>;
+  readonly compact: boolean;
+  readonly fallbackLabel: string | null;
+  readonly fallbackSourceProvider: ProviderKind | null;
+  readonly fallbackTargetProvider: ProviderKind | null;
+}) {
+  const continuousTrail = trail.length > 1 ? trail : null;
+  const fallbackTrail =
+    fallbackLabel && fallbackSourceProvider && fallbackTargetProvider
+      ? [
+          { provider: fallbackSourceProvider, isReturn: false },
+          { provider: fallbackTargetProvider, isReturn: false },
+        ]
+      : null;
+  const displayedTrail = continuousTrail ?? fallbackTrail;
+  if (!displayedTrail) return null;
+  const currentProvider = displayedTrail.at(-1)?.provider;
+  if (!currentProvider) return null;
+
+  const accessibleLabel = continuousTrail
+    ? `Provider path. ${describeProviderHandoffTrail(continuousTrail)}. Current provider: ${PROVIDER_DISPLAY_NAMES[currentProvider]}.`
+    : (fallbackLabel ?? "Provider handoff");
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Badge
+            aria-label={accessibleLabel}
+            variant="secondary"
+            className="hidden !h-6 shrink-0 items-center justify-center gap-1 rounded-md px-1.5 text-[10px] font-normal text-muted-foreground sm:inline-flex"
+            dir="ltr"
+          >
+            <HeaderTrail trail={displayedTrail} compact={compact} />
+          </Badge>
+        }
+      />
+      <TooltipPopup side="bottom" className="max-w-96" viewportClassName="px-2.5 py-1.5">
+        {continuousTrail ? <TooltipTrail trail={continuousTrail} /> : fallbackLabel}
+      </TooltipPopup>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/components/chat/ProviderHandoffTrail.tsx
+++ b/apps/web/src/components/chat/ProviderHandoffTrail.tsx
@@ -12,10 +12,8 @@ import { ProviderIcon } from "../ProviderIcon";
 import { Badge } from "../ui/badge";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
-export interface ProviderHandoffTrailEntry {
-  readonly provider: ProviderKind;
-  readonly isReturn: boolean;
-}
+import type { ProviderHandoffTrailEntry } from "~/lib/threadHandoff";
+export type { ProviderHandoffTrailEntry } from "~/lib/threadHandoff";
 
 export interface ProviderHandoffTrailPresentation {
   readonly first: ProviderHandoffTrailEntry | null;
@@ -25,7 +23,6 @@ export interface ProviderHandoffTrailPresentation {
 
 const HEADER_TRAIL_LIMIT = 5;
 const HEADER_TRAILING_COUNT = 3;
-const TOOLTIP_TRAIL_LIMIT = 12;
 
 export function resolveProviderHandoffTrailPresentation(
   trail: ReadonlyArray<ProviderHandoffTrailEntry>,
@@ -125,7 +122,7 @@ function HeaderTrail({
           >
             +{presentation.hiddenCount}
           </span>
-          <TrailConnector isReturn={false} />
+          <TrailConnector isReturn={presentation.trailing[0]?.isReturn ?? false} />
         </>
       ) : null}
       {presentation.trailing.map((entry, index) => {
@@ -142,23 +139,17 @@ function HeaderTrail({
 }
 
 function TooltipTrail({ trail }: { readonly trail: ReadonlyArray<ProviderHandoffTrailEntry> }) {
-  const visibleTrail = trail.slice(-TOOLTIP_TRAIL_LIMIT);
-  const hiddenCount = trail.length - visibleTrail.length;
-
   return (
-    <div className="max-w-96 py-1">
+    <div className="max-h-64 max-w-96 overflow-y-auto py-1">
       <div className="font-medium text-foreground">Provider path</div>
       <div className="mt-1.5 flex flex-wrap items-center gap-1" dir="ltr">
-        {hiddenCount > 0 ? (
-          <span className="text-muted-foreground">{hiddenCount} earlier ·</span>
-        ) : null}
-        {visibleTrail.map((entry, index) => (
+        {trail.map((entry, index) => (
           <React.Fragment key={`${index}:${entry.provider}`}>
             {index > 0 ? <TrailConnector isReturn={entry.isReturn} /> : null}
             <span
               className={cn(
                 "inline-flex items-center gap-1 rounded-[4px] px-1 py-0.5",
-                index === visibleTrail.length - 1
+                index === trail.length - 1
                   ? "bg-[var(--color-bg-accent)] text-foreground"
                   : "text-muted-foreground",
               )}
@@ -209,6 +200,7 @@ export function ProviderHandoffTrail({
       <TooltipTrigger
         render={
           <Badge
+            tabIndex={0}
             aria-label={accessibleLabel}
             variant="secondary"
             className="hidden !h-6 shrink-0 items-center justify-center gap-1 rounded-md px-1.5 text-[10px] font-normal text-muted-foreground sm:inline-flex"

--- a/apps/web/src/hooks/useThreadHandoff.ts
+++ b/apps/web/src/hooks/useThreadHandoff.ts
@@ -3,10 +3,11 @@
 // Layer: Web hook
 // Exports: useThreadHandoff
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { type ProviderKind } from "@synara/contracts";
 import { useComposerDraftStore } from "../composerDraftStore";
+import { useAppSettings } from "../appSettings";
 import { useProviderStatusesForLocalConfig } from "./useProviderStatusesForLocalConfig";
 import { useRefreshProviderStatusesNow } from "./useProviderStatusRefresh";
 import {
@@ -18,7 +19,9 @@ import {
   resolveThreadHandoffTitle,
 } from "../lib/threadHandoff";
 import { resolveProviderSendAvailabilityWithRefresh } from "../lib/providerAvailability";
-import { serverSettingsQueryOptions } from "../lib/serverReactQuery";
+import { resolveProviderDiscoveryCwd } from "../lib/providerDiscovery";
+import { providerModelsPrefetchQueryOptions } from "../lib/providerModelPrefetch";
+import { serverConfigQueryOptions, serverSettingsQueryOptions } from "../lib/serverReactQuery";
 import { newCommandId, newThreadId } from "../lib/utils";
 import { readNativeApi } from "../nativeApi";
 import { useStore } from "../store";
@@ -26,11 +29,53 @@ import { type Thread } from "../types";
 
 export function useThreadHandoff() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { settings } = useAppSettings();
   const projects = useStore((store) => store.projects);
   const syncServerShellSnapshot = useStore((store) => store.syncServerShellSnapshot);
   const providerStatuses = useProviderStatusesForLocalConfig();
   const refreshProviderStatuses = useRefreshProviderStatusesNow();
   const serverSettingsQuery = useQuery(serverSettingsQueryOptions());
+  const serverConfigQuery = useQuery(serverConfigQueryOptions());
+
+  const resolveTargetModelSelection = async (
+    thread: Thread,
+    targetProvider: ProviderKind,
+    projectDefaultModelSelection: Thread["modelSelection"] | null | undefined,
+    stickyModelSelectionByProvider: Partial<Record<ProviderKind, Thread["modelSelection"]>>,
+  ): Promise<Thread["modelSelection"]> => {
+    const hasKnownPiSelection =
+      targetProvider !== "pi" ||
+      stickyModelSelectionByProvider.pi?.provider === "pi" ||
+      projectDefaultModelSelection?.provider === "pi";
+    let discoveredFallbackModel: string | null = null;
+
+    if (!hasKnownPiSelection) {
+      const project = projects.find((entry) => entry.id === thread.projectId);
+      const cwd = resolveProviderDiscoveryCwd({
+        activeThreadWorktreePath: thread.worktreePath ?? null,
+        activeProjectCwd: project?.cwd ?? null,
+        serverCwd: serverConfigQuery.data?.cwd ?? null,
+      });
+      const discovered = await queryClient.fetchQuery(
+        providerModelsPrefetchQueryOptions({
+          provider: "pi",
+          settings,
+          cwd,
+          priority: "prefetch",
+        }),
+      );
+      discoveredFallbackModel = discovered.models[0]?.slug ?? null;
+    }
+
+    return resolveThreadHandoffModelSelection({
+      sourceThread: thread,
+      targetProvider,
+      projectDefaultModelSelection,
+      stickyModelSelectionByProvider,
+      discoveredFallbackModel,
+    });
+  };
 
   const createThreadHandoff = async (
     thread: Thread,
@@ -83,12 +128,12 @@ export function useThreadHandoff() {
       sourceThreadId: thread.id,
       projectId: thread.projectId,
       title: resolveThreadHandoffTitle(thread),
-      modelSelection: resolveThreadHandoffModelSelection({
-        sourceThread: thread,
+      modelSelection: await resolveTargetModelSelection(
+        thread,
         targetProvider,
-        projectDefaultModelSelection: project.defaultModelSelection,
+        project.defaultModelSelection,
         stickyModelSelectionByProvider,
-      }),
+      ),
       runtimeMode: thread.runtimeMode,
       interactionMode: thread.interactionMode,
       envMode: thread.envMode ?? (thread.worktreePath ? "worktree" : "local"),
@@ -126,7 +171,63 @@ export function useThreadHandoff() {
     return nextThreadId;
   };
 
+  const continueThreadWithProvider = async (
+    thread: Thread,
+    targetProvider: ProviderKind,
+  ): Promise<Thread["id"]> => {
+    const api = readNativeApi();
+    if (!api) {
+      throw new Error("Native API not found");
+    }
+
+    const project = projects.find((entry) => entry.id === thread.projectId);
+    if (!project) {
+      throw new Error("Project not found for provider handoff.");
+    }
+    if (!canCreateThreadHandoff({ thread })) {
+      throw new Error("This thread cannot switch providers yet.");
+    }
+
+    const targetAvailability = await resolveProviderSendAvailabilityWithRefresh({
+      provider: targetProvider,
+      statuses: providerStatuses,
+      refreshStatuses: () => refreshProviderStatuses({ silent: true }),
+    });
+    if (
+      !isEligibleHandoffTargetProvider({
+        sourceProvider: thread.modelSelection.provider,
+        targetProvider,
+        targetProviderEnabled: serverSettingsQuery.data?.providers[targetProvider].enabled,
+        targetProviderStatus: targetAvailability.status,
+      })
+    ) {
+      throw new Error(
+        targetAvailability.usable
+          ? "This provider is not available for the current thread."
+          : targetAvailability.unavailableReason,
+      );
+    }
+
+    const { stickyModelSelectionByProvider } = useComposerDraftStore.getState();
+    await api.orchestration.dispatchCommand({
+      type: "thread.provider.handoff",
+      commandId: newCommandId(),
+      threadId: thread.id,
+      expectedSourceProvider: thread.modelSelection.provider,
+      targetModelSelection: await resolveTargetModelSelection(
+        thread,
+        targetProvider,
+        project.defaultModelSelection,
+        stickyModelSelectionByProvider,
+      ),
+      createdAt: new Date().toISOString(),
+    });
+
+    return thread.id;
+  };
+
   return {
     createThreadHandoff,
+    continueThreadWithProvider,
   };
 }

--- a/apps/web/src/lib/threadHandoff.test.ts
+++ b/apps/web/src/lib/threadHandoff.test.ts
@@ -8,10 +8,13 @@ import {
   type ServerProviderStatus,
 } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
+import { DEFAULT_PROVIDER_ORDER } from "../providerOrdering";
 import {
   buildThreadHandoffImportedActivities,
   buildThreadHandoffImportedMessages,
   resolveAvailableHandoffTargetProviders,
+  resolvePendingProviderHandoff,
+  resolveProviderHandoffTrail,
   resolveThreadHandoffTitle,
   resolveThreadHandoffModelSelection,
 } from "./threadHandoff";
@@ -185,6 +188,29 @@ describe("threadHandoff", () => {
     ).toEqual([]);
   });
 
+  it("supports every configured Synara provider as a continuous handoff target", () => {
+    const providers = DEFAULT_PROVIDER_ORDER;
+    const providerStatuses = providers.map(
+      (provider): ServerProviderStatus => ({
+        provider,
+        status: "ready",
+        available: true,
+        authStatus: provider === "opencode" ? "unknown" : "authenticated",
+        checkedAt: "2026-09-10T10:00:00.000Z",
+      }),
+    );
+
+    for (const sourceProvider of providers) {
+      expect(
+        resolveAvailableHandoffTargetProviders({
+          sourceProvider,
+          providerSettings: DEFAULT_SERVER_SETTINGS_VIEW.providers,
+          providerStatuses,
+        }),
+      ).toEqual(providers.filter((provider) => provider !== sourceProvider));
+    }
+  });
+
   it("preserves the source thread title for the created handoff thread", () => {
     expect(resolveThreadHandoffTitle({ title: "General Greeting" })).toBe("General Greeting");
     expect(resolveThreadHandoffTitle({ title: "  Debug   Grok handoff  " })).toBe(
@@ -235,5 +261,90 @@ describe("threadHandoff", () => {
       provider: "codex",
       model: "gpt-5.5",
     });
+  });
+
+  it("uses the discovered Pi model when Pi has no static default", () => {
+    expect(
+      resolveThreadHandoffModelSelection({
+        sourceThread: {
+          modelSelection: { provider: "codex", model: "gpt-5.5" },
+        },
+        targetProvider: "pi",
+        projectDefaultModelSelection: null,
+        stickyModelSelectionByProvider: {},
+        discoveredFallbackModel: "openai/gpt-5.5",
+      }),
+    ).toEqual({ provider: "pi", model: "openai/gpt-5.5" });
+  });
+
+  it("keeps the handoff pending until a matching terminal activity arrives", () => {
+    const pending = {
+      kind: "provider.handoff.requested",
+      payload: {
+        handoffCommandId: "handoff-1",
+        sourceModelSelection: { provider: "claudeAgent", model: "claude-sonnet" },
+        targetModelSelection: { provider: "grok", model: "grok-code" },
+      },
+    };
+    expect(resolvePendingProviderHandoff([pending])).toMatchObject({
+      handoffCommandId: "handoff-1",
+      targetModelSelection: { provider: "grok" },
+    });
+    expect(
+      resolvePendingProviderHandoff([
+        pending,
+        {
+          kind: "provider.handoff.completed",
+          payload: {
+            handoffCommandId: "handoff-1",
+            sourceModelSelection: { provider: "claudeAgent", model: "claude-sonnet" },
+            targetModelSelection: { provider: "grok", model: "grok-code" },
+          },
+        },
+      ]),
+    ).toBeNull();
+    expect(
+      resolvePendingProviderHandoff([
+        pending,
+        {
+          kind: "provider.handoff.failed",
+          payload: {
+            handoffCommandId: "handoff-1",
+            sourceModelSelection: { provider: "claudeAgent", model: "claude-sonnet" },
+            targetModelSelection: { provider: "grok", model: "grok-code" },
+          },
+        },
+      ]),
+    ).toBeNull();
+  });
+
+  it("builds an ordered provider trail and marks returns", () => {
+    const activity = (
+      id: string,
+      sourceProvider: ProviderKind,
+      targetProvider: ProviderKind,
+    ): Pick<OrchestrationThreadActivity, "kind" | "payload"> => ({
+      kind: "provider.handoff.completed",
+      payload: {
+        sourceModelSelection: { provider: sourceProvider, model: `${sourceProvider}-model` },
+        targetModelSelection: { provider: targetProvider, model: `${targetProvider}-model` },
+        id,
+      },
+    });
+
+    expect(
+      resolveProviderHandoffTrail([
+        activity("one", "claudeAgent", "antigravity"),
+        activity("two", "antigravity", "codex"),
+        activity("three", "codex", "grok"),
+        activity("four", "grok", "claudeAgent"),
+      ]),
+    ).toEqual([
+      { provider: "claudeAgent", isReturn: false },
+      { provider: "antigravity", isReturn: false },
+      { provider: "codex", isReturn: false },
+      { provider: "grok", isReturn: false },
+      { provider: "claudeAgent", isReturn: true },
+    ]);
   });
 });

--- a/apps/web/src/lib/threadHandoff.ts
+++ b/apps/web/src/lib/threadHandoff.ts
@@ -15,8 +15,10 @@ import {
   type ThreadHandoffImportedMessage,
 } from "@synara/contracts";
 import { getDefaultModel } from "@synara/shared/model";
+import { resolvePendingProviderHandoff } from "@synara/shared/providerHandoff";
+export { resolvePendingProviderHandoff } from "@synara/shared/providerHandoff";
 import { type Thread } from "../types";
-import { DEFAULT_PROVIDER_ORDER } from "../providerOrdering";
+import { DEFAULT_PROVIDER_ORDER, isProviderKind } from "../providerOrdering";
 import { stripEmbeddedAssistantSelections } from "./assistantSelections";
 import { extractTrailingBrowserAnnotations } from "./browserAnnotations";
 import { isCompletedContextCompaction } from "./contextWindow";
@@ -29,6 +31,48 @@ const IMPORTABLE_THREAD_ACTIVITY_KINDS = new Set([
   "context-compaction",
   "context-window.updated",
 ]);
+
+export interface ProviderHandoffTrailEntry {
+  readonly provider: ProviderKind;
+  readonly isReturn: boolean;
+}
+
+function providerFromModelSelectionPayload(value: unknown): ProviderKind | null {
+  if (typeof value !== "object" || value === null || !("provider" in value)) {
+    return null;
+  }
+  const provider = (value as { readonly provider?: unknown }).provider;
+  return typeof provider === "string" && isProviderKind(provider) ? provider : null;
+}
+
+export function resolveProviderHandoffTrail(
+  activities: ReadonlyArray<Pick<OrchestrationThreadActivity, "kind" | "payload">>,
+): ReadonlyArray<ProviderHandoffTrailEntry> {
+  const trail: ProviderHandoffTrailEntry[] = [];
+  const seen = new Set<ProviderKind>();
+
+  for (const activity of activities) {
+    if (activity.kind !== "provider.handoff.completed") continue;
+    if (typeof activity.payload !== "object" || activity.payload === null) continue;
+
+    const payload = activity.payload as {
+      readonly sourceModelSelection?: unknown;
+      readonly targetModelSelection?: unknown;
+    };
+    const source = providerFromModelSelectionPayload(payload.sourceModelSelection);
+    const target = providerFromModelSelectionPayload(payload.targetModelSelection);
+    if (!source || !target || source === target) continue;
+
+    if (trail.length === 0 || trail.at(-1)?.provider !== source) {
+      trail.push({ provider: source, isReturn: seen.has(source) });
+      seen.add(source);
+    }
+    trail.push({ provider: target, isReturn: seen.has(target) });
+    seen.add(target);
+  }
+
+  return trail;
+}
 
 function isImportableThreadMessage(
   message: Thread["messages"][number],
@@ -181,12 +225,15 @@ export function hasNativeThreadHandoffMessages(thread: Pick<Thread, "messages">)
 }
 
 export function canCreateThreadHandoff(input: {
-  readonly thread: Pick<Thread, "handoff" | "messages" | "session">;
+  readonly thread: Pick<Thread, "activities" | "handoff" | "messages" | "session">;
   readonly isBusy?: boolean;
   readonly hasPendingApprovals?: boolean;
   readonly hasPendingUserInput?: boolean;
 }): boolean {
   if (input.isBusy || input.hasPendingApprovals || input.hasPendingUserInput) {
+    return false;
+  }
+  if (resolvePendingProviderHandoff(input.thread.activities) !== null) {
     return false;
   }
   const sessionStatus = input.thread.session?.orchestrationStatus;
@@ -208,6 +255,7 @@ export function resolveThreadHandoffModelSelection(input: {
   readonly targetProvider: ProviderKind;
   readonly projectDefaultModelSelection: ModelSelection | null | undefined;
   readonly stickyModelSelectionByProvider: Partial<Record<ProviderKind, ModelSelection>>;
+  readonly discoveredFallbackModel?: string | null;
 }): ModelSelection {
   const isCompatibleSelection = (
     selection: ModelSelection | null | undefined,
@@ -222,9 +270,9 @@ export function resolveThreadHandoffModelSelection(input: {
   if (isCompatibleSelection(input.projectDefaultModelSelection)) {
     return input.projectDefaultModelSelection;
   }
-  const defaultModel = getDefaultModel(input.targetProvider);
+  const defaultModel = getDefaultModel(input.targetProvider) ?? input.discoveredFallbackModel;
   if (!defaultModel) {
-    throw new Error("Select a Pi model before handing off to Pi.");
+    throw new Error("No Pi model is available. Configure Pi and retry the handoff.");
   }
   return {
     provider: input.targetProvider,

--- a/apps/web/src/providerUpdates.test.ts
+++ b/apps/web/src/providerUpdates.test.ts
@@ -55,6 +55,7 @@ function serverSettings(overrides: Partial<ServerSettings["providers"]> = {}): S
 
   return {
     enableAssistantStreaming: false,
+    enableContinuousProviderHandoff: false,
     enableProviderUpdateChecks: true,
     defaultThreadEnvMode: "local",
     addProjectBaseDirectory: "",

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -1169,6 +1169,15 @@ function SettingsRouteView() {
         })}
 
         {renderBooleanSettingRow({
+          settingKey: "enableContinuousProviderHandoff",
+          title: "Continue handoffs in this chat",
+          description:
+            "Switch providers without opening another conversation. The next provider receives a bounded recap of this chat and keeps the same workspace.",
+          resetLabel: "continuous provider handoff",
+          ariaLabel: "Continue provider handoffs in the current chat",
+        })}
+
+        {renderBooleanSettingRow({
           settingKey: "autoOpenDevicePane",
           title: "Automatically open simulator",
           description:

--- a/apps/web/src/storeNormalization.test.ts
+++ b/apps/web/src/storeNormalization.test.ts
@@ -5,6 +5,7 @@ import { MessageId, TurnId } from "@synara/contracts";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  capThreadActivities,
   createThreadActivityAccumulator,
   dedupeActivitiesById,
   dedupeActivitiesByIdAfterAppend,
@@ -394,5 +395,21 @@ describe("accounting activity retention", () => {
       makeActivity({ id: "new-tool", turnId: TurnId.makeUnsafe("new-turn"), sequence: 6001 }),
     );
     expect(accumulator.result()).toHaveLength(1999);
+  });
+});
+
+describe("provider transition retention", () => {
+  it("keeps the provider path and pending transition outside the work-log cap", () => {
+    const transitions = [
+      "provider.handoff.requested",
+      "provider.handoff.completed",
+      "provider.handoff.failed",
+    ].map((kind, index) => makeActivity({ id: `handoff-${index}`, kind }));
+    const noise = Array.from({ length: 2_010 }, (_, index) =>
+      makeActivity({ id: `noise-${index}` }),
+    );
+    const capped = capThreadActivities([...transitions, ...noise]);
+    expect(capped.slice(0, 3)).toEqual(transitions);
+    expect(capped).toHaveLength(2_003);
   });
 });

--- a/apps/web/src/storeNormalization.ts
+++ b/apps/web/src/storeNormalization.ts
@@ -1,3 +1,4 @@
+import { isProviderHandoffActivity } from "@synara/shared/providerHandoff";
 // FILE: storeNormalization.ts
 // Purpose: Normalizes orchestration projects, threads, messages, and activities with stable identity.
 // Exports: Pure normalization and equality helpers consumed by projection and event reduction.
@@ -1325,7 +1326,9 @@ export function capThreadActivities<TActivity extends Thread["activities"][numbe
       retainedIds.add(activity.id);
     }
   }
-  return activities.filter((activity) => retainedIds.has(activity.id));
+  return activities.filter(
+    (activity) => retainedIds.has(activity.id) || isProviderHandoffActivity(activity),
+  );
 }
 
 function activityRequestId(activity: Thread["activities"][number]): string | null {

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -299,6 +299,7 @@ describe("wsNativeApi", () => {
     const payload = {
       settings: {
         enableAssistantStreaming: true,
+        enableContinuousProviderHandoff: false,
         enableProviderUpdateChecks: true,
         defaultThreadEnvMode: "local",
         addProjectBaseDirectory: "",

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -70,6 +70,57 @@ const decodeOrchestrationCommand = Schema.decodeUnknownEffect(OrchestrationComma
 const decodeOrchestrationEvent = Schema.decodeUnknownEffect(OrchestrationEvent);
 const decodeThreadPullRequest = Schema.decodeUnknownEffect(OrchestrationThreadPullRequest);
 
+it.effect("decodes continuous provider handoff commands and events", () =>
+  Effect.gen(function* () {
+    const command = yield* decodeClientOrchestrationCommand({
+      type: "thread.provider.handoff",
+      commandId: "cmd-provider-handoff",
+      threadId: "thread-1",
+      expectedSourceProvider: "claudeAgent",
+      targetModelSelection: { provider: "grok", model: "grok-code" },
+      createdAt: "2026-09-10T10:00:00.000Z",
+    });
+    assert.equal(command.type, "thread.provider.handoff");
+
+    const completionInput = {
+      type: "thread.provider.handoff.complete",
+      commandId: "server:complete-provider-handoff",
+      threadId: "thread-1",
+      handoffCommandId: "cmd-provider-handoff",
+      handoffEventId: "event-provider-handoff",
+      sourceModelSelection: { provider: "claudeAgent", model: "claude-sonnet" },
+      targetModelSelection: { provider: "grok", model: "grok-code" },
+      createdAt: "2026-09-10T10:00:00.000Z",
+    };
+    const completion = yield* decodeOrchestrationCommand(completionInput);
+    assert.equal(completion.type, "thread.provider.handoff.complete");
+    assert.equal(
+      (yield* Effect.exit(decodeClientOrchestrationCommand(completionInput)))._tag,
+      "Failure",
+    );
+
+    const event = yield* decodeOrchestrationEvent({
+      sequence: 1,
+      eventId: "event-provider-handoff",
+      aggregateKind: "thread",
+      aggregateId: "thread-1",
+      type: "thread.provider-handoff-requested",
+      occurredAt: "2026-09-10T10:00:00.000Z",
+      commandId: "cmd-provider-handoff",
+      causationEventId: null,
+      correlationId: "cmd-provider-handoff",
+      metadata: {},
+      payload: {
+        threadId: "thread-1",
+        sourceModelSelection: { provider: "claudeAgent", model: "claude-sonnet" },
+        targetModelSelection: { provider: "grok", model: "grok-code" },
+        createdAt: "2026-09-10T10:00:00.000Z",
+      },
+    });
+    assert.equal(event.type, "thread.provider-handoff-requested");
+  }),
+);
+
 it.effect("decodes last-known PRs persisted before draft/mergeability/diff fields existed", () =>
   Effect.gen(function* () {
     const legacy = yield* decodeThreadPullRequest({

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1174,6 +1174,26 @@ const ThreadHandoffCreateCommand = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
+const ThreadProviderHandoffCommand = Schema.Struct({
+  type: Schema.Literal("thread.provider.handoff"),
+  commandId: CommandId,
+  threadId: ThreadId,
+  expectedSourceProvider: ProviderKind,
+  targetModelSelection: ModelSelection,
+  createdAt: IsoDateTime,
+});
+
+const ThreadProviderHandoffCompleteCommand = Schema.Struct({
+  type: Schema.Literal("thread.provider.handoff.complete"),
+  commandId: CommandId,
+  threadId: ThreadId,
+  handoffCommandId: CommandId,
+  handoffEventId: EventId,
+  sourceModelSelection: ModelSelection,
+  targetModelSelection: ModelSelection,
+  createdAt: IsoDateTime,
+});
+
 const ThreadForkCreateCommand = Schema.Struct({
   type: Schema.Literal("thread.fork.create"),
   commandId: CommandId,
@@ -1490,6 +1510,7 @@ const DispatchableClientOrchestrationCommand = Schema.Union([
   ProjectDeleteCommand,
   ThreadCreateCommand,
   ThreadHandoffCreateCommand,
+  ThreadProviderHandoffCommand,
   ThreadForkCreateCommand,
   ThreadDeleteCommand,
   ThreadArchiveCommand,
@@ -1526,6 +1547,7 @@ export const ClientOrchestrationCommand = Schema.Union([
   ProjectDeleteCommand,
   ThreadCreateCommand,
   ThreadHandoffCreateCommand,
+  ThreadProviderHandoffCommand,
   ThreadForkCreateCommand,
   ThreadDeleteCommand,
   ThreadArchiveCommand,
@@ -1680,6 +1702,7 @@ const ThreadSidechatExpireCommand = Schema.Struct({
 
 const InternalOrchestrationCommand = Schema.Union([
   ThreadSessionSetCommand,
+  ThreadProviderHandoffCompleteCommand,
   ThreadGoalContinueCommand,
   ThreadMessagesImportCommand,
   ThreadMessageAssistantDeltaCommand,
@@ -1738,6 +1761,7 @@ export const OrchestrationEventType = Schema.Literals([
   "thread.conversation-rollback-requested",
   "thread.conversation-rolled-back",
   "thread.message-edit-resend-requested",
+  "thread.provider-handoff-requested",
   "thread.session-stop-requested",
   "thread.session-set",
   "thread.proposed-plan-upserted",
@@ -2102,6 +2126,13 @@ export const ThreadSessionStopRequestedPayload = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
+export const ThreadProviderHandoffRequestedPayload = Schema.Struct({
+  threadId: ThreadId,
+  sourceModelSelection: ModelSelection,
+  targetModelSelection: ModelSelection,
+  createdAt: IsoDateTime,
+});
+
 export const ThreadSessionSetPayload = Schema.Struct({
   threadId: ThreadId,
   session: OrchestrationSession,
@@ -2310,6 +2341,11 @@ export const OrchestrationEvent = Schema.Union([
     ...EventBaseFields,
     type: Schema.Literal("thread.message-edit-resend-requested"),
     payload: ThreadMessageEditResendRequestedPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
+    type: Schema.Literal("thread.provider-handoff-requested"),
+    payload: ThreadProviderHandoffRequestedPayload,
   }),
   Schema.Struct({
     ...EventBaseFields,

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -90,6 +90,7 @@ export type SkillsServerSettings = typeof SkillsServerSettings.Type;
 
 export const ServerSettings = Schema.Struct({
   enableAssistantStreaming: Schema.Boolean.pipe(Schema.withDecodingDefault(() => true)),
+  enableContinuousProviderHandoff: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
   enableProviderUpdateChecks: Schema.Boolean.pipe(Schema.withDecodingDefault(() => true)),
   defaultThreadEnvMode: ThreadEnvironmentMode.pipe(Schema.withDecodingDefault(() => "local")),
   addProjectBaseDirectory: StringSetting.pipe(Schema.withDecodingDefault(() => "")),
@@ -142,6 +143,7 @@ const ProviderSettingsBasePatch = {
 
 export const ServerSettingsPatch = Schema.Struct({
   enableAssistantStreaming: Schema.optionalKey(Schema.Boolean),
+  enableContinuousProviderHandoff: Schema.optionalKey(Schema.Boolean),
   enableProviderUpdateChecks: Schema.optionalKey(Schema.Boolean),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvironmentMode),
   addProjectBaseDirectory: Schema.optionalKey(StringSetting),

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -296,6 +296,10 @@
       "types": "./src/providerDeliveryBlock.ts",
       "import": "./src/providerDeliveryBlock.ts"
     },
+    "./providerHandoff": {
+      "types": "./src/providerHandoff.ts",
+      "import": "./src/providerHandoff.ts"
+    },
     "./browserAnnotations": {
       "types": "./src/browserAnnotations.ts",
       "import": "./src/browserAnnotations.ts"

--- a/packages/shared/src/providerHandoff.ts
+++ b/packages/shared/src/providerHandoff.ts
@@ -1,0 +1,90 @@
+import {
+  ProviderKind,
+  type ModelSelection,
+  type OrchestrationThreadActivity,
+} from "@synara/contracts";
+import { Schema } from "effect";
+
+export const PROVIDER_HANDOFF_REQUESTED_ACTIVITY_KIND = "provider.handoff.requested";
+export const PROVIDER_HANDOFF_COMPLETED_ACTIVITY_KIND = "provider.handoff.completed";
+export const PROVIDER_HANDOFF_FAILED_ACTIVITY_KIND = "provider.handoff.failed";
+
+export interface PendingProviderHandoff {
+  readonly handoffCommandId: string;
+  readonly sourceModelSelection: ModelSelection;
+  readonly targetModelSelection: ModelSelection;
+}
+
+export function toProviderHandoffActivityModelSelection(
+  modelSelection: ModelSelection,
+): OrchestrationThreadActivity["payload"] {
+  return JSON.parse(JSON.stringify(modelSelection)) as OrchestrationThreadActivity["payload"];
+}
+
+function readModelSelection(value: unknown): ModelSelection | null {
+  if (typeof value !== "object" || value === null) return null;
+  const candidate = value as { readonly provider?: unknown; readonly model?: unknown };
+  return Schema.is(ProviderKind)(candidate.provider) && typeof candidate.model === "string"
+    ? (value as ModelSelection)
+    : null;
+}
+
+function readHandoffPayload(activity: Pick<OrchestrationThreadActivity, "payload">): {
+  readonly handoffCommandId: string;
+  readonly sourceModelSelection: ModelSelection | null;
+  readonly targetModelSelection: ModelSelection | null;
+} | null {
+  if (typeof activity.payload !== "object" || activity.payload === null) return null;
+  const payload = activity.payload as {
+    readonly handoffCommandId?: unknown;
+    readonly sourceModelSelection?: unknown;
+    readonly targetModelSelection?: unknown;
+  };
+  if (typeof payload.handoffCommandId !== "string") return null;
+  return {
+    handoffCommandId: payload.handoffCommandId,
+    sourceModelSelection: readModelSelection(payload.sourceModelSelection),
+    targetModelSelection: readModelSelection(payload.targetModelSelection),
+  };
+}
+
+/**
+ * Resolves the latest durable provider-switch request that has no matching
+ * completion or failure activity yet. Commands are serialized per thread, so
+ * at most one unresolved request can be admitted at a time.
+ */
+export function resolvePendingProviderHandoff(
+  activities: ReadonlyArray<Pick<OrchestrationThreadActivity, "kind" | "payload">>,
+): PendingProviderHandoff | null {
+  let pending: PendingProviderHandoff | null = null;
+
+  for (const activity of activities) {
+    if (
+      activity.kind !== PROVIDER_HANDOFF_REQUESTED_ACTIVITY_KIND &&
+      activity.kind !== PROVIDER_HANDOFF_COMPLETED_ACTIVITY_KIND &&
+      activity.kind !== PROVIDER_HANDOFF_FAILED_ACTIVITY_KIND
+    ) {
+      continue;
+    }
+
+    const payload = readHandoffPayload(activity);
+    if (!payload) continue;
+
+    if (activity.kind === PROVIDER_HANDOFF_REQUESTED_ACTIVITY_KIND) {
+      if (payload.sourceModelSelection && payload.targetModelSelection) {
+        pending = {
+          handoffCommandId: payload.handoffCommandId,
+          sourceModelSelection: payload.sourceModelSelection,
+          targetModelSelection: payload.targetModelSelection,
+        };
+      }
+      continue;
+    }
+
+    if (pending?.handoffCommandId === payload.handoffCommandId) {
+      pending = null;
+    }
+  }
+
+  return pending;
+}

--- a/packages/shared/src/providerHandoff.ts
+++ b/packages/shared/src/providerHandoff.ts
@@ -88,3 +88,23 @@ export function resolvePendingProviderHandoff(
 
   return pending;
 }
+
+/** Provider transitions are durable conversation metadata, outside the work-log cap. */
+export function isProviderHandoffActivity(activity: { readonly kind: string }): boolean {
+  return (
+    activity.kind === PROVIDER_HANDOFF_REQUESTED_ACTIVITY_KIND ||
+    activity.kind === PROVIDER_HANDOFF_COMPLETED_ACTIVITY_KIND ||
+    activity.kind === PROVIDER_HANDOFF_FAILED_ACTIVITY_KIND
+  );
+}
+
+export function retainProviderHandoffHistory<T extends { readonly kind: string }>(
+  activities: readonly T[],
+  maxActivities: number,
+): readonly T[] {
+  if (activities.length <= maxActivities) return activities;
+  const tailStart = activities.length - maxActivities;
+  return activities.filter(
+    (activity, index) => index >= tailStart || isProviderHandoffActivity(activity),
+  );
+}


### PR DESCRIPTION
Adds an opt-in **Continue here** outcome to Hand off, so a provider change keeps the same Synara conversation, URL, workspace, and visible history. **New conversation** retains the existing linked-thread flow, and the setting defaults to off.

The issue is valid: current main only supports creating a separate handoff thread. This adapts iiiMohammed's [prototype](https://github.com/iiiMohammed/synara/commit/4057b1b0aa8bbe9ce7eb369a602437ac18383df5), preserving the original commit attribution and integrating it with the extracted ChatView composer.

- Start the target through the existing provider lifecycle, with a bounded transcript recap on its next turn. Persist requested/completed/failed transitions and reject conflicting turns or switches.
- Preserve transition metadata outside work-log caps and restore pending transitions into command state on restart. A restart regression exercises more than 2,000 intervening activity rows.
- Persist recap completion for every provider, preserve it until successful consumption, and start a fresh target session when handing off a stopped fork.
- Show a compact provider path with return arrows and a keyboard-accessible full-history popup. Extract the handoff menu for browser coverage of both outcomes and the default-off path.

Validation: `bun fmt`, `bun lint` (warnings, no errors), and workspace typecheck with focused server/web rechecks after fixes. Focused contract, reactor, provider-service, projection/restart, settings, web-store and handoff suites pass; all six Chromium menu/path regressions pass. Provider coverage uses service doubles; no new live authenticated-provider smoke test was performed in this worktree.

Closes #1136.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes orchestration commands, provider session replacement, and turn gating in security-sensitive conversation state; incorrect settlement could route messages to the wrong provider or leave threads stuck.
> 
> **Overview**
> Adds **opt-in continuous provider handoffs** so users can switch providers in the **same conversation** (default remains separate handoff threads). A new server setting and **Settings → Chat behavior → Continue handoffs in this chat** gate the feature.
> 
> **Orchestration** introduces `thread.provider.handoff` / completion events, durable `provider.handoff.*` activities, and invariants that block turns, queued dispatch, checkpoint revert, and duplicate switches while a handoff is pending. The **provider command reactor** performs the runtime switch (authorized provider change, prior-transcript bootstrap, bounded recap), records failures, and handles quarantine/uncertain settlement.
> 
> **Projections** retain handoff lifecycle rows outside activity caps and hydrate them into command read models after restart. **Web** adds a handoff menu (**Continue here** vs **New conversation**), locks the composer during pending switches, shows a compact **provider path** in the header, and resolves Pi targets via runtime model discovery when needed.
> 
> Docs in `handoffs.mdx` describe the continuous flow and pending-switch behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb608cba5c80dd915a74407babc69589c4466595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->