### PR TITLE
Fix live turn ownership during runtime reconciliation

### DIFF
--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -47,6 +47,9 @@ import { makeProviderServiceLive } from "../src/provider/Layers/ProviderService.
 import { makeCodexAdapterLive } from "../src/provider/Layers/CodexAdapter.ts";
 import { CodexAdapter } from "../src/provider/Services/CodexAdapter.ts";
 import { ProviderService } from "../src/provider/Services/ProviderService.ts";
+import { ProviderRuntimeReconciler } from "../src/provider/Services/ProviderRuntimeReconciler.ts";
+import { makeProviderRuntimeReconcilerLive } from "../src/provider/Layers/ProviderRuntimeReconciler.ts";
+import { ProviderRuntimeEventRepositoryLive } from "../src/persistence/Layers/ProviderRuntimeEvents.ts";
 import { ServerSettingsService } from "../src/serverSettings.ts";
 import { CheckpointReactorLive } from "../src/orchestration/Layers/CheckpointReactor.ts";
 import { StudioOutputReactorLive } from "../src/orchestration/Layers/StudioOutputReactor.ts";
@@ -176,6 +179,7 @@ export interface OrchestrationIntegrationHarness {
   readonly engine: OrchestrationEngineShape;
   readonly snapshotQuery: ProjectionSnapshotQuery["Service"];
   readonly providerService: ProviderService["Service"];
+  readonly runtimeReconciler: ProviderRuntimeReconciler["Service"];
   readonly checkpointStore: CheckpointStore["Service"];
   readonly checkpointRepository: ProjectionCheckpointRepository["Service"];
   readonly waitForThread: (
@@ -222,6 +226,8 @@ export interface OrchestrationIntegrationHarness {
 interface MakeOrchestrationIntegrationHarnessOptions {
   readonly provider?: ProviderKind;
   readonly realCodex?: boolean;
+  readonly serverSettings?: Parameters<typeof ServerSettingsService.layerTest>[0];
+  readonly runtimeReconcilerOptions?: Parameters<typeof makeProviderRuntimeReconcilerLive>[0];
 }
 
 export const makeOrchestrationIntegrationHarness = (
@@ -333,7 +339,7 @@ export const makeOrchestrationIntegrationHarness = (
       Layer.provideMerge(studioOutputReactorLayer),
       Layer.provideMerge(gitCoreLayer),
       Layer.provideMerge(textGenerationLayer),
-      Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(ServerSettingsService.layerTest(options?.serverSettings)),
       Layer.provideMerge(AgentGatewayOperationRepositoryLive),
     );
     const checkpointReactorLayer = CheckpointReactorLive.pipe(
@@ -354,7 +360,10 @@ export const makeOrchestrationIntegrationHarness = (
       Layer.provideMerge(threadGitMetadataReactorLayer),
       Layer.provideMerge(sidechatExpiryReactorLayer),
     );
-    const layer = orchestrationReactorLayer.pipe(
+    const layer = makeProviderRuntimeReconcilerLive(options?.runtimeReconcilerOptions).pipe(
+      Layer.provideMerge(orchestrationReactorLayer),
+      Layer.provide(providerSessionDirectoryLayer),
+      Layer.provide(ProviderRuntimeEventRepositoryLive),
       Layer.provide(persistenceLayer),
       Layer.provideMerge(ServerConfig.layerTest(workspaceDir, rootDir)),
       Layer.provideMerge(NodeServices.layer),
@@ -374,6 +383,10 @@ export const makeOrchestrationIntegrationHarness = (
     ).pipe(Effect.orDie);
     const providerService = yield* tryRuntimePromise("load ProviderService service", () =>
       runtime.runPromise(Effect.service(ProviderService)),
+    ).pipe(Effect.orDie);
+    const runtimeReconciler = yield* tryRuntimePromise(
+      "load ProviderRuntimeReconciler service",
+      () => runtime.runPromise(Effect.service(ProviderRuntimeReconciler)),
     ).pipe(Effect.orDie);
     const checkpointStore = yield* tryRuntimePromise("load CheckpointStore service", () =>
       runtime.runPromise(Effect.service(CheckpointStore)),
@@ -536,6 +549,7 @@ export const makeOrchestrationIntegrationHarness = (
       engine,
       snapshotQuery,
       providerService,
+      runtimeReconciler,
       checkpointStore,
       checkpointRepository,
       waitForThread,

--- a/apps/server/integration/fixtures/codexLifecycle.cjs
+++ b/apps/server/integration/fixtures/codexLifecycle.cjs
@@ -1,0 +1,91 @@
+// Deterministic app-server protocol peer, launched as `node app-server` by the
+// real Codex adapter. No model, credentials, network, or live application state.
+const fs = require("node:fs");
+const path = require("node:path");
+const readline = require("node:readline");
+
+const stateDir = process.env.CODEX_HOME;
+if (
+  !stateDir ||
+  !path.isAbsolute(stateDir) ||
+  stateDir !== process.env.CODEX_SQLITE_HOME ||
+  [process.cwd(), process.env.USERPROFILE, process.env.HOME].includes(stateDir)
+)
+  throw new Error("Lifecycle fixture requires one isolated absolute Codex state directory.");
+
+const threadId = "fixture-native-thread";
+let turnCount = 0;
+let activeTurn;
+const write = (message) => process.stdout.write(`${JSON.stringify(message)}\n`);
+const notify = (method, params) => write({ method, params });
+const record = (event) =>
+  fs.appendFileSync(path.join(stateDir, "protocol.jsonl"), `${JSON.stringify(event)}\n`);
+const complete = (state = "completed") => {
+  if (!activeTurn) return;
+  const turnId = activeTurn;
+  activeTurn = undefined;
+  record({ type: "completed", turnId, state });
+  notify("item/completed", {
+    threadId,
+    turnId,
+    item: {
+      type: "agentMessage",
+      id: `message-${turnId}`,
+      text: `Completed ${turnId}.`,
+      phase: "final_answer",
+    },
+  });
+  notify("turn/completed", {
+    threadId,
+    turn: { id: turnId, status: state, items: [], error: null },
+  });
+};
+
+readline.createInterface({ input: process.stdin }).on("line", (line) => {
+  const request = JSON.parse(line);
+  if (request.id === undefined) return;
+  let result = {};
+  switch (request.method) {
+    case "initialize":
+      result = { userAgent: "synara-lifecycle-fixture" };
+      break;
+    case "account/read":
+      result = { account: { type: "apiKey" }, requiresOpenaiAuth: false };
+      break;
+    case "thread/start":
+    case "thread/resume":
+      result = { thread: { id: threadId, turns: [] }, model: "gpt-5.6-sol" };
+      break;
+    case "thread/read":
+      result = { thread: { id: threadId, turns: [] } };
+      break;
+    case "turn/start": {
+      if (activeTurn) throw new Error("Overlapping provider turn/start calls");
+      activeTurn = `fixture-turn-${++turnCount}`;
+      const turnId = activeTurn;
+      record({ type: "started", turnId });
+      result = { turn: { id: turnId, status: "inProgress", items: [], error: null } };
+      write({ id: request.id, result });
+      notify("turn/started", { threadId, turn: result.turn });
+      notify("item/agentMessage/delta", {
+        threadId,
+        turnId,
+        itemId: `message-${turnId}`,
+        delta: `Working on ${turnId}.`,
+      });
+      return;
+    }
+    case "turn/interrupt":
+      complete("interrupted");
+      break;
+  }
+  write({ id: request.id, result });
+});
+
+const timer = setInterval(() => {
+  if (activeTurn && fs.existsSync(path.join(stateDir, `complete-${activeTurn}`))) complete();
+}, 20);
+process.stdin.on("end", () => {
+  clearInterval(timer);
+  process.exit(0);
+});

--- a/apps/server/integration/fixtures/codexLifecycle.cjs
+++ b/apps/server/integration/fixtures/codexLifecycle.cjs
@@ -47,6 +47,9 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
   let result = {};
   switch (request.method) {
     case "initialize":
+      process.stderr.write(
+        `${new Date().toISOString()} ERROR codex_models_manager::manager: failed to refresh available models: timeout waiting for child process to exit\n`,
+      );
       result = { userAgent: "synara-lifecycle-fixture" };
       break;
     case "account/read":

--- a/apps/server/integration/overlappingTurnLifecycle.integration.test.ts
+++ b/apps/server/integration/overlappingTurnLifecycle.integration.test.ts
@@ -1,0 +1,256 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { CommandId, MessageId, ProjectId, ThreadId } from "@synara/contracts";
+import * as processRuntime from "@synara/shared/processRuntime";
+import { Effect, Option } from "effect";
+import { expect, it, vi } from "vitest";
+
+import { makeAgentGatewayCredentials } from "../src/agentGateway/Layers/AgentGatewayCredentials.ts";
+import { AgentGatewaySessionRegistryLive } from "../src/agentGateway/Layers/AgentGatewaySessionRegistry.ts";
+import { makeAgentGatewayMcpTransport } from "../src/agentGateway/mcpTransport.ts";
+import { mcpToolResultJson } from "../src/agentGateway/protocol.ts";
+import { ServerConfig } from "../src/config.ts";
+import { makeOrchestrationIntegrationHarness } from "./OrchestrationEngineHarness.integration.ts";
+
+it.each([false, true])(
+  "preserves manual ownership and completes queued automation (legacy interruption: %s)",
+  async (legacyInterruption) => {
+    let reconciliationOffsetMs = 0;
+    try {
+      const spawnProcess = processRuntime.spawnProcess;
+      vi.spyOn(processRuntime, "spawnProcess").mockImplementation((command, args, options) => {
+        if (args?.includes("app-server") || args?.includes("--version")) {
+          expect(command).toBe(process.execPath);
+          expect(options?.env?.CODEX_HOME).toBe(process.env.CODEX_HOME);
+          expect(options?.env?.CODEX_SQLITE_HOME).toBe(process.env.CODEX_HOME);
+        }
+        return spawnProcess(command, args, options);
+      });
+      await Effect.acquireUseRelease(
+        makeOrchestrationIntegrationHarness({
+          realCodex: true,
+          serverSettings: { providers: { codex: { binaryPath: process.execPath } } },
+          runtimeReconcilerOptions: { now: () => Date.now() + reconciliationOffsetMs },
+        }),
+        (harness) =>
+          Effect.gen(function* () {
+            // Use the real adapter/process transport against a deterministic local
+            // protocol peer. Synara, Codex home/config/SQLite, and Git are isolated.
+            const codexState = path.join(harness.rootDir, "codex-home-overlay");
+            expect(path.isAbsolute(codexState)).toBe(true);
+            expect([
+              process.env.USERPROFILE,
+              process.cwd(),
+              harness.workspaceDir,
+              harness.rootDir,
+            ]).not.toContain(codexState);
+            fs.mkdirSync(codexState);
+            fs.writeFileSync(
+              path.join(codexState, "config.toml"),
+              `sqlite_home = ${JSON.stringify(codexState)}\n`,
+            );
+            vi.stubEnv("SYNARA_HOME", harness.rootDir);
+            vi.stubEnv("CODEX_HOME", codexState);
+            vi.stubEnv("CODEX_SQLITE_HOME", codexState);
+            fs.copyFileSync(
+              path.join(import.meta.dirname, "fixtures/codexLifecycle.cjs"),
+              path.join(harness.workspaceDir, "app-server"),
+            );
+
+            const projectId = ProjectId.makeUnsafe("lifecycle-project");
+            const threadId = ThreadId.makeUnsafe("lifecycle-thread");
+            const modelSelection = { provider: "codex", model: "gpt-5.6-sol" } as const;
+            const createdAt = new Date().toISOString();
+            yield* harness.engine.dispatch({
+              type: "project.create",
+              commandId: CommandId.makeUnsafe("lifecycle-project-create"),
+              projectId,
+              title: "Lifecycle fixture",
+              workspaceRoot: harness.workspaceDir,
+              defaultModelSelection: modelSelection,
+              createdAt,
+            });
+            yield* harness.engine.dispatch({
+              type: "thread.create",
+              commandId: CommandId.makeUnsafe("lifecycle-thread-create"),
+              threadId,
+              projectId,
+              title: "Lifecycle fixture",
+              modelSelection,
+              runtimeMode: "full-access",
+              interactionMode: "default",
+              branch: null,
+              worktreePath: null,
+              createdAt,
+            });
+            const start = (id: string, dispatchOrigin: "user" | "automation") =>
+              harness.engine.dispatch({
+                type: "thread.turn.start",
+                commandId: CommandId.makeUnsafe(`${id}-start`),
+                threadId,
+                message: {
+                  messageId: MessageId.makeUnsafe(id),
+                  role: "user",
+                  text: id,
+                  attachments: [],
+                },
+                modelSelection,
+                runtimeMode: "full-access",
+                interactionMode: "default",
+                dispatchMode: "queue",
+                dispatchOrigin,
+                createdAt: new Date().toISOString(),
+              });
+            yield* start("manual-message", "user");
+            yield* harness.waitForThread(
+              threadId,
+              (thread) =>
+                thread.latestTurn?.state === "running" &&
+                thread.session?.activeTurnId === "fixture-turn-1" &&
+                thread.messages.some((message) =>
+                  message.text.includes("Working on fixture-turn-1"),
+                ),
+            );
+
+            // Advance only reconciliation's observation clock. The live adapter
+            // and its activity watchdog continue using real time.
+            const reconcileAfterDeadline = () =>
+              Effect.acquireUseRelease(
+                Effect.sync(() => {
+                  reconciliationOffsetMs = 46 * 60_000;
+                }),
+                () => harness.runtimeReconciler.reconcileNow,
+                () =>
+                  Effect.sync(() => {
+                    reconciliationOffsetMs = 0;
+                  }),
+              );
+            yield* reconcileAfterDeadline();
+
+            const credentials = yield* makeAgentGatewayCredentials.pipe(
+              Effect.provide(AgentGatewaySessionRegistryLive),
+              Effect.provide(ServerConfig.layerTest(harness.workspaceDir, harness.rootDir)),
+            );
+            const token = credentials.issueSessionToken(threadId, "codex");
+            const transport = makeAgentGatewayMcpTransport({
+              credentials,
+              snapshotQuery: harness.snapshotQuery,
+              instructions: "Lifecycle fixture",
+              requireThreadShell: (id) =>
+                harness.snapshotQuery
+                  .getThreadShellById(ThreadId.makeUnsafe(id))
+                  .pipe(Effect.map(Option.getOrThrow)),
+              tools: [
+                {
+                  requiredCapability: "automation:write",
+                  requiresActiveTurn: true,
+                  definition: {
+                    name: "lifecycle_write",
+                    description: "Check exact turn ownership",
+                    inputSchema: { type: "object" },
+                  },
+                  handler: (_args, context) =>
+                    Effect.succeed(mcpToolResultJson({ turnId: context.callerTurnId })),
+                },
+              ],
+            });
+            const write = () =>
+              transport({
+                authorizationHeader: `Bearer ${token}`,
+                body: {
+                  jsonrpc: "2.0",
+                  id: 1,
+                  method: "tools/call",
+                  params: { name: "lifecycle_write", arguments: {} },
+                },
+              });
+            expect(JSON.stringify(yield* write())).toContain("fixture-turn-1");
+
+            if (legacyInterruption) {
+              const shell = Option.getOrThrow(
+                yield* harness.snapshotQuery.getThreadShellById(threadId),
+              );
+              yield* harness.engine.dispatch({
+                type: "thread.session.set",
+                commandId: CommandId.makeUnsafe("legacy-false-interruption"),
+                threadId,
+                session: {
+                  ...shell.session!,
+                  status: "interrupted",
+                  activeTurnId: null,
+                  updatedAt: new Date().toISOString(),
+                },
+                createdAt: new Date().toISOString(),
+              });
+              expect(JSON.stringify(yield* write())).toContain("caller_turn_inactive");
+            }
+            yield* start("automation-message", "automation");
+            yield* harness.waitForDomainEvent(
+              (event) =>
+                event.type ===
+                  (legacyInterruption ? "thread.turn-start-requested" : "thread.turn-queued") &&
+                event.payload.messageId === "automation-message",
+            );
+            if (legacyInterruption) {
+              const stale = Option.getOrThrow(
+                yield* harness.snapshotQuery.getThreadShellById(threadId),
+              );
+              expect(stale.session).toMatchObject({ status: "starting", activeTurnId: null });
+              expect(stale.latestTurn?.state).toBe("interrupted");
+            }
+            yield* reconcileAfterDeadline();
+            const queued = Option.getOrThrow(
+              yield* harness.snapshotQuery.getThreadShellById(threadId),
+            );
+            expect(queued.session?.activeTurnId).toBe("fixture-turn-1");
+            expect(queued.latestTurn).toMatchObject({
+              turnId: "fixture-turn-1",
+              state: "running",
+              completedAt: null,
+            });
+            expect(JSON.stringify(yield* write())).not.toContain("caller_turn_inactive");
+            const protocol = () =>
+              fs
+                .readFileSync(path.join(codexState, "protocol.jsonl"), "utf8")
+                .trim()
+                .split("\n")
+                .map((line) => JSON.parse(line) as { type: string; turnId: string });
+            expect(protocol().filter((event) => event.type === "started")).toHaveLength(1);
+
+            fs.writeFileSync(path.join(codexState, "complete-fixture-turn-1"), "");
+            yield* harness.waitForThread(
+              threadId,
+              (thread) => thread.session?.activeTurnId === "fixture-turn-2",
+            );
+            fs.writeFileSync(path.join(codexState, "complete-fixture-turn-2"), "");
+            const completed = yield* harness.waitForThread(
+              threadId,
+              (thread) =>
+                thread.session?.status === "ready" &&
+                thread.latestTurn?.turnId === "fixture-turn-2" &&
+                thread.latestTurn.state === "completed",
+            );
+            expect(completed.session?.activeTurnId).toBeNull();
+            expect(
+              completed.messages
+                .filter((message) => message.role === "assistant")
+                .map((message) => message.turnId),
+            ).toEqual(expect.arrayContaining(["fixture-turn-1", "fixture-turn-2"]));
+            expect(protocol()).toEqual([
+              { type: "started", turnId: "fixture-turn-1" },
+              { type: "completed", turnId: "fixture-turn-1", state: "completed" },
+              { type: "started", turnId: "fixture-turn-2" },
+              { type: "completed", turnId: "fixture-turn-2", state: "completed" },
+            ]);
+            expect(JSON.stringify(yield* write())).toContain("caller_turn_inactive");
+          }),
+        (harness) => harness.dispose,
+      ).pipe(Effect.scoped, Effect.provide(NodeServices.layer), Effect.runPromise);
+    } finally {
+      vi.restoreAllMocks();
+      vi.unstubAllEnvs();
+    }
+  },
+);

--- a/apps/server/integration/overlappingTurnLifecycle.integration.test.ts
+++ b/apps/server/integration/overlappingTurnLifecycle.integration.test.ts
@@ -104,7 +104,17 @@ it.each([false, true])(
                 createdAt: new Date().toISOString(),
               });
             yield* start("manual-message", "user");
-            yield* harness.waitForThread(
+            // Model refresh stderr can arrive before a provider turn ID exists.
+            // It must remain visible without failing or retrying the first start.
+            yield* harness.waitForDomainEvent(
+              (event) =>
+                event.type === "thread.activity-appended" &&
+                event.payload.activity.kind === "runtime.warning" &&
+                JSON.stringify(event.payload.activity.payload).includes(
+                  "failed to refresh available models: timeout waiting for child process to exit",
+                ),
+            );
+            const manual = yield* harness.waitForThread(
               threadId,
               (thread) =>
                 thread.latestTurn?.state === "running" &&
@@ -113,6 +123,7 @@ it.each([false, true])(
                   message.text.includes("Working on fixture-turn-1"),
                 ),
             );
+            expect(manual.session?.lastError).toBeNull();
 
             // Advance only reconciliation's observation clock. The live adapter
             // and its activity watchdog continue using real time.

--- a/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
+++ b/apps/server/src/agentGateway/Layers/AgentGateway.test.ts
@@ -2364,6 +2364,53 @@ describe("AgentGateway", () => {
     }).pipe(Effect.provide(gatewayLayer));
   });
 
+  it.effect("diagnoses an abandoned startup even without delivery blockers or incidents", () => {
+    const thread = makeThreadShell("thread-parent", {
+      latestTurn: {
+        ...baseThreads[0]!.latestTurn!,
+        state: "interrupted",
+        completedAt: NOW,
+      },
+      session: {
+        threadId: ThreadId.makeUnsafe("thread-parent"),
+        status: "starting",
+        providerName: "codex",
+        runtimeMode: "approval-required",
+        activeTurnId: null,
+        lastError: null,
+        updatedAt: NOW,
+      },
+    });
+    const { gatewayLayer, makeHarness } = makeHarnessLayer([thread]);
+    return Effect.gen(function* () {
+      const harness = yield* makeHarness;
+      const diagnose = () =>
+        harness.callTool({
+          token: "token-parent",
+          name: "synara_diagnose_thread",
+          args: { threadId: "thread-parent" },
+        });
+      const payload = toolResultJson((yield* diagnose()).result);
+      assert.deepEqual(payload.providerDeliveryBlockers, []);
+      assert.deepEqual(payload.operationalIncidents, []);
+      assert.includeMembers(
+        (payload.findings as Array<{ code: string }>).map((finding) => finding.code),
+        ["provider_lifecycle_stale"],
+      );
+
+      // The same combination is normal while a new queued turn is starting.
+      const now = new Date().toISOString();
+      harness.setThreadDetail(
+        makeThreadDetail({
+          ...thread,
+          updatedAt: now,
+          session: { ...thread.session!, updatedAt: now },
+        }),
+      );
+      assert.deepEqual(toolResultJson((yield* diagnose()).result).findings, []);
+    }).pipe(Effect.provide(gatewayLayer));
+  });
+
   it.effect("creates a standalone cross-provider thread and dispatches the initial turn", () => {
     const { gatewayLayer, makeHarness } = makeHarnessLayer(baseThreads);
     return Effect.gen(function* () {

--- a/apps/server/src/agentGateway/threadDiagnosticTools.ts
+++ b/apps/server/src/agentGateway/threadDiagnosticTools.ts
@@ -8,6 +8,10 @@ import { Effect, Option } from "effect";
 import type { ProjectionSnapshotQueryShape } from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import type { ThreadDiagnosticsQueryShape } from "../diagnostics/Services/ThreadDiagnosticsQuery.ts";
 import {
+  projectedLifecycleAgeMs,
+  RUNTIME_RECONCILIATION_MAX_TURN_AGE_MS,
+} from "../provider/providerRuntimeReconciliation.ts";
+import {
   PROVIDER_COMMAND_REACTOR_CONSUMER,
   type OrchestrationEventDeliveryRepositoryShape,
 } from "../persistence/Services/OrchestrationEventDeliveries.ts";
@@ -396,6 +400,18 @@ export function makeThreadDiagnosticTools(input: {
           }),
         ]);
         const findings = [
+          ...((detail.session?.status === "starting" || detail.session?.status === "running") &&
+          detail.session.activeTurnId === null &&
+          detail.latestTurn?.state !== "running" &&
+          projectedLifecycleAgeMs(detail, Date.now()) >= RUNTIME_RECONCILIATION_MAX_TURN_AGE_MS
+            ? [
+                {
+                  severity: "warning",
+                  code: "provider_lifecycle_stale",
+                  detail: `Session remains '${detail.session.status}' without an active provider turn beyond the recovery grace period; latest turn is '${detail.latestTurn?.state ?? "absent"}'. Check live provider ownership before recovery.`,
+                },
+              ]
+            : []),
           ...(detail.session?.lastError
             ? [
                 {

--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -966,6 +966,7 @@ layer("AutomationService", (it) => {
         ...createInput("local"),
         mode: "dedicated",
         heartbeatCooldownSeconds: 0,
+        schedule: { type: "interval", everySeconds: 300 },
       });
       // A dedicated automation starts without a thread: the server assigns its own.
       assert.strictEqual(created.targetThreadId, null);
@@ -1003,7 +1004,45 @@ layer("AutomationService", (it) => {
           listed.runs.find((entry) => entry.id === first.run.id)?.status === "succeeded",
       });
 
-      const second = yield* service.runNow({ automationId: created.id });
+      const manualTurnId = TurnId.makeUnsafe("turn-dedicated-manual");
+      threadShell = Option.some(
+        makeThreadShell({
+          id: dedicatedThreadId,
+          latestTurn: makeLatestTurn("running", manualTurnId),
+        }),
+      );
+      const definition = (yield* service.list({ projectId })).definitions.find(
+        (entry) => entry.id === created.id,
+      )!;
+      const scheduled = yield* service.runDueOnce({
+        now: definition.nextRunAt!,
+        limit: 10,
+        leaseOwnerId: "test-scheduler",
+      });
+      const deferred = scheduled.find((entry) => entry.run.automationId === created.id)!;
+      assert.isNotNull(deferred.run.deferredUntil);
+      assert.isNull(deferred.run.threadId);
+      assert.strictEqual(
+        dispatchedCommands.filter((command) => command.type === "thread.turn.start").length,
+        1,
+      );
+
+      // The observed bug falsely interrupted the manual projection before the
+      // scheduler checked eligibility. This admits dispatch despite a live turn;
+      // the reactor must still queue it (covered by the process integration).
+      threadShell = Option.some(
+        makeThreadShell({
+          id: dedicatedThreadId,
+          latestTurn: makeLatestTurn("interrupted", manualTurnId),
+        }),
+      );
+      const retried = yield* service.runDueOnce({
+        now: deferred.run.deferredUntil!,
+        limit: 10,
+        leaseOwnerId: "test-scheduler",
+      });
+      const second = retried.find((entry) => entry.run.id === deferred.run.id)!;
+      assert.exists(second, "The deferred dedicated automation must be dispatched.");
 
       // The second run continues the claimed thread instead of opening a new one.
       assert.strictEqual(second.run.threadId, dedicatedThreadId);
@@ -1011,6 +1050,55 @@ layer("AutomationService", (it) => {
       assert.strictEqual(
         dispatchedCommands.filter((command) => command.type === "thread.create").length,
         1,
+      );
+      const queuedStart = dispatchedCommands.find(
+        (command) => command.commandId === second.run.turnStartCommandId,
+      );
+      assert.include(queuedStart, {
+        type: "thread.turn.start",
+        dispatchMode: "queue",
+        dispatchOrigin: "automation",
+      });
+
+      // Neither a live manual turn nor its completion belongs to this run.
+      for (const state of ["running", "completed"] as const) {
+        threadShell = Option.some(
+          makeThreadShell({
+            id: dedicatedThreadId,
+            latestTurn: makeLatestTurn(state, manualTurnId),
+          }),
+        );
+        yield* service.reconcileThread({ threadId: dedicatedThreadId });
+        const waiting = (yield* service.list({ projectId })).runs.find(
+          (entry) => entry.id === second.run.id,
+        );
+        assert.strictEqual(waiting?.status, "running");
+        assert.isNull(waiting?.turnId);
+      }
+
+      const automationTurnId = TurnId.makeUnsafe("turn-dedicated-scheduled");
+      yield* completeAutomationRun({
+        run: second.run,
+        threadId: dedicatedThreadId,
+        turnId: automationTurnId,
+      });
+      yield* service.reportResult({
+        callerThreadId: dedicatedThreadId,
+        callerTurnId: automationTurnId,
+        decision: "silent",
+        title: "No changes",
+        summary: "The scheduled check completed.",
+      });
+      yield* service.reconcileThread({ threadId: dedicatedThreadId });
+      const finished = yield* waitForAutomationList({
+        service,
+        description: "the queued dedicated run to report its own result",
+        predicate: (listed) =>
+          listed.runs.find((entry) => entry.id === second.run.id)?.status === "succeeded",
+      });
+      assert.strictEqual(
+        finished.runs.find((entry) => entry.id === second.run.id)?.result?.decision,
+        "silent",
       );
     }),
   );

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -5333,6 +5333,47 @@ it.layer(
     }),
   );
 
+  it.effect(
+    "reopens an interrupted turn's completion timestamp when live ownership is restored",
+    () =>
+      Effect.gen(function* () {
+        const eventStore = yield* OrchestrationEventStore;
+        const projectionPipeline = yield* OrchestrationProjectionPipeline;
+        const sql = yield* SqlClient.SqlClient;
+        const threadId = ThreadId.makeUnsafe("thread-live-realignment");
+        const turnId = TurnId.makeUnsafe("turn-live-realignment");
+        const append = makeScenarioAppender(
+          makeAppendAndProject(eventStore, projectionPipeline),
+          "live-realignment",
+        );
+        for (const [index, status] of (["running", "interrupted", "running"] as const).entries()) {
+          const updatedAt = `2026-09-11T20:0${index}:00.000Z`;
+          yield* append({
+            type: "thread.session-set",
+            aggregateKind: "thread",
+            aggregateId: threadId,
+            occurredAt: updatedAt,
+            payload: {
+              threadId,
+              session: {
+                threadId,
+                status,
+                providerName: "codex",
+                runtimeMode: "full-access",
+                activeTurnId: status === "running" ? turnId : null,
+                lastError: null,
+                updatedAt,
+              },
+            },
+          });
+        }
+        assert.deepEqual(
+          yield* sql`SELECT state, completed_at AS "completedAt", started_at AS "startedAt" FROM projection_turns WHERE thread_id = ${threadId}`,
+          [{ state: "running", completedAt: null, startedAt: "2026-09-11T20:00:00.000Z" }],
+        );
+      }),
+  );
+
   it.effect("projects steer dispatch mode onto the triggering user message", () =>
     Effect.gen(function* () {
       const eventStore = yield* OrchestrationEventStore;

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1337,6 +1337,9 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
             yield* projectionTurnRepository.upsertByTurnId({
               ...existingTurn.value,
               state: nextState,
+              // Live reconciliation can restore an incorrectly interrupted
+              // turn. Its completion timestamp must be reopened with it.
+              completedAt: nextState === "running" ? null : existingTurn.value.completedAt,
               pendingMessageId:
                 existingTurn.value.pendingMessageId ??
                 (Option.isSome(pendingTurnStart) ? pendingTurnStart.value.messageId : null),

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -2503,10 +2503,10 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
       // turn past the staleness cutoff, including threads whose runtime binding
       // row is already gone (`thread-unbound-oldest`) and archived threads
       // (`thread-archived-running`) - archiving does not settle a live turn.
-      // Excluded: `thread-fresh-running` (updated after the cutoff),
-      // `thread-settled` (no active turn), and `thread-queued-oldest` (a pending
-      // turn with no active turn id on either the session or the runtime row).
+      // A starting session with no turn must also reach the planner, which
+      // owns the longer startup grace period. Otherwise it is never repaired.
       assert.deepEqual(candidates, [
+        ThreadId.makeUnsafe("thread-queued-oldest"),
         ThreadId.makeUnsafe("thread-unbound-oldest"),
         ThreadId.makeUnsafe("thread-archived-running"),
         ThreadId.makeUnsafe("thread-stale-running"),
@@ -2518,7 +2518,19 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
         updatedBefore: "2026-07-23T09:00:00.000Z",
         limit: 1,
       });
-      assert.deepEqual(oldestCandidate, [ThreadId.makeUnsafe("thread-unbound-oldest")]);
+      assert.deepEqual(oldestCandidate, [ThreadId.makeUnsafe("thread-queued-oldest")]);
+
+      // Exact stuck signature: an interrupted previous turn, an optimistic
+      // starting session, and no runtime binding left to supply an active id.
+      yield* sql`UPDATE projection_turns SET state = 'interrupted', completed_at = '2026-07-21T01:00:00.000Z', checkpoint_turn_count = NULL, checkpoint_status = NULL WHERE thread_id = 'thread-queued-oldest'`;
+      yield* sql`DELETE FROM provider_session_runtime WHERE thread_id = 'thread-queued-oldest'`;
+      assert.deepEqual(
+        yield* snapshotQuery.listStaleInFlightThreadIds({
+          updatedBefore: "2026-07-23T09:00:00.000Z",
+          limit: 1,
+        }),
+        [ThreadId.makeUnsafe("thread-queued-oldest")],
+      );
     }),
   );
 

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -1028,12 +1028,13 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
               sessions.active_turn_id IS NOT NULL
               AND sessions.status <> 'error'
             )
+            OR sessions.status IN ('starting', 'running')
             OR latest_turn.state = 'running'
             OR json_extract(runtime.runtime_payload_json, '$.activeTurnId') IS NOT NULL
           )
           -- Later of the session lifecycle timestamp and the thread timestamp:
-          -- threads.updated_at advances on every appended message, so a turn
-          -- that is actively streaming output is not a stale candidate.
+          -- these are shell/lifecycle timestamps, not provider progress.
+          -- The planner checks live ownership before settling a candidate.
           AND MAX(COALESCE(sessions.updated_at, threads.updated_at), threads.updated_at) <= ${updatedBefore}
         ORDER BY MAX(COALESCE(sessions.updated_at, threads.updated_at), threads.updated_at) ASC, threads.thread_id ASC
         LIMIT ${Math.max(1, Math.min(1_000, Math.floor(limit)))}

--- a/apps/server/src/provider/Layers/ProviderRuntimeReconciler.ts
+++ b/apps/server/src/provider/Layers/ProviderRuntimeReconciler.ts
@@ -42,6 +42,7 @@ const DEFAULT_RECONCILIATION_INTERVAL_MS = 5_000;
 const DEFAULT_RECONCILIATION_CANDIDATE_LIMIT = 256;
 
 export interface ProviderRuntimeReconcilerLiveOptions {
+  readonly now?: () => number;
   readonly intervalMs?: number;
   readonly staleAfterMs?: number;
   readonly candidateLimit?: number;
@@ -147,10 +148,13 @@ const make = (options?: ProviderRuntimeReconcilerLiveOptions) =>
       // Nothing left to repair: the projected session already matches the plan
       // and no turn is left running. Dispatching anyway writes two fresh events
       // on every tick for as long as the thread stays a candidate.
-      if (
-        thread.latestTurn?.state !== "running" &&
-        isSameProjectedSession(thread.session, session)
-      ) {
+      const turnNeedsRepair =
+        plan.action === "align-running-turn"
+          ? thread.latestTurn?.turnId !== plan.runtimeTurnId ||
+            thread.latestTurn.state !== "running" ||
+            thread.latestTurn.completedAt !== null
+          : thread.latestTurn?.state === "running";
+      if (!turnNeedsRepair && isSameProjectedSession(thread.session, session)) {
         return;
       }
 
@@ -212,7 +216,7 @@ const make = (options?: ProviderRuntimeReconcilerLiveOptions) =>
     });
 
     const reconcileNow = Effect.gen(function* () {
-      const nowMs = Date.now();
+      const nowMs = (options?.now ?? Date.now)();
       const candidateThreadIds = yield* projectionSnapshotQuery.listStaleInFlightThreadIds({
         updatedBefore: new Date(nowMs - staleAfterMs).toISOString(),
         limit: candidateLimit,

--- a/apps/server/src/provider/providerRuntimeReconciliation.test.ts
+++ b/apps/server/src/provider/providerRuntimeReconciliation.test.ts
@@ -106,6 +106,86 @@ function liveSession(input: {
 }
 
 describe("planProviderRuntimeReconciliation", () => {
+  it("preserves a live manual turn beyond the abandonment deadline", () => {
+    // Assistant messages and tool progress do not advance the thread shell's
+    // updatedAt. A long turn can have an old shell while its adapter is live.
+    expect(
+      planProviderRuntimeReconciliation({
+        threads: [threadShell()],
+        bindings: [binding()],
+        liveSessions: [liveSession({ status: "running", activeTurnId: OLD_TURN_ID })],
+        pumpHealth: [],
+        nowMs: NOW + 46 * 60_000,
+      }),
+    ).toEqual([]);
+  });
+
+  it("realigns an aged automation startup with the still-live manual turn", () => {
+    const thread = threadShell({
+      latestTurn: {
+        ...threadShell().latestTurn!,
+        state: "interrupted",
+        completedAt: "2026-07-23T20:00:10.000Z",
+      },
+      session: { ...threadShell().session!, status: "starting", activeTurnId: null },
+    });
+    expect(
+      planProviderRuntimeReconciliation({
+        threads: [thread],
+        bindings: [binding(null)],
+        liveSessions: [liveSession({ status: "running", activeTurnId: OLD_TURN_ID })],
+        pumpHealth: [],
+        nowMs: NOW + 46 * 60_000,
+      }),
+    ).toEqual([
+      expect.objectContaining({ action: "align-running-turn", runtimeTurnId: OLD_TURN_ID }),
+    ]);
+  });
+
+  it.each(["completed", "error"] as const)(
+    "does not repeatedly reopen a final %s turn",
+    (state) => {
+      expect(
+        planProviderRuntimeReconciliation({
+          threads: [
+            threadShell({
+              latestTurn: {
+                ...threadShell().latestTurn!,
+                state,
+                completedAt: "2026-07-23T20:00:10.000Z",
+              },
+            }),
+          ],
+          bindings: [binding()],
+          liveSessions: [liveSession({ status: "running", activeTurnId: OLD_TURN_ID })],
+          pumpHealth: [],
+          nowMs: NOW + 46 * 60_000,
+        }),
+      ).toEqual([]);
+    },
+  );
+
+  it("settles an abandoned starting session without a binding or live turn", () => {
+    expect(
+      planProviderRuntimeReconciliation({
+        threads: [
+          threadShell({
+            latestTurn: {
+              ...threadShell().latestTurn!,
+              state: "interrupted",
+              completedAt: "2026-07-23T20:00:10.000Z",
+            },
+            session: { ...threadShell().session!, status: "starting", activeTurnId: null },
+          }),
+        ],
+        bindings: [],
+        liveSessions: [],
+        pumpHealth: [],
+        nowMs: NOW + 46 * 60_000,
+      }),
+    ).toEqual([expect.objectContaining({ action: "settle-interrupted", projectedTurnId: null })]);
+  });
+
   it("settles a stale projection when the live Adapter is ready with no active turn", () => {
     expect(
       planProviderRuntimeReconciliation({

--- a/apps/server/src/provider/providerRuntimeReconciliation.ts
+++ b/apps/server/src/provider/providerRuntimeReconciliation.ts
@@ -22,12 +22,11 @@ import type { ProviderRuntimeBinding } from "./Services/ProviderSessionDirectory
 export const DEFAULT_RUNTIME_RECONCILIATION_STALE_AFTER_MS = 15_000;
 
 /**
- * Absolute upper bound on a single turn. Past this the turn is settled even
- * when the live runtime still claims to be running, because every other signal
- * this planner trusts (a settled session, a missing session, a failed binding)
- * can be absent when a provider wedges mid-turn. `thread.updatedAt` advances on
- * every appended message, so a legitimately long-running turn keeps resetting
- * this clock and is never affected.
+ * Recovery grace period for a lifecycle with no authoritative live turn.
+ * Thread/session timestamps describe lifecycle and shell changes, not provider
+ * progress: assistant text and tools deliberately do not update the shell.
+ * An adapter-owned turn must be stopped by its watchdog/interrupt path before
+ * reconciliation can settle it, regardless of this deadline.
  */
 export const RUNTIME_RECONCILIATION_MAX_TURN_AGE_MS = 45 * 60_000;
 
@@ -132,11 +131,10 @@ function projectedInFlightTurnId(thread: OrchestrationThreadShell): TurnId | nul
   );
 }
 
-function projectedLifecycleAgeMs(thread: OrchestrationThreadShell, nowMs: number): number {
+export function projectedLifecycleAgeMs(thread: OrchestrationThreadShell, nowMs: number): number {
   // The later of the session lifecycle timestamp and the thread timestamp:
-  // `thread.updatedAt` advances on every appended message, so a turn that is
-  // actively streaming output never counts as stale even though its session
-  // row only moves on lifecycle transitions.
+  // neither timestamp is an inactivity clock. Live adapter ownership is
+  // checked separately before any age-based settlement.
   const sessionObservedAt = Date.parse(thread.session?.updatedAt ?? thread.updatedAt);
   const threadObservedAt = Date.parse(thread.updatedAt);
   const observedAt = Number.isFinite(sessionObservedAt)
@@ -147,7 +145,7 @@ function projectedLifecycleAgeMs(thread: OrchestrationThreadShell, nowMs: number
   return Number.isFinite(observedAt) ? Math.max(0, nowMs - observedAt) : Number.POSITIVE_INFINITY;
 }
 
-/** Time since anything at all was projected onto the thread (messages included). */
+/** Time since the persisted thread shell changed (not assistant/tool progress). */
 function threadActivityAgeMs(thread: OrchestrationThreadShell, nowMs: number): number {
   const observedAt = Date.parse(thread.updatedAt);
   return Number.isFinite(observedAt) ? Math.max(0, nowMs - observedAt) : Number.POSITIVE_INFINITY;
@@ -225,7 +223,7 @@ export function planProviderRuntimeReconciliation(input: {
     const detail = pumpDetail(provider, healthByProvider);
     const abandoned =
       lifecycleAgeMs >= maxTurnAgeMs && threadActivityAgeMs(thread, input.nowMs) >= maxTurnAgeMs;
-    const abandonedDetail = ` Nothing has progressed on this thread for over ${Math.round(maxTurnAgeMs / 60_000)} minutes.${detail}`;
+    const abandonedDetail = ` The projected lifecycle has not changed for over ${Math.round(maxTurnAgeMs / 60_000)} minutes.${detail}`;
 
     // Native child threads share a parent session and intentionally have no
     // directory binding of their own; their parent's terminal events settle
@@ -235,8 +233,24 @@ export function planProviderRuntimeReconciliation(input: {
     const projectedTurnId = projectedInFlightTurnId(thread);
     const liveTurnId = turnIdOrNull(liveSession?.activeTurnId);
 
-    if (liveSession?.status === "running" && liveTurnId !== null && !abandoned) {
-      if (liveTurnId === projectedTurnId) continue;
+    // A time limit cannot revoke a live turn's ownership: doing so clears its
+    // binding and MCP write authority while the provider keeps executing.
+    if (liveSession?.status === "running" && liveTurnId !== null) {
+      // Completed/error turns are final in the projector. Replaying running
+      // cannot reopen them and would otherwise create a repair on every tick.
+      if (
+        thread.latestTurn?.turnId === liveTurnId &&
+        (thread.latestTurn.state === "completed" || thread.latestTurn.state === "error")
+      )
+        continue;
+      if (
+        liveTurnId === projectedTurnId &&
+        thread.session?.status === "running" &&
+        thread.latestTurn?.turnId === liveTurnId &&
+        thread.latestTurn.state === "running" &&
+        thread.latestTurn.completedAt === null
+      )
+        continue;
       plans.push({
         action: "align-running-turn",
         threadId: thread.id,


### PR DESCRIPTION
## What Changed

Preserve a live provider turn's ownership when its projected lifecycle is older than 45 minutes. Reconciliation can realign an incorrectly interrupted manual turn, including clearing its old completion timestamp, while preserving completed/error turns.

Include ownerless `starting`/`running` sessions in reconciliation candidates and report `provider_lifecycle_stale` from thread diagnosis when the recovery grace period has elapsed.

## Why

Thread/session timestamps describe shell and lifecycle changes; assistant text and tools do not refresh them. Previously, the 45-minute fallback could mark a still-running Codex turn interrupted and clear its binding. A scheduled continuation then passed the projection-based eligibility check and left the thread `starting` with an interrupted latest turn. The provider reactor correctly queued against the live turn, but the old caller had already lost MCP write authority. Candidate selection excluded the resulting state and diagnosis had no corresponding finding.

The fix retains exact active-turn authorization and existing queue/steer semantics. Truly stalled providers remain the responsibility of their runtime watchdog/stop path, which must stop the actual owner before settling it.

## Verification

- Regression tests first reproduced the false interruption, omitted startup candidate, and empty diagnosis on the original implementation.
- Windows process integration uses the production Codex adapter, process manager, durable orchestration/projection/queue, and MCP authorization against a deterministic local app-server protocol process. Both healthy long-turn and legacy interrupted/starting cases complete manual and automation turns in order. Synara, Git, SQLite, and Codex homes are isolated; the subprocess guard rejects accidental real Codex launches. This is protocol acceptance, not a hosted-model test.
- Dedicated automation coverage exercises scheduler deferral, the false-interruption eligibility gap, exact run/turn association, and silent completion reporting.
- Focused regression suites: 341 passing tests, including both new process integration cases.
- The process fixture also emits the observed Codex model-refresh stderr warning during initialization. Both integration cases pass with the warning projected, the first turn starting without retry, and `lastError` remaining null. Server typecheck and formatting/lint for the two updated test files pass.
- Workspace typecheck: 7/7 packages. Lint: zero errors (559 warnings).
- Formatting: all 3,181 matched files pass on an LF export of the staged Git tree; the Windows checkout has pre-existing CRLF and unrelated untracked planning files.
- Broad server sweep (provider/orchestration/automation/gateway and existing integrations, excluding ProviderHealth): 2,778 passed, 34 failed, 5 skipped across 192 files. Seven failures were CRLF expectations; the eight selected checkpoint tests and the affected integration test all passed with process-local `core.autocrlf=false`. All remaining **27/27 failures reproduced on unchanged main** (`a355cf2000b18aeb032e7dac18b74efdb3ab3268`) in an isolated Git archive with the same locked dependencies. These are existing platform/path, hook, discovery, SDK-fixture, and atomic-file tests; no changes were made to those implementations.
- The initial broad run stalled in ProviderHealth after its update-timeout assertion failed. That failure also reproduces on unchanged main; that file was excluded from the completed sweep. The repository-wide Windows suite is therefore not green, while the lifecycle change and its focused/integration checks are verified.
- [CI on the implementation commit](https://github.com/Emanuele-web04/synara/actions/runs/34664474540) passed both server shards, Windows process regression, static checks, and the desktop build. It failed the AppSnap temporary-file assertion and ChatView wheel-follow geometry assertion. The same ChatView assertion fails on [unchanged main](https://github.com/Emanuele-web04/synara/actions/runs/34646617440). The focused AppSnap test passes locally on both base and head; its existing capture promise settles before asynchronous temporary-file deletion. Desktop, web, shared contracts, and locked dependencies are unchanged by this PR. The latest test-only commit has a fresh CI run.

## Checklist

- [x] This PR is small and focused: lifecycle repair and regression coverage.
- [x] I explained what changed and why.
- [x] UI screenshots and animation video are not applicable to this server change.
