### PR TITLE
fix(server): settle late provider startup failures within a grace

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -40,6 +40,7 @@ import {
   Deferred,
   Effect,
   Exit,
+  Fiber,
   Layer,
   ManagedRuntime,
   Option,
@@ -7156,7 +7157,7 @@ describe("ProviderCommandReactor", () => {
     expect((await readHarnessThread(harness))?.session?.status).not.toBe("error");
   });
 
-  it("rejects a startup failure inside a production-proportional settle grace", async () => {
+  it("rejects a startup failure that lands inside the settle grace window", async () => {
     const harness = await createHarness({
       commandEventTimeout: Duration.millis(120),
       commandSettleGrace: Duration.millis(80),
@@ -7332,6 +7333,183 @@ describe("ProviderCommandReactor", () => {
       }),
     );
     expect(Option.isNone(blocking)).toBe(true);
+  });
+
+  it("recovers a turn start after a held checkpoint lease frees", async () => {
+    const coordinator = await Effect.runPromise(
+      Effect.gen(function* () {
+        return yield* TurnCheckpointCoordinator;
+      }).pipe(Effect.provide(TurnCheckpointCoordinatorLive)),
+    );
+    const acquired = Effect.runSync(Deferred.make<void>());
+    const release = Effect.runSync(Deferred.make<void>());
+    const holder = Effect.runFork(
+      coordinator.withThreadLease(
+        ThreadId.makeUnsafe("thread-1"),
+        Deferred.succeed(acquired, undefined).pipe(Effect.andThen(Deferred.await(release))),
+      ),
+    );
+    await Effect.runPromise(Deferred.await(acquired));
+
+    const harness = await createHarness({
+      commandEventTimeout: Duration.millis(500),
+      commandSettleGrace: Duration.zero,
+      commandLeaseAcquireTimeout: Duration.millis(40),
+      threadLease: coordinator.withThreadLease,
+    });
+    const now = new Date().toISOString();
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-held-lease"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-held-lease"),
+          role: "user",
+          text: "hello held lease",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+    await waitFor(async () =>
+      Boolean((await readHarnessThread(harness))?.session?.lastError?.includes("held thread")),
+    );
+    expect(harness.startSession.mock.calls.length).toBe(0);
+
+    Effect.runSync(Deferred.succeed(release, undefined));
+    await Effect.runPromise(Fiber.interrupt(holder).pipe(Effect.ignore));
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-after-release"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-after-release"),
+          role: "user",
+          text: "hello after release",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+  });
+
+  it("surfaces a goal continuation blocked by a held checkpoint lease", async () => {
+    const harness = await createHarness({
+      commandEventTimeout: Duration.millis(500),
+      commandSettleGrace: Duration.zero,
+      commandLeaseAcquireTimeout: Duration.millis(25),
+      threadLease: () => Effect.never,
+    });
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-goal-held-lease"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        goal: "Continue with a held checkpoint lease",
+      }),
+    );
+
+    await waitFor(async () =>
+      Boolean((await readHarnessThread(harness))?.session?.lastError?.includes("held thread")),
+    );
+    expect(harness.startSession.mock.calls.length).toBe(0);
+    expect(harness.sendTurn.mock.calls.length).toBe(0);
+  });
+
+  it("surfaces a rollback blocked by a held checkpoint lease", async () => {
+    const harness = await createHarness({
+      commandEventTimeout: Duration.millis(500),
+      commandSettleGrace: Duration.zero,
+      commandLeaseAcquireTimeout: Duration.millis(25),
+      threadLease: () => Effect.never,
+    });
+    const now = new Date().toISOString();
+    await seedRollbackTarget(harness, {
+      messageId: asMessageId("user-message-rollback-held-lease"),
+      turnId: asTurnId("turn-rollback-held-lease"),
+      createdAt: now,
+    });
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.conversation.rollback",
+        commandId: CommandId.makeUnsafe("cmd-rollback-held-lease"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        messageId: asMessageId("user-message-rollback-held-lease"),
+        numTurns: 1,
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(async () =>
+      Boolean((await readHarnessThread(harness))?.session?.lastError?.includes("held thread")),
+    );
+    expect(harness.rollbackConversation.mock.calls.length).toBe(0);
+  });
+
+  it("surfaces an edit resend blocked by a held checkpoint lease", async () => {
+    const harness = await createHarness({
+      commandEventTimeout: Duration.millis(500),
+      commandSettleGrace: Duration.zero,
+      commandLeaseAcquireTimeout: Duration.millis(25),
+      threadLease: () => Effect.never,
+    });
+    const now = new Date().toISOString();
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.messages.import",
+        commandId: CommandId.makeUnsafe("cmd-import-edit-held-lease"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        messages: [
+          {
+            messageId: asMessageId("user-message-edit-held-lease"),
+            role: "user",
+            text: "old prompt",
+            createdAt: now,
+            updatedAt: now,
+          },
+        ],
+        createdAt: now,
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.message.assistant.complete",
+        commandId: CommandId.makeUnsafe("cmd-assistant-edit-held-lease"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        messageId: asMessageId("assistant-edit-held-lease"),
+        turnId: asTurnId("turn-edit-held-lease"),
+        createdAt: now,
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.message.edit-and-resend",
+        commandId: CommandId.makeUnsafe("cmd-edit-and-resend-held-lease"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        messageId: asMessageId("user-message-edit-held-lease"),
+        text: "edited prompt",
+        runtimeMode: "approval-required",
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(async () =>
+      Boolean((await readHarnessThread(harness))?.session?.lastError?.includes("held thread")),
+    );
+    expect(harness.startSession.mock.calls.length).toBe(0);
+    expect(harness.sendTurn.mock.calls.length).toBe(0);
   });
 
   it("uses the runtime mode requested by thread.turn.start when starting the provider session", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -84,6 +84,10 @@ import { GitCore, type GitCoreShape } from "../../git/Services/GitCore.ts";
 import { TextGeneration, type TextGenerationShape } from "../../git/Services/TextGeneration.ts";
 import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
 import { TurnCheckpointCoordinatorLive } from "./TurnCheckpointCoordinator.ts";
+import {
+  TurnCheckpointCoordinator,
+  type TurnCheckpointCoordinatorShape,
+} from "../Services/TurnCheckpointCoordinator.ts";
 import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
 import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQuery.ts";
 import {
@@ -266,6 +270,8 @@ describe("ProviderCommandReactor", () => {
     readonly interruptTurn?: ProviderServiceShape["interruptTurn"];
     readonly commandEventTimeout?: Duration.Duration;
     readonly commandSettleGrace?: Duration.Duration;
+    readonly commandLeaseAcquireTimeout?: Duration.Duration;
+    readonly threadLease?: TurnCheckpointCoordinatorShape["withThreadLease"];
     readonly gatewayOperationId?: string;
     readonly gitWritingModelSelection?: ModelSelection;
     readonly omitStopRuntimeSession?: boolean;
@@ -625,10 +631,17 @@ describe("ProviderCommandReactor", () => {
       // Tests keep the settle grace at zero unless they exercise it explicitly,
       // so a hanging mock still settles on the primary deadline.
       commandSettleGrace: input?.commandSettleGrace ?? Duration.zero,
+      ...(input?.commandLeaseAcquireTimeout === undefined
+        ? {}
+        : { commandLeaseAcquireTimeout: input.commandLeaseAcquireTimeout }),
     }).pipe(
       Layer.provideMerge(orchestrationLayer),
       Layer.provideMerge(OrchestrationProjectionSnapshotQueryLive),
-      Layer.provideMerge(TurnCheckpointCoordinatorLive),
+      Layer.provideMerge(
+        input?.threadLease
+          ? Layer.succeed(TurnCheckpointCoordinator, { withThreadLease: input.threadLease })
+          : TurnCheckpointCoordinatorLive,
+      ),
       Layer.provideMerge(Layer.succeed(ProviderService, service)),
       Layer.provideMerge(
         Layer.succeed(ProviderHealth, {
@@ -7141,6 +7154,184 @@ describe("ProviderCommandReactor", () => {
     );
     expect(Option.isNone(blocking)).toBe(true);
     expect((await readHarnessThread(harness))?.session?.status).not.toBe("error");
+  });
+
+  it("rejects a startup failure inside a production-proportional settle grace", async () => {
+    const harness = await createHarness({
+      commandEventTimeout: Duration.millis(120),
+      commandSettleGrace: Duration.millis(80),
+    });
+    const now = new Date().toISOString();
+    harness.startSession.mockImplementationOnce(() =>
+      Effect.sleep(Duration.millis(120)).pipe(
+        Effect.andThen(
+          Effect.fail(
+            new ProviderAdapterValidationError({
+              provider: "codex",
+              operation: "ProviderService.startSession",
+              issue:
+                "Provider 'codex' did not finish starting within 60000ms for thread 'thread-1'.",
+            }),
+          ),
+        ),
+      ),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-proportional-grace"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-proportional-grace"),
+          role: "user",
+          text: "hello proportional grace",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    const events = await Effect.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((items) => Array.from(items)),
+      ),
+    );
+    const startEvent = events.find((event) => event.type === "thread.turn-start-requested");
+    expect(startEvent).toBeDefined();
+    await waitFor(async () => {
+      const delivery = await Effect.runPromise(
+        harness.deliveryRepository.getDelivery({
+          consumerName: PROVIDER_COMMAND_REACTOR_CONSUMER,
+          eventSequence: startEvent!.sequence,
+        }),
+      );
+      return Option.isSome(delivery) && delivery.value.state === "succeeded";
+    });
+    const blocking = await Effect.runPromise(
+      harness.deliveryRepository.firstBlockingDeliveryForThread({
+        consumerName: PROVIDER_COMMAND_REACTOR_CONSUMER,
+        threadId: "thread-1",
+      }),
+    );
+    expect(Option.isNone(blocking)).toBe(true);
+    expect(harness.sendTurn.mock.calls.length).toBe(0);
+  });
+
+  it("settles uncertain when a startup failure lands beyond the settle grace", async () => {
+    const harness = await createHarness({
+      commandEventTimeout: Duration.millis(120),
+      commandSettleGrace: Duration.millis(80),
+    });
+    const now = new Date().toISOString();
+    harness.startSession.mockImplementationOnce(() =>
+      Effect.sleep(Duration.millis(230)).pipe(
+        Effect.andThen(
+          Effect.fail(
+            new ProviderAdapterValidationError({
+              provider: "codex",
+              operation: "ProviderService.startSession",
+              issue:
+                "Provider 'codex' did not finish starting within 60000ms for thread 'thread-1'.",
+            }),
+          ),
+        ),
+      ),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-beyond-grace"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-beyond-grace"),
+          role: "user",
+          text: "hello beyond grace",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(async () => {
+      const blocking = await Effect.runPromise(
+        harness.deliveryRepository.firstBlockingDeliveryForThread({
+          consumerName: PROVIDER_COMMAND_REACTOR_CONSUMER,
+          threadId: "thread-1",
+        }),
+      );
+      return Option.isSome(blocking) && blocking.value.state === "uncertain";
+    });
+  });
+
+  it("rejects a turn start retryably when the thread checkpoint lease never frees", async () => {
+    const harness = await createHarness({
+      commandEventTimeout: Duration.millis(500),
+      commandSettleGrace: Duration.zero,
+      commandLeaseAcquireTimeout: Duration.millis(25),
+      threadLease: () => Effect.never,
+    });
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-stuck-lease"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-stuck-lease"),
+          role: "user",
+          text: "hello stuck lease",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    const events = await Effect.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((items) => Array.from(items)),
+      ),
+    );
+    const startEvent = events.find((event) => event.type === "thread.turn-start-requested");
+    expect(startEvent).toBeDefined();
+    await waitFor(async () => {
+      const delivery = await Effect.runPromise(
+        harness.deliveryRepository.getDelivery({
+          consumerName: PROVIDER_COMMAND_REACTOR_CONSUMER,
+          eventSequence: startEvent!.sequence,
+        }),
+      );
+      return Option.isSome(delivery) && delivery.value.state === "succeeded";
+    });
+    expect(harness.startSession.mock.calls.length).toBe(0);
+    expect(harness.sendTurn.mock.calls.length).toBe(0);
+    await waitFor(async () =>
+      Boolean((await readHarnessThread(harness))?.session?.lastError?.includes("held thread")),
+    );
+    await waitFor(async () =>
+      Boolean(
+        (await readHarnessThread(harness))?.activities.some(
+          (activity) =>
+            activity.kind === "provider.turn.start.failed" &&
+            (activity.payload as Record<string, unknown> | null)?.settlementStatus === "retryable",
+        ),
+      ),
+    );
+    const blocking = await Effect.runPromise(
+      harness.deliveryRepository.firstBlockingDeliveryForThread({
+        consumerName: PROVIDER_COMMAND_REACTOR_CONSUMER,
+        threadId: "thread-1",
+      }),
+    );
+    expect(Option.isNone(blocking)).toBe(true);
   });
 
   it("uses the runtime mode requested by thread.turn.start when starting the provider session", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -265,6 +265,7 @@ describe("ProviderCommandReactor", () => {
     readonly startReactor?: boolean;
     readonly interruptTurn?: ProviderServiceShape["interruptTurn"];
     readonly commandEventTimeout?: Duration.Duration;
+    readonly commandSettleGrace?: Duration.Duration;
     readonly gatewayOperationId?: string;
     readonly gitWritingModelSelection?: ModelSelection;
     readonly omitStopRuntimeSession?: boolean;
@@ -617,11 +618,14 @@ describe("ProviderCommandReactor", () => {
       Layer.provide(OrchestrationEventStoreLive),
       Layer.provide(OrchestrationCommandReceiptRepositoryLive),
     );
-    const layer = makeProviderCommandReactorLive(
-      input?.commandEventTimeout === undefined
-        ? undefined
-        : { commandEventTimeout: input.commandEventTimeout },
-    ).pipe(
+    const layer = makeProviderCommandReactorLive({
+      ...(input?.commandEventTimeout === undefined
+        ? {}
+        : { commandEventTimeout: input.commandEventTimeout }),
+      // Tests keep the settle grace at zero unless they exercise it explicitly,
+      // so a hanging mock still settles on the primary deadline.
+      commandSettleGrace: input?.commandSettleGrace ?? Duration.zero,
+    }).pipe(
       Layer.provideMerge(orchestrationLayer),
       Layer.provideMerge(OrchestrationProjectionSnapshotQueryLive),
       Layer.provideMerge(TurnCheckpointCoordinatorLive),
@@ -7015,6 +7019,128 @@ describe("ProviderCommandReactor", () => {
         ),
       ),
     );
+  });
+
+  it("recovers a startup failure that settles after the command deadline within the settle grace", async () => {
+    const harness = await createHarness({
+      commandEventTimeout: Duration.millis(25),
+      commandSettleGrace: Duration.millis(500),
+    });
+    const now = new Date().toISOString();
+    harness.startSession.mockImplementationOnce(() =>
+      Effect.sleep(Duration.millis(60)).pipe(
+        Effect.andThen(
+          Effect.fail(
+            new ProviderAdapterValidationError({
+              provider: "codex",
+              operation: "ProviderService.startSession",
+              issue:
+                "Provider 'codex' did not finish starting within 60000ms for thread 'thread-1'.",
+            }),
+          ),
+        ),
+      ),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-settles-after-deadline"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-settles-after-deadline"),
+          role: "user",
+          text: "hello late-failing provider",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    const events = await Effect.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((items) => Array.from(items)),
+      ),
+    );
+    const startEvent = events.find((event) => event.type === "thread.turn-start-requested");
+    expect(startEvent).toBeDefined();
+    await waitFor(async () => {
+      const delivery = await Effect.runPromise(
+        harness.deliveryRepository.getDelivery({
+          consumerName: PROVIDER_COMMAND_REACTOR_CONSUMER,
+          eventSequence: startEvent!.sequence,
+        }),
+      );
+      return Option.isSome(delivery) && delivery.value.state === "succeeded";
+    });
+
+    const blocking = await Effect.runPromise(
+      harness.deliveryRepository.firstBlockingDeliveryForThread({
+        consumerName: PROVIDER_COMMAND_REACTOR_CONSUMER,
+        threadId: "thread-1",
+      }),
+    );
+    expect(Option.isNone(blocking)).toBe(true);
+    expect(harness.sendTurn.mock.calls.length).toBe(0);
+    await waitFor(async () => (await readHarnessThread(harness))?.session?.status === "error");
+    expect((await readHarnessThread(harness))?.session?.activeTurnId).toBeNull();
+  });
+
+  it("honors a provider start that completes after the command deadline within the settle grace", async () => {
+    const harness = await createHarness({
+      commandEventTimeout: Duration.millis(25),
+      commandSettleGrace: Duration.millis(500),
+    });
+    const now = new Date().toISOString();
+    const defaultStartSession = harness.startSession.getMockImplementation();
+    harness.startSession.mockImplementationOnce((threadId, input) =>
+      Effect.sleep(Duration.millis(60)).pipe(Effect.andThen(defaultStartSession!(threadId, input))),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-completes-after-deadline"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-completes-after-deadline"),
+          role: "user",
+          text: "hello late provider",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    const events = await Effect.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((items) => Array.from(items)),
+      ),
+    );
+    const startEvent = events.find((event) => event.type === "thread.turn-start-requested");
+    expect(startEvent).toBeDefined();
+    await waitFor(async () => {
+      const delivery = await Effect.runPromise(
+        harness.deliveryRepository.getDelivery({
+          consumerName: PROVIDER_COMMAND_REACTOR_CONSUMER,
+          eventSequence: startEvent!.sequence,
+        }),
+      );
+      return Option.isSome(delivery) && delivery.value.state === "succeeded";
+    });
+    const blocking = await Effect.runPromise(
+      harness.deliveryRepository.firstBlockingDeliveryForThread({
+        consumerName: PROVIDER_COMMAND_REACTOR_CONSUMER,
+        threadId: "thread-1",
+      }),
+    );
+    expect(Option.isNone(blocking)).toBe(true);
+    expect((await readHarnessThread(harness))?.session?.status).not.toBe("error");
   });
 
   it("uses the runtime mode requested by thread.turn.start when starting the provider session", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -215,23 +215,37 @@ type BoundedProviderCallResult<E> =
     };
 
 /**
- * Runs a provider call under a hard deadline and reduces it to a decision.
- * A call that never returns cannot simply be awaited here: the caller holds the
- * reactor's single delivery permit, so waiting forever stalls every thread.
- * Interruption is re-raised untouched so shutdown still cancels cleanly.
+ * Runs a provider call under a hard deadline and reduces it to a decision. The
+ * call keeps running for the bounded settle grace past the deadline so an
+ * outcome that lands just late is still classified by what actually happened
+ * instead of being written off as uncertain. A call that never returns cannot
+ * simply be awaited here: the caller holds the reactor's single delivery
+ * permit, so waiting forever stalls every thread. Interruption is re-raised
+ * untouched so shutdown still cancels cleanly.
  */
 const runBoundedProviderCall = <E, R>(input: {
   readonly label: string;
   readonly timeout: Duration.Duration;
+  readonly settleGrace: Duration.Duration;
   readonly call: Effect.Effect<unknown, E, R>;
 }): Effect.Effect<BoundedProviderCallResult<E>, E, R> =>
   Effect.suspend(() => {
     let timedOut = false;
+    const startedAt = Date.now();
+    const timeoutMs = Duration.toMillis(input.timeout);
     return input.call.pipe(
-      Effect.timeoutOption(input.timeout),
+      Effect.timeoutOption(Duration.sum(input.timeout, input.settleGrace)),
       Effect.flatMap((result) =>
-        Effect.sync(() => {
+        Effect.gen(function* () {
           timedOut = Option.isNone(result);
+          const elapsedMs = Date.now() - startedAt;
+          if (!timedOut && elapsedMs > timeoutMs) {
+            yield* Effect.logInfo("provider command settled within its settle grace", {
+              label: input.label,
+              timeoutMs,
+              elapsedMs,
+            });
+          }
         }),
       ),
       Effect.exit,
@@ -445,6 +459,15 @@ const PROVIDER_COMMAND_SAFE_RETRY_DELAY = Duration.millis(50);
 const PROVIDER_COMMAND_INTERRUPT_TIMEOUT = Duration.seconds(10);
 const PROVIDER_COMMAND_STOP_TIMEOUT = Duration.seconds(15);
 const PROVIDER_COMMAND_EVENT_TIMEOUT = Duration.seconds(120);
+/**
+ * A provider call that settles just after its command deadline can still carry
+ * a definitive outcome: a bounded startup failure whose retirement outlived the
+ * deadline proves the command never ran. Waiting this short grace window before
+ * declaring the delivery uncertain keeps such recoveries from quarantining the
+ * thread, while a call that never returns still degrades into a terminal
+ * failure well before it could deadlock the single-permit delivery lock.
+ */
+const PROVIDER_COMMAND_SETTLE_GRACE = Duration.seconds(15);
 const GATEWAY_OPERATION_COMPLETION_WAIT_TIMEOUT = Duration.seconds(120);
 const PROVIDER_INPUT_SAFETY_MARGIN_CHARS = 1_000;
 const THREAD_MENTION_CONTEXT_SUFFIX_PREFIX_CHARS = 2;
@@ -674,10 +697,12 @@ function buildGeneratedWorktreeBranchName(raw: string): string {
 
 export interface ProviderCommandReactorLiveOptions {
   readonly commandEventTimeout?: Duration.Duration;
+  readonly commandSettleGrace?: Duration.Duration;
 }
 
 interface ProviderCommandReactorConfigShape {
   readonly commandEventTimeout: Duration.Duration;
+  readonly commandSettleGrace: Duration.Duration;
 }
 
 class ProviderCommandReactorConfig extends ServiceMap.Service<
@@ -686,7 +711,7 @@ class ProviderCommandReactorConfig extends ServiceMap.Service<
 >()("synara/orchestration/Layers/ProviderCommandReactorConfig") {}
 
 const make = Effect.gen(function* () {
-  const { commandEventTimeout } = yield* ProviderCommandReactorConfig;
+  const { commandEventTimeout, commandSettleGrace } = yield* ProviderCommandReactorConfig;
   const orchestrationEngine = yield* OrchestrationEngineService;
   const deliveryRepository = yield* OrchestrationEventDeliveryRepository;
   const turnCheckpointCoordinator = yield* TurnCheckpointCoordinator;
@@ -3754,6 +3779,7 @@ const make = Effect.gen(function* () {
     const result = yield* runBoundedProviderCall({
       label: "The provider interrupt",
       timeout: PROVIDER_COMMAND_INTERRUPT_TIMEOUT,
+      settleGrace: commandSettleGrace,
       call: providerService.interruptTurn({
         threadId: providerThread.id,
         ...(turnId ? { turnId } : {}),
@@ -4449,6 +4475,7 @@ const make = Effect.gen(function* () {
       const childInterrupt = yield* runBoundedProviderCall({
         label: "The provider interrupt",
         timeout: PROVIDER_COMMAND_INTERRUPT_TIMEOUT,
+        settleGrace: commandSettleGrace,
         call: providerService.interruptTurn({
           threadId: providerThread.id,
           turnId: thread.session.activeTurnId,
@@ -4515,6 +4542,7 @@ const make = Effect.gen(function* () {
         const stopped = yield* runBoundedProviderCall({
           label: "The provider session stop",
           timeout: PROVIDER_COMMAND_STOP_TIMEOUT,
+          settleGrace: commandSettleGrace,
           call: providerService.stopRuntimeSession({ threadId: providerThread.id }),
         });
         if (stopped._tag !== "ok") {
@@ -5130,12 +5158,14 @@ const make = Effect.gen(function* () {
         const workerResult = yield* runBoundedProviderCall({
           label: `The provider command '${event.type}'`,
           timeout: commandEventTimeout,
+          settleGrace: commandSettleGrace,
           call: processDomainEvent(event),
         });
         if (workerResult._tag === "timeout") {
           // The delivery lock is single-permit and process-wide, so an attempt
-          // that never returns is a total outage. Settle it as uncertain and
-          // let the thread quarantine rather than block every other thread.
+          // that never returns is a total outage. It has already run through
+          // the bounded settle grace, so settle it as uncertain and let the
+          // thread quarantine rather than block every other thread.
           if (event.type === "thread.turn-start-requested") {
             yield* surfaceTimedOutTurnStart(event, workerResult.detail).pipe(
               Effect.catchCause((cause) =>
@@ -5753,6 +5783,7 @@ export const makeProviderCommandReactorLive = (options?: ProviderCommandReactorL
     Layer.provide(
       Layer.succeed(ProviderCommandReactorConfig, {
         commandEventTimeout: options?.commandEventTimeout ?? PROVIDER_COMMAND_EVENT_TIMEOUT,
+        commandSettleGrace: options?.commandSettleGrace ?? PROVIDER_COMMAND_SETTLE_GRACE,
       }),
     ),
     Layer.provideMerge(OrchestrationEventDeliveryRepositoryLive),

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -36,6 +36,7 @@ import {
   Effect,
   Equal,
   Exit,
+  Fiber,
   Layer,
   Option,
   Queue,
@@ -468,6 +469,14 @@ const PROVIDER_COMMAND_EVENT_TIMEOUT = Duration.seconds(120);
  * failure well before it could deadlock the single-permit delivery lock.
  */
 const PROVIDER_COMMAND_SETTLE_GRACE = Duration.seconds(15);
+/**
+ * Provider intents take the per-thread checkpoint lease before they can start,
+ * and that lease is also held by checkpoint captures that park on slow git
+ * work. Bound only the acquisition: a command that cannot start within this
+ * window is rejected as retryable instead of silently consuming its delivery
+ * deadline and racing the provider startup timeout into a quarantine.
+ */
+const PROVIDER_COMMAND_LEASE_ACQUIRE_TIMEOUT = Duration.seconds(30);
 const GATEWAY_OPERATION_COMPLETION_WAIT_TIMEOUT = Duration.seconds(120);
 const PROVIDER_INPUT_SAFETY_MARGIN_CHARS = 1_000;
 const THREAD_MENTION_CONTEXT_SUFFIX_PREFIX_CHARS = 2;
@@ -698,11 +707,13 @@ function buildGeneratedWorktreeBranchName(raw: string): string {
 export interface ProviderCommandReactorLiveOptions {
   readonly commandEventTimeout?: Duration.Duration;
   readonly commandSettleGrace?: Duration.Duration;
+  readonly commandLeaseAcquireTimeout?: Duration.Duration;
 }
 
 interface ProviderCommandReactorConfigShape {
   readonly commandEventTimeout: Duration.Duration;
   readonly commandSettleGrace: Duration.Duration;
+  readonly commandLeaseAcquireTimeout: Duration.Duration;
 }
 
 class ProviderCommandReactorConfig extends ServiceMap.Service<
@@ -711,7 +722,8 @@ class ProviderCommandReactorConfig extends ServiceMap.Service<
 >()("synara/orchestration/Layers/ProviderCommandReactorConfig") {}
 
 const make = Effect.gen(function* () {
-  const { commandEventTimeout, commandSettleGrace } = yield* ProviderCommandReactorConfig;
+  const { commandEventTimeout, commandSettleGrace, commandLeaseAcquireTimeout } =
+    yield* ProviderCommandReactorConfig;
   const orchestrationEngine = yield* OrchestrationEngineService;
   const deliveryRepository = yield* OrchestrationEventDeliveryRepository;
   const turnCheckpointCoordinator = yield* TurnCheckpointCoordinator;
@@ -1371,10 +1383,63 @@ const make = Effect.gen(function* () {
   const resolveProviderSessionThread = (threadId: ThreadId) =>
     resolveProviderSessionThreadFromProjection(projectionSnapshotQuery, threadId);
 
-  const withProviderSessionLease = <A, E, R>(threadId: ThreadId, effect: Effect.Effect<A, E, R>) =>
+  const withProviderSessionLease = <A, E, R>(
+    threadId: ThreadId,
+    effect: Effect.Effect<A, E, R>,
+    options?: {
+      readonly onAcquireTimeout?: (input: {
+        readonly detail: string;
+        readonly provider: ProviderKind;
+      }) => Effect.Effect<unknown, unknown>;
+    },
+  ) =>
     resolveProviderSessionThread(threadId).pipe(
       Effect.flatMap((providerThread) =>
-        turnCheckpointCoordinator.withThreadLease(providerThread?.id ?? threadId, effect),
+        Effect.gen(function* () {
+          const leaseThreadId = providerThread?.id ?? threadId;
+          const acquired = yield* Deferred.make<void>();
+          const release = yield* Deferred.make<void>();
+          const leaseFiber = yield* Effect.forkChild(
+            turnCheckpointCoordinator.withThreadLease(
+              leaseThreadId,
+              Deferred.succeed(acquired, undefined).pipe(Effect.andThen(Deferred.await(release))),
+            ),
+            { startImmediately: true },
+          );
+          const handshake = yield* Deferred.await(acquired).pipe(
+            Effect.timeoutOption(commandLeaseAcquireTimeout),
+          );
+          if (Option.isNone(handshake)) {
+            yield* Fiber.interrupt(leaseFiber).pipe(Effect.ignore);
+            const detail = `Another checkpoint operation held thread '${leaseThreadId}' for more than ${Duration.toMillis(commandLeaseAcquireTimeout)}ms.`;
+            const projectedProvider = providerThread?.session?.providerName;
+            const thread = yield* resolveThread(threadId);
+            const provider: ProviderKind =
+              projectedProvider !== null &&
+              projectedProvider !== undefined &&
+              Schema.is(ProviderKind)(projectedProvider)
+                ? projectedProvider
+                : (thread?.modelSelection.provider ?? "codex");
+            if (options?.onAcquireTimeout !== undefined) {
+              yield* options.onAcquireTimeout({ detail, provider }).pipe(
+                Effect.catchCause((cause) =>
+                  Effect.logWarning("failed to surface a provider command lease timeout", {
+                    threadId,
+                    cause: Cause.pretty(cause),
+                  }),
+                ),
+              );
+            }
+            return yield* new ProviderAdapterValidationError({
+              provider,
+              operation: "provider.session.lease",
+              issue: detail,
+            });
+          }
+          return yield* effect.pipe(
+            Effect.ensuring(Deferred.succeed(release, undefined).pipe(Effect.ignore)),
+          );
+        }),
       ),
     );
 
@@ -3259,7 +3324,30 @@ const make = Effect.gen(function* () {
   const processTurnStartRequested = (
     event: Extract<ProviderIntentEvent, { type: "thread.turn-start-requested" }>,
   ) =>
-    withProviderSessionLease(event.payload.threadId, processTurnStartRequestedWithoutLease(event));
+    withProviderSessionLease(event.payload.threadId, processTurnStartRequestedWithoutLease(event), {
+      onAcquireTimeout: ({ detail }) =>
+        Effect.gen(function* () {
+          const createdAt = new Date().toISOString();
+          yield* appendProviderFailureActivity({
+            threadId: event.payload.threadId,
+            kind: "provider.turn.start.failed",
+            summary: "Provider turn start blocked by a checkpoint operation",
+            detail,
+            turnId: null,
+            createdAt,
+            settlementStatus: "retryable",
+          });
+          const thread = yield* resolveThread(event.payload.threadId);
+          if (thread && thread.session?.activeTurnId == null) {
+            yield* setThreadSessionError({
+              threadId: event.payload.threadId,
+              runtimeMode: event.payload.runtimeMode,
+              detail,
+              createdAt,
+            });
+          }
+        }),
+    });
 
   const processTurnQueued = Effect.fnUntraced(function* (
     event: Extract<ProviderIntentEvent, { type: "thread.turn-queued" }>,
@@ -5784,6 +5872,8 @@ export const makeProviderCommandReactorLive = (options?: ProviderCommandReactorL
       Layer.succeed(ProviderCommandReactorConfig, {
         commandEventTimeout: options?.commandEventTimeout ?? PROVIDER_COMMAND_EVENT_TIMEOUT,
         commandSettleGrace: options?.commandSettleGrace ?? PROVIDER_COMMAND_SETTLE_GRACE,
+        commandLeaseAcquireTimeout:
+          options?.commandLeaseAcquireTimeout ?? PROVIDER_COMMAND_LEASE_ACQUIRE_TIMEOUT,
       }),
     ),
     Layer.provideMerge(OrchestrationEventDeliveryRepositoryLive),

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -3759,6 +3759,30 @@ const make = Effect.gen(function* () {
           });
         }
       }),
+      {
+        onAcquireTimeout: ({ detail }) =>
+          Effect.gen(function* () {
+            const createdAt = new Date().toISOString();
+            yield* appendProviderFailureActivity({
+              threadId: event.payload.threadId,
+              kind: "provider.turn.start.failed",
+              summary: "Goal continuation blocked by a checkpoint operation",
+              detail,
+              turnId: null,
+              createdAt,
+              settlementStatus: "retryable",
+            });
+            const thread = yield* resolveThread(event.payload.threadId);
+            if (thread && thread.session?.activeTurnId == null) {
+              yield* setThreadSessionError({
+                threadId: event.payload.threadId,
+                runtimeMode: thread.runtimeMode,
+                detail,
+                createdAt,
+              });
+            }
+          }),
+      },
     );
 
   const processQueueDrainEvent = Effect.fnUntraced(function* (event: ProviderQueueDrainEvent) {
@@ -4256,6 +4280,21 @@ const make = Effect.gen(function* () {
     withProviderSessionLease(
       event.payload.threadId,
       processConversationRollbackRequestedWithoutLease(event),
+      {
+        onAcquireTimeout: ({ detail }) =>
+          Effect.gen(function* () {
+            const createdAt = new Date().toISOString();
+            const thread = yield* resolveThread(event.payload.threadId);
+            if (thread && thread.session?.activeTurnId == null) {
+              yield* setThreadSessionError({
+                threadId: event.payload.threadId,
+                runtimeMode: thread.runtimeMode,
+                detail,
+                createdAt,
+              });
+            }
+          }),
+      },
     );
 
   const processMessageEditResendPayload = Effect.fnUntraced(function* (


### PR DESCRIPTION
## Problem

A provider command that exceeds its delivery deadline is settled as `uncertain`, and that quarantines the thread: every later `thread.turn-start-requested` for the thread is skipped until someone uses **Unblock thread**.

Observed on installed v0.8.3 (opencode provider, dedicated automation thread):

- `13:56:21Z` — `thread.turn-start-requested` (event 1132769) dispatched.
- `14:34:59Z` — `provider session start exceeded its deadline` (`HandshakeTimeout`, 60s deadline): a confirmed startup failure.
- `14:35:07Z` — the outer 120s command deadline expired while the bounded 10s retirement (`adapter.stopSession`) was still running, so `runBoundedProviderCall` reported `timeout` and the delivery settled `uncertain`.

Constants involved: `PROVIDER_COMMAND_EVENT_TIMEOUT` 120s, `PROVIDER_START_SESSION_TIMEOUT` 60s, `PROVIDER_STOP_SESSION_TIMEOUT` 10s.

## Fix

**1. Bounded settle grace.** `runBoundedProviderCall` now lets the call run for a bounded **settle grace** (`PROVIDER_COMMAND_SETTLE_GRACE`, 15s) past its deadline. An outcome that lands inside that window is classified by what actually happened instead of being written off as `uncertain`:

- a late startup rejection (`ProviderAdapterValidationError` etc.) completes the delivery without quarantining the thread;
- a late acceptance proceeds normally;
- a call that never returns still settles `timeout` → `uncertain`, preserving the existing quarantine guarantee and the single-permit stall bound.

**2. Bounded checkpoint lease acquisition (TASK-10 evidence).** Tracing the missing time budget found an unbounded prelude: `withProviderSessionLease` acquired the per-thread checkpoint lease through a plain semaphore with **no acquisition timeout**, while checkpoint captures can park on slow git work (the revert path already bounds its own acquisition at 15s). Provider intents now bound only the acquisition (`PROVIDER_COMMAND_LEASE_ACQUIRE_TIMEOUT`, 30s, configurable for tests); a command that cannot start within the window fails as a **retryable rejection**, so the delivery completes instead of quarantining.

**3. Visible per-intent outcome (correction-cycle Δ4).** All four leased intents now surface a held lease: turn start and goal continuation append `provider.turn.start.failed` with `settlementStatus: "retryable"` plus a session error, rollback sets the session error, and edit resend surfaces through its existing handler. No leased intent fails silently.

## Tests

- `bun run --cwd apps/server test src/orchestration/Layers/ProviderCommandReactor.test.ts` → **246/246 pass**, including:
  - a startup failure that settles after the command deadline within the grace completes the delivery and does not block the thread;
  - a provider start that completes after the deadline within the grace still dispatches the turn;
  - a startup failure beyond the grace still settles `uncertain` (quarantine preserved);
  - a stuck-lease turn start is rejected retryably without touching the provider;
  - a **real-coordinator** test that holds the live checkpoint lease, observes the retryable rejection, releases the lease, and then sees the next turn start start the session and dispatch;
  - held-lease surfacing tests for goal continuation, rollback, and edit resend.
- `bun run --cwd apps/server typecheck` → clean. `bun run lint` → 0 errors (pre-existing warnings only).
- `bun run fmt:check` cannot run cleanly on this Windows checkout: `core.autocrlf=true` makes every file CRLF, so oxfmt flags all files including untouched ones. Formatted-copy comparison (`oxfmt` on a temp copy + `git diff --ignore-cr-at-eol`) shows both changed files are format-clean apart from line endings.

## Caveats

- The grace is a bounded mitigation, not a proof: other prelude work (e.g. live-session lookups) could still consume the whole budget; the lease was the confirmed unbounded component, and the deadline hierarchy itself is unchanged.
- The 30s lease window is a candidate, not a measured sufficiency: the correction-cycle arbitration asked for a full phase budget (prelude/start/cleanup) before accepting the source; that tracing remains a follow-up gate.
- The 120ms/80ms grace test covers the inside-window semantics; it does not claim production proportionality (120s/15s would be 120ms/15ms). Tight-ratio coverage needs clock control that the current harness does not provide.
- The full server suite was not run locally; the complete reactor suite and server typecheck passed, and CI covers the wider lanes.
