### PR TITLE
fix(github): preserve unlinked commit authors in PR details (repair for #1067)

### DIFF
--- a/apps/server/src/git/Layers/GitHubCli.test.ts
+++ b/apps/server/src/git/Layers/GitHubCli.test.ts
@@ -1080,6 +1080,202 @@ layer("GitHubCliLive", (it) => {
     }),
   );
 
+  for (const { label, login } of [
+    { label: "empty", login: "" },
+    { label: "null", login: null },
+    { label: "whitespace-only", login: " \t " },
+    { label: "missing", login: undefined },
+  ]) {
+    it.effect(`tolerates commit authors with ${label} GitHub login`, () =>
+      Effect.gen(function* () {
+        mockedRunProcess.mockResolvedValueOnce({
+          stdout: JSON.stringify({
+            number: 1016,
+            title: "fix(models): normalize provider model display names",
+            url: "https://github.com/acme/app/pull/1016",
+            headRefName: "fix/normalize-model-display-names",
+            baseRefName: "main",
+            state: "MERGED",
+            mergedAt: "2026-09-08T13:33:01Z",
+            createdAt: "2026-09-07T05:30:14Z",
+            updatedAt: "2026-09-08T13:33:01Z",
+            commits: [
+              {
+                oid: "31967670e7d8ac8e6271187cf91e3d08ed48dc96",
+                messageHeadline: "fix(models): normalize provider model display names",
+                committedDate: "2026-09-07T05:16:29Z",
+                authors: [
+                  { login: " SHLE1 ", name: " SHLE1 " },
+                  {
+                    login,
+                    name: " Local co-author ",
+                    avatarUrl: "https://avatars.githubusercontent.com/unrelated",
+                    url: "https://github.com/unrelated",
+                  },
+                  { login, name: " ", slug: "not-a-user" },
+                ],
+              },
+              {
+                oid: "5a554f9e40043fba3184182c22f7f4bab617fc19",
+                messageHeadline: "fix(models): ignore inherited display-name tokens",
+                committedDate: "2026-09-08T13:18:37Z",
+                // `gh` emits empty-string logins for local-git authors with no
+                // GitHub account. This must not fail the whole detail payload.
+                authors: [{ id: "", login, name: "Emanuele Di Pietro" }],
+              },
+            ],
+          }),
+          stderr: "",
+          code: 0,
+          signal: null,
+          timedOut: false,
+        });
+        const gh = yield* GitHubCli;
+        const detail = yield* gh.getPullRequestDetail({
+          cwd: "/repo",
+          repository: "acme/app",
+          number: 1016,
+        });
+        assert.equal(detail.commits[1]?.oid, "5a554f9e40043fba3184182c22f7f4bab617fc19");
+        assert.equal(
+          detail.commits[1]?.messageHeadline,
+          "fix(models): ignore inherited display-name tokens",
+        );
+        assert.deepStrictEqual(
+          detail.commits.map((commit) => commit.authors),
+          [
+            [
+              {
+                login: "SHLE1",
+                name: "SHLE1",
+                avatarUrl: "https://avatars.githubusercontent.com/SHLE1?size=64",
+                url: "https://github.com/SHLE1",
+              },
+              { login: null, name: "Local co-author", avatarUrl: null, url: null },
+            ],
+            [{ login: null, name: "Emanuele Di Pietro", avatarUrl: null, url: null }],
+          ],
+        );
+      }),
+    );
+  }
+
+  for (const invalidAuthor of [{ login: 123 }, { login: null, name: false }]) {
+    it.effect(`rejects malformed commit author ${JSON.stringify(invalidAuthor)}`, () =>
+      Effect.gen(function* () {
+        mockedRunProcess.mockResolvedValueOnce({
+          stdout: JSON.stringify({
+            number: 9,
+            title: "Malformed author",
+            url: "https://github.com/acme/app/pull/9",
+            headRefName: "malformed-author",
+            baseRefName: "main",
+            createdAt: "2026-07-01T00:00:00Z",
+            updatedAt: "2026-07-02T00:00:00Z",
+            commits: [
+              {
+                oid: "abc123",
+                committedDate: "2026-07-01T00:00:00Z",
+                authors: [invalidAuthor],
+              },
+            ],
+          }),
+          stderr: "",
+          code: 0,
+          signal: null,
+          timedOut: false,
+        });
+        const gh = yield* GitHubCli;
+        const error = yield* gh.getPullRequestDetail({
+          cwd: "/repo",
+          repository: "acme/app",
+          number: 9,
+        }).pipe(Effect.flip);
+        expect(error.detail).toContain("invalid pull request detail JSON");
+      }),
+    );
+  }
+
+  it.effect("normalizes nullable actors without losing comments or treating teams as users", () =>
+    Effect.gen(function* () {
+      mockedRunProcess.mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          number: 9,
+          title: "Nullable actors",
+          url: "https://github.com/acme/app/pull/9",
+          headRefName: "nullable-actors",
+          baseRefName: "main",
+          createdAt: "2026-07-01T00:00:00Z",
+          updatedAt: "2026-07-02T00:00:00Z",
+          author: { login: null, slug: null, name: "Local author" },
+          reviewRequests: [
+            { login: " reviewer ", slug: "unused" },
+            { __typename: "Team", login: "", slug: " platform " },
+            { __typename: "Team", login: null, slug: "security" },
+            { __typename: "Team", login: " \t ", slug: "infra" },
+            { login: "", slug: "" },
+            { login: null, slug: null },
+            { login: " \t ", slug: " \t " },
+            {},
+          ],
+          comments: [
+            {
+              id: "comment",
+              body: "Keep this comment",
+              createdAt: "2026-07-01T01:00:00Z",
+              author: { login: "", name: "Former user" },
+            },
+          ],
+          reviews: [
+            {
+              id: "review",
+              body: "Keep this review",
+              submittedAt: "2026-07-01T02:00:00Z",
+              state: "APPROVED",
+              author: { login: " \t " },
+            },
+          ],
+        }),
+        stderr: "",
+        code: 0,
+        signal: null,
+        timedOut: false,
+      });
+      const gh = yield* GitHubCli;
+      const detail = yield* gh.getPullRequestDetail({
+        cwd: "/repo",
+        repository: "acme/app",
+        number: 9,
+      });
+
+      assert.equal(detail.author, null);
+      assert.deepStrictEqual(detail.reviewRequestLogins, ["reviewer"]);
+      assert.deepStrictEqual(detail.reviewers, [
+        {
+          login: "reviewer",
+          name: null,
+          avatarUrl: "https://avatars.githubusercontent.com/reviewer?size=64",
+          url: null,
+        },
+        { login: "platform", name: null, avatarUrl: null, url: null },
+        { login: "security", name: null, avatarUrl: null, url: null },
+        { login: "infra", name: null, avatarUrl: null, url: null },
+      ]);
+      assert.deepStrictEqual(
+        detail.comments.map(({ id, body, author, reviewState }) => ({
+          id,
+          body,
+          author,
+          reviewState,
+        })),
+        [
+          { id: "comment", body: "Keep this comment", author: null, reviewState: null },
+          { id: "review", body: "Keep this review", author: null, reviewState: "APPROVED" },
+        ],
+      );
+    }),
+  );
+
   it.effect("loads bounded diffs and runs merge actions", () =>
     Effect.gen(function* () {
       mockedRunProcess

--- a/apps/server/src/git/Layers/GitHubCli.test.ts
+++ b/apps/server/src/git/Layers/GitHubCli.test.ts
@@ -1160,6 +1160,47 @@ layer("GitHubCliLive", (it) => {
     );
   }
 
+  it.effect("does not synthesize profile links for GitHub App commit authors", () =>
+    Effect.gen(function* () {
+      mockedRunProcess.mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          number: 17,
+          title: "App-authored commit",
+          url: "https://github.com/acme/app/pull/17",
+          headRefName: "app-commit",
+          baseRefName: "main",
+          createdAt: "2026-07-01T00:00:00Z",
+          updatedAt: "2026-07-02T00:00:00Z",
+          commits: [
+            {
+              oid: "app123",
+              committedDate: "2026-07-01T00:00:00Z",
+              authors: [{ login: "app/dependabot", name: "dependabot[bot]" }],
+            },
+          ],
+        }),
+        stderr: "",
+        code: 0,
+        signal: null,
+        timedOut: false,
+      });
+      const gh = yield* GitHubCli;
+      const detail = yield* gh.getPullRequestDetail({
+        cwd: "/repo",
+        repository: "acme/app",
+        number: 17,
+      });
+      assert.deepStrictEqual(detail.commits[0]?.authors, [
+        {
+          login: "app/dependabot",
+          name: "dependabot[bot]",
+          avatarUrl: null,
+          url: null,
+        },
+      ]);
+    }),
+  );
+
   for (const invalidAuthor of [{ login: 123 }, { login: null, name: false }]) {
     it.effect(`rejects malformed commit author ${JSON.stringify(invalidAuthor)}`, () =>
       Effect.gen(function* () {
@@ -1196,7 +1237,7 @@ layer("GitHubCliLive", (it) => {
     );
   }
 
-  it.effect("normalizes nullable actors without losing comments or treating teams as users", () =>
+  it.effect("normalizes actors without losing comments or treating teams as users", () =>
     Effect.gen(function* () {
       mockedRunProcess.mockResolvedValueOnce({
         stdout: JSON.stringify({
@@ -1207,23 +1248,19 @@ layer("GitHubCliLive", (it) => {
           baseRefName: "main",
           createdAt: "2026-07-01T00:00:00Z",
           updatedAt: "2026-07-02T00:00:00Z",
-          author: { login: null, slug: null, name: "Local author" },
+          author: { login: "local-author", name: "Local author" },
           reviewRequests: [
             { login: " reviewer ", slug: "unused" },
-            { __typename: "Team", login: "", slug: " platform " },
-            { __typename: "Team", login: null, slug: "security" },
-            { __typename: "Team", login: " \t ", slug: "infra" },
-            { login: "", slug: "" },
-            { login: null, slug: null },
-            { login: " \t ", slug: " \t " },
-            {},
+            { __typename: "Team", slug: " platform " },
+            { __typename: "Team", slug: "security" },
+            { __typename: "Team", slug: "infra" },
           ],
           comments: [
             {
               id: "comment",
               body: "Keep this comment",
               createdAt: "2026-07-01T01:00:00Z",
-              author: { login: "", name: "Former user" },
+              author: { login: "former-user", name: "Former user" },
             },
           ],
           reviews: [
@@ -1232,7 +1269,7 @@ layer("GitHubCliLive", (it) => {
               body: "Keep this review",
               submittedAt: "2026-07-01T02:00:00Z",
               state: "APPROVED",
-              author: { login: " \t " },
+              author: { login: "reviewer" },
             },
           ],
         }),
@@ -1248,7 +1285,7 @@ layer("GitHubCliLive", (it) => {
         number: 9,
       });
 
-      assert.equal(detail.author, null);
+      assert.equal(detail.author?.login, "local-author");
       assert.deepStrictEqual(detail.reviewRequestLogins, ["reviewer"]);
       assert.deepStrictEqual(detail.reviewers, [
         {
@@ -1269,8 +1306,28 @@ layer("GitHubCliLive", (it) => {
           reviewState,
         })),
         [
-          { id: "comment", body: "Keep this comment", author: null, reviewState: null },
-          { id: "review", body: "Keep this review", author: null, reviewState: "APPROVED" },
+          {
+            id: "comment",
+            body: "Keep this comment",
+            author: {
+              login: "former-user",
+              name: "Former user",
+              avatarUrl: "https://avatars.githubusercontent.com/former-user?size=64",
+              url: null,
+            },
+            reviewState: null,
+          },
+          {
+            id: "review",
+            body: "Keep this review",
+            author: {
+              login: "reviewer",
+              name: null,
+              avatarUrl: "https://avatars.githubusercontent.com/reviewer?size=64",
+              url: null,
+            },
+            reviewState: "APPROVED",
+          },
         ],
       );
     }),

--- a/apps/server/src/git/Layers/GitHubCli.ts
+++ b/apps/server/src/git/Layers/GitHubCli.ts
@@ -9,6 +9,7 @@ import {
   type PullRequestCheck,
   type PullRequestComment,
   type PullRequestCommit,
+  type PullRequestCommitAuthor,
   type PullRequestLabel,
   type PullRequestMergeCapabilities,
   type PullRequestStack,
@@ -193,8 +194,11 @@ const RawPullRequestChecksSchema = Schema.Struct({
 
 const RawActorSchema = Schema.Struct({
   __typename: Schema.optional(Schema.NullOr(Schema.String)),
-  login: Schema.optional(TrimmedNonEmptyString),
-  slug: Schema.optional(TrimmedNonEmptyString),
+  // `gh pr view --json` emits `login: ""` (and `id: ""`) for commit authors that
+  // have no GitHub account (e.g. a local `git config user.name` commit). These
+  // must decode as "no login" instead of failing the whole PR detail payload.
+  login: Schema.optional(Schema.NullOr(Schema.String)),
+  slug: Schema.optional(Schema.NullOr(Schema.String)),
   name: Schema.optional(Schema.NullOr(Schema.String)),
   avatarUrl: Schema.optional(Schema.NullOr(Schema.String)),
   url: Schema.optional(Schema.NullOr(Schema.String)),
@@ -639,16 +643,31 @@ function normalizeActor(
   raw: Schema.Schema.Type<typeof RawActorSchema> | null | undefined,
 ): PullRequestActor | null {
   if (!raw) return null;
-  const login = raw.login ?? raw.slug;
+  const login = raw.login?.trim() || raw.slug?.trim() || null;
   if (!login) return null;
+  const rawLogin = raw.login?.trim() || null;
   return {
     login,
     name: raw.name?.trim() || null,
     // gh's JSON never includes avatar URLs, so derive the canonical login-addressed one —
     // but only from a real user login. A team's slug is not a username, and deriving from it
     // could show an unrelated user who happens to share the name.
-    avatarUrl: raw.avatarUrl?.trim() || (raw.login ? githubAvatarUrlForLogin(raw.login) : null),
+    avatarUrl: raw.avatarUrl?.trim() || (rawLogin ? githubAvatarUrlForLogin(rawLogin) : null),
     url: raw.url?.trim() || null,
+  };
+}
+
+function normalizeCommitAuthor(
+  raw: Schema.Schema.Type<typeof RawActorSchema>,
+): PullRequestCommitAuthor | null {
+  const login = raw.login?.trim() || null;
+  const name = raw.name?.trim() || null;
+  if (!login && !name) return null;
+  return {
+    login,
+    name,
+    avatarUrl: login ? raw.avatarUrl?.trim() || githubAvatarUrlForLogin(login) : null,
+    url: login ? raw.url?.trim() || `https://github.com/${encodeURIComponent(login)}` : null,
   };
 }
 
@@ -681,9 +700,10 @@ function normalizePullRequestListItem(
     reviewDecision: raw.reviewDecision?.trim() || null,
     // Only User review requests have a login. A Team slug is not a viewer identity and
     // comparing it with the current user's login would create false-positive badges.
-    reviewRequestLogins: (raw.reviewRequests ?? []).flatMap((actor) =>
-      actor.login ? [actor.login] : [],
-    ),
+    reviewRequestLogins: (raw.reviewRequests ?? []).flatMap((actor) => {
+      const login = actor.login?.trim() || null;
+      return login ? [login] : [];
+    }),
     labels: normalizeLabels(raw.labels),
     mergeability: normalizePullRequestMergeability(raw.mergeable),
     stack: null,
@@ -778,7 +798,7 @@ function normalizePullRequestDetail(
         messageBody: commit.messageBody ?? "",
         committedDate: commit.committedDate,
         authors: (commit.authors ?? []).flatMap((actor) => {
-          const normalized = normalizeActor(actor);
+          const normalized = normalizeCommitAuthor(actor);
           return normalized ? [normalized] : [];
         }),
       }),

--- a/apps/server/src/git/Layers/GitHubCli.ts
+++ b/apps/server/src/git/Layers/GitHubCli.ts
@@ -194,11 +194,19 @@ const RawPullRequestChecksSchema = Schema.Struct({
 
 const RawActorSchema = Schema.Struct({
   __typename: Schema.optional(Schema.NullOr(Schema.String)),
-  // `gh pr view --json` emits `login: ""` (and `id: ""`) for commit authors that
-  // have no GitHub account (e.g. a local `git config user.name` commit). These
-  // must decode as "no login" instead of failing the whole PR detail payload.
+  login: Schema.optional(TrimmedNonEmptyString),
+  slug: Schema.optional(TrimmedNonEmptyString),
+  name: Schema.optional(Schema.NullOr(Schema.String)),
+  avatarUrl: Schema.optional(Schema.NullOr(Schema.String)),
+  url: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
+// Commit authors are the one GitHub actor shape that may be anonymous. `gh`
+// emits empty or null logins for commits authored with a local git identity;
+// keep that exception local to commits so PR users, reviewers, and comments
+// continue to reject malformed actor payloads.
+const RawCommitAuthorSchema = Schema.Struct({
   login: Schema.optional(Schema.NullOr(Schema.String)),
-  slug: Schema.optional(Schema.NullOr(Schema.String)),
   name: Schema.optional(Schema.NullOr(Schema.String)),
   avatarUrl: Schema.optional(Schema.NullOr(Schema.String)),
   url: Schema.optional(Schema.NullOr(Schema.String)),
@@ -233,7 +241,7 @@ const RawCommitSchema = Schema.Struct({
   messageHeadline: Schema.optional(Schema.NullOr(Schema.String)),
   messageBody: Schema.optional(Schema.NullOr(Schema.String)),
   committedDate: TrimmedNonEmptyString,
-  authors: Schema.optional(Schema.NullOr(Schema.Array(RawActorSchema))),
+  authors: Schema.optional(Schema.NullOr(Schema.Array(RawCommitAuthorSchema))),
 });
 
 const RawRepositoryMergeCapabilitiesSchema = Schema.Struct({
@@ -658,7 +666,7 @@ function normalizeActor(
 }
 
 function normalizeCommitAuthor(
-  raw: Schema.Schema.Type<typeof RawActorSchema>,
+  raw: Schema.Schema.Type<typeof RawCommitAuthorSchema>,
 ): PullRequestCommitAuthor | null {
   const login = raw.login?.trim() || null;
   const name = raw.name?.trim() || null;
@@ -667,7 +675,10 @@ function normalizeCommitAuthor(
     login,
     name,
     avatarUrl: login ? raw.avatarUrl?.trim() || githubAvatarUrlForLogin(login) : null,
-    url: login ? raw.url?.trim() || `https://github.com/${encodeURIComponent(login)}` : null,
+    url: login
+      ? raw.url?.trim() ||
+        (login.startsWith("app/") ? null : `https://github.com/${encodeURIComponent(login)}`)
+      : null,
   };
 }
 
@@ -701,6 +712,7 @@ function normalizePullRequestListItem(
     // Only User review requests have a login. A Team slug is not a viewer identity and
     // comparing it with the current user's login would create false-positive badges.
     reviewRequestLogins: (raw.reviewRequests ?? []).flatMap((actor) => {
+      if (actor.__typename === "Team") return [];
       const login = actor.login?.trim() || null;
       return login ? [login] : [];
     }),

--- a/apps/server/src/wsCompatibility.test.ts
+++ b/apps/server/src/wsCompatibility.test.ts
@@ -66,6 +66,23 @@ describe("WebSocket compatibility bootstrap", () => {
     ).toBeNull();
   });
 
+  it("rejects revision-one clients after the commit-author wire shape change", async () => {
+    const error = await Effect.runPromise(
+      negotiateWsCompatibility({
+        protocolEpoch: WS_PROTOCOL_EPOCH,
+        minRevision: 1,
+        maxRevision: 1,
+        clientBuild: "stale-client",
+        requiredCapabilities: [],
+      }).pipe(Effect.flip),
+    );
+
+    expect(error).toMatchObject({
+      code: "WS_PROTOCOL_INCOMPATIBLE",
+      action: "update-client",
+    });
+  });
+
   it("rejects a missing required capability with terminal server-update guidance", async () => {
     const error = await Effect.runPromise(
       negotiateWsCompatibility({

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.test.ts
@@ -99,6 +99,20 @@ describe("buildPullRequestTimelineEvents", () => {
     expect(titles).toContain("reviewer commented");
   });
 
+  it("surfaces preserved commit author names in the timeline", () => {
+    const events = buildPullRequestTimelineEvents({
+      ...makeTimelineSource(),
+      commits: [
+        makeCommit({
+          authors: [{ login: null, name: "Local author", avatarUrl: null, url: null }],
+        }),
+      ],
+    });
+    expect(events.find((event) => event.id === "abcdef1234567890")?.title).toBe(
+      "Commit abcdef1 by Local author",
+    );
+  });
+
   it("falls back to placeholders for missing authors and empty commit messages", () => {
     const events = buildPullRequestTimelineEvents({
       ...makeTimelineSource(),

--- a/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
+++ b/apps/web/src/components/pullRequest/pullRequestDetail.logic.ts
@@ -90,7 +90,13 @@ export function buildPullRequestTimelineEvents(
     ...detail.commits.map((commit) => ({
       id: commit.oid,
       at: commit.committedDate,
-      title: `Commit ${commit.oid.slice(0, 7)}`,
+      title: (() => {
+        const author = commit.authors.find((candidate) => candidate.name?.trim() || candidate.login);
+        const authorLabel = author?.name?.trim() || author?.login;
+        return authorLabel
+          ? `Commit ${commit.oid.slice(0, 7)} by ${authorLabel}`
+          : `Commit ${commit.oid.slice(0, 7)}`;
+      })(),
       body: commit.messageHeadline || "No commit message.",
     })),
     ...detail.comments.map((comment) => ({

--- a/packages/contracts/src/pullRequests.test.ts
+++ b/packages/contracts/src/pullRequests.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import { Schema } from "effect";
 
 import {
+  PullRequestActor,
+  PullRequestCommit,
+  PullRequestCommitAuthor,
   PullRequestCommentInput,
   PullRequestActionResult,
   PullRequestDetail,
@@ -18,6 +21,36 @@ const decodeReviewRequestCountResult = Schema.decodeUnknownSync(
   PullRequestReviewRequestCountResult,
 );
 const decodeActionResult = Schema.decodeUnknownSync(PullRequestActionResult);
+
+describe("PullRequestCommitAuthor", () => {
+  const decodeAuthor = Schema.decodeUnknownSync(PullRequestCommitAuthor);
+  const localAuthor = {
+    login: null,
+    name: "Local author",
+    avatarUrl: null,
+    url: null,
+  };
+
+  it("preserves name-only authors through the commit wire contract", () => {
+    const commit = Schema.decodeUnknownSync(PullRequestCommit)({
+      oid: "abc123",
+      messageHeadline: "Keep local author",
+      messageBody: "",
+      committedDate: "2026-09-08T13:18:37Z",
+      authors: [localAuthor],
+    });
+    expect(commit.authors).toEqual([localAuthor]);
+    expect(() => Schema.decodeUnknownSync(PullRequestActor)(localAuthor)).toThrow();
+  });
+
+  it.each(["", "   ", 123, false, {}])("rejects invalid login %j", (login) => {
+    expect(() => decodeAuthor({ ...localAuthor, login })).toThrow();
+  });
+
+  it("rejects non-string names", () => {
+    expect(() => decodeAuthor({ ...localAuthor, name: 123 })).toThrow();
+  });
+});
 
 function listEntry() {
   return {

--- a/packages/contracts/src/pullRequests.ts
+++ b/packages/contracts/src/pullRequests.ts
@@ -29,6 +29,14 @@ export const PullRequestActor = Schema.Struct({
 });
 export type PullRequestActor = typeof PullRequestActor.Type;
 
+export const PullRequestCommitAuthor = Schema.Struct({
+  login: Schema.NullOr(TrimmedNonEmptyString),
+  name: Schema.NullOr(Schema.String),
+  avatarUrl: Schema.NullOr(Schema.String),
+  url: Schema.NullOr(Schema.String),
+});
+export type PullRequestCommitAuthor = typeof PullRequestCommitAuthor.Type;
+
 export const PullRequestLabel = Schema.Struct({
   name: TrimmedNonEmptyString,
   color: Schema.NullOr(Schema.String),
@@ -80,7 +88,7 @@ export const PullRequestCommit = Schema.Struct({
   messageHeadline: Schema.String,
   messageBody: Schema.String,
   committedDate: IsoDateTime,
-  authors: Schema.Array(PullRequestActor),
+  authors: Schema.Array(PullRequestCommitAuthor),
 });
 export type PullRequestCommit = typeof PullRequestCommit.Type;
 

--- a/packages/contracts/src/wsCompatibility.ts
+++ b/packages/contracts/src/wsCompatibility.ts
@@ -3,8 +3,11 @@ import { Schema } from "effect";
 import { NonNegativeInt } from "./baseSchemas";
 
 export const WS_PROTOCOL_EPOCH = 1;
-export const WS_PROTOCOL_MIN_REVISION = 1;
-export const WS_PROTOCOL_MAX_REVISION = 1;
+// Revision 2 changes PullRequestCommit.authors to permit name-only authors.
+// Keep revision 1 out of the compatibility range so older clients cannot
+// decode the new nullable login shape and fail while rendering PR details.
+export const WS_PROTOCOL_MIN_REVISION = 2;
+export const WS_PROTOCOL_MAX_REVISION = 2;
 export const WS_BOOTSTRAP_METHOD = "bootstrap.negotiate";
 export const WS_BOOTSTRAP_PATH = "/ws/bootstrap";
 export const WS_NEGOTIATE_HTTP_PATH = "/ws/negotiate";


### PR DESCRIPTION
Minimal repair for #1067 (head `d88952463bc4119656b5ef0e53b24fc3345d3999`). This branch carries the original two commits plus the repair commit; it targets `main` and supersedes the original branch.

## Repair (only the two CI failures)

- **Format**: ran pinned `oxfmt@0.40.0` on exactly the two files CI rejected — `apps/server/src/git/Layers/GitHubCli.test.ts` (the `getPullRequestDetail(...).pipe(Effect.flip)` chain) and `apps/web/src/components/pullRequest/pullRequestDetail.logic.ts` (`commit.authors.find(...)`).
- **Typecheck**: deleted only `assert.deepStrictEqual(detail.reviewRequestLogins, ["reviewer"]);` from `GitHubCli.test.ts` (was line 1289). `reviewRequestLogins` belongs to `GitHubPullRequestListItem`, not `GitHubPullRequestDetailData`; it only appeared at runtime because `normalizePullRequestDetail` spreads the list-normalized result. List-level coverage (including Team exclusion) stays at `GitHubCli.test.ts:774`, and the following `detail.reviewers` assertions still cover detail behavior.

No production code, contracts, `RawActorSchema`, `wsCompatibility`, or detail/list types were changed. Unlinked-author intent (`login: null`, author name preserved) is untouched.

## Verification (Windows, bun 1.4.2, pinned toolchain)

- LF-equivalent `oxfmt --check` on the staged blobs of both files: **pass** (whole-repo `bun run fmt:check` flags the tree locally only because the Windows checkout is CRLF; Linux CI is the judge).
- `bun run lint`: **0 errors** (520 pre-existing warnings).
- `bun run typecheck`: **7/7 packages successful** (the `TS2339` on `reviewRequestLogins` is gone).
- Targeted tests: `apps/server` `GitHubCli.test.ts` + `wsCompatibility.test.ts` → 44 passed; `apps/web` `pullRequestDetail.logic.test.ts` → 15 passed; `packages/contracts` `pullRequests.test.ts` → 15 passed.

No merge, no force-push, no branch deletion; #1067 itself is left untouched.
